### PR TITLE
Fix Documentation build on Windows

### DIFF
--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -1,4 +1,4 @@
-const { spawn } = require("child_process");
+const spawn = require('cross-spawn');
 const { join, resolve } = require("path");
 const { readFile, writeFile } = require("fs");
 const _ = require("lodash");
@@ -13,7 +13,7 @@ const md = new MarkdownIt();
 (function generateTypeDoc() {
   return new Promise((resolve, reject) => {
     const typedoc = spawn(
-      "typedoc.cmd",
+      "typedoc",
       [
         "-json",
         OUTPUT,

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,15 +86,6 @@
       "integrity": "sha1-UALhT3Xi1x5WQoHfBDHIwbSio2o=",
       "dev": true
     },
-    "@types/mz": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.31.tgz",
-      "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
-      "dev": true,
-      "requires": {
-        "@types/node": "6.0.85"
-      }
-    },
     "@types/node": {
       "version": "6.0.85",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
@@ -111,11 +102,15 @@
         "@types/node": "6.0.85"
       }
     },
-    "a-sync-waterfall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.0.tgz",
-      "integrity": "sha1-OOgxnXk3niRiiEW1O5ZyKyng5Hw=",
-      "dev": true
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "abbrev": {
       "version": "1.1.0",
@@ -131,34 +126,6 @@
       "requires": {
         "mime-types": "2.1.16",
         "negotiator": "0.6.1"
-      }
-    },
-    "acetate": {
-      "version": "github:patrickarlt/acetate#3972c9389f93dc8773439b06ce2026d4ab871943",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "ava": "0.17.0",
-        "browser-sync": "2.18.13",
-        "chalk": "1.1.3",
-        "chokidar": "1.7.0",
-        "common-tags": "1.4.0",
-        "es6-promisify": "5.0.0",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "highlight.js": "9.12.0",
-        "js-yaml": "3.9.1",
-        "lodash": "4.17.4",
-        "markdown-it": "8.3.2",
-        "mime": "1.3.6",
-        "mkdirp": "0.5.1",
-        "node-uuid": "1.4.8",
-        "normalize-newline": "3.0.0",
-        "normalize-url": "1.9.1",
-        "nunjucks": "3.0.1",
-        "pretty-hrtime": "1.0.3",
-        "symlink-dir": "1.1.0",
-        "yargs": "6.6.0"
       }
     },
     "acetate-cli": {
@@ -180,12 +147,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
       "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
-      "dev": true
-    },
-    "after": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-      "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic=",
       "dev": true
     },
     "ajv": {
@@ -215,15 +176,6 @@
       "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
       "dev": true
     },
-    "ansi-align": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
-      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2"
-      }
-    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -240,12 +192,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
-    },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
     },
     "anymatch": {
@@ -313,12 +259,6 @@
       "requires": {
         "arr-flatten": "1.1.0"
       }
-    },
-    "arr-exclude": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-      "integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
-      "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -453,12 +393,6 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
-    "async-each-series": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
-      "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
-      "dev": true
-    },
     "async-foreach": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
@@ -470,124 +404,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "auto-bind": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-0.1.0.tgz",
-      "integrity": "sha1-einvyMI4jT1XjgL8LfUxyB/8HuE=",
-      "dev": true
-    },
-    "ava": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-0.17.0.tgz",
-      "integrity": "sha1-NZ4qiWFoAe8Dkpw88QqdT45FHQI=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "1.1.0",
-        "array-union": "1.0.2",
-        "array-uniq": "1.0.3",
-        "arrify": "1.0.1",
-        "auto-bind": "0.1.0",
-        "ava-files": "0.2.0",
-        "ava-init": "0.1.6",
-        "babel-code-frame": "6.22.0",
-        "babel-core": "6.25.0",
-        "babel-plugin-ava-throws-helper": "0.1.0",
-        "babel-plugin-detective": "2.0.0",
-        "babel-plugin-espower": "2.3.2",
-        "babel-plugin-transform-runtime": "6.23.0",
-        "babel-preset-es2015": "6.24.1",
-        "babel-preset-es2015-node4": "2.1.1",
-        "babel-preset-stage-2": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "bluebird": "3.5.0",
-        "caching-transform": "1.0.1",
-        "chalk": "1.1.3",
-        "chokidar": "1.7.0",
-        "clean-yaml-object": "0.1.0",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "cli-truncate": "0.2.1",
-        "co-with-promise": "4.6.0",
-        "common-path-prefix": "1.0.0",
-        "convert-source-map": "1.5.0",
-        "core-assert": "0.2.1",
-        "currently-unhandled": "0.4.1",
-        "debug": "2.6.8",
-        "empower-core": "0.6.2",
-        "figures": "1.7.0",
-        "find-cache-dir": "0.1.1",
-        "fn-name": "2.0.1",
-        "get-port": "2.1.0",
-        "has-flag": "2.0.0",
-        "ignore-by-default": "1.0.1",
-        "is-ci": "1.0.10",
-        "is-generator-fn": "1.0.0",
-        "is-obj": "1.0.1",
-        "is-observable": "0.2.0",
-        "is-promise": "2.1.0",
-        "last-line-stream": "1.0.0",
-        "lodash.debounce": "4.0.8",
-        "lodash.difference": "4.5.0",
-        "lodash.isequal": "4.5.0",
-        "loud-rejection": "1.6.0",
-        "matcher": "0.1.2",
-        "max-timeout": "1.0.0",
-        "md5-hex": "1.3.0",
-        "meow": "3.7.0",
-        "ms": "0.7.3",
-        "object-assign": "4.1.1",
-        "observable-to-promise": "0.4.0",
-        "option-chain": "0.1.1",
-        "package-hash": "1.2.0",
-        "pkg-conf": "1.1.3",
-        "plur": "2.1.2",
-        "power-assert-context-formatter": "1.1.1",
-        "power-assert-renderer-assertion": "1.1.1",
-        "power-assert-renderer-succinct": "1.1.1",
-        "pretty-ms": "2.1.0",
-        "repeating": "2.0.1",
-        "require-precompiled": "0.1.0",
-        "resolve-cwd": "1.0.0",
-        "semver": "5.4.1",
-        "set-immediate-shim": "1.0.1",
-        "source-map-support": "0.4.15",
-        "stack-utils": "0.4.0",
-        "strip-ansi": "3.0.1",
-        "strip-bom": "2.0.0",
-        "time-require": "0.1.2",
-        "unique-temp-dir": "1.0.0",
-        "update-notifier": "1.0.3"
-      }
-    },
-    "ava-files": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ava-files/-/ava-files-0.2.0.tgz",
-      "integrity": "sha1-x7i24uDOpjtXpuJ+DbFFx8Gc/iA=",
-      "dev": true,
-      "requires": {
-        "auto-bind": "0.1.0",
-        "bluebird": "3.5.0",
-        "globby": "6.1.0",
-        "ignore-by-default": "1.0.1",
-        "lodash.flatten": "4.4.0",
-        "multimatch": "2.1.0",
-        "slash": "1.0.0"
-      }
-    },
-    "ava-init": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.1.6.tgz",
-      "integrity": "sha1-7xntCyS2vzWdrW+63xoF2DY5XJE=",
-      "dev": true,
-      "requires": {
-        "arr-exclude": "1.0.0",
-        "cross-spawn": "4.0.2",
-        "pinkie-promise": "2.0.1",
-        "read-pkg-up": "1.0.1",
-        "the-argv": "1.0.0",
-        "write-pkg": "1.0.0"
-      }
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -655,28 +471,6 @@
         "trim-right": "1.0.1"
       }
     },
-    "babel-helper-bindify-decorators": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
-      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
@@ -699,29 +493,6 @@
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0",
         "lodash": "4.17.4"
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-explode-class": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-      "dev": true,
-      "requires": {
-        "babel-helper-bindify-decorators": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
       }
     },
     "babel-helper-function-name": {
@@ -778,19 +549,6 @@
         "lodash": "4.17.4"
       }
     },
-    "babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
@@ -824,16 +582,6 @@
         "babel-runtime": "6.25.0"
       }
     },
-    "babel-plugin-ava-throws-helper": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ava-throws-helper/-/babel-plugin-ava-throws-helper-0.1.0.tgz",
-      "integrity": "sha1-lREHcIoSIIAmv4ykzvGKh7ybDP4=",
-      "dev": true,
-      "requires": {
-        "babel-template": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
@@ -841,122 +589,6 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-detective": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-detective/-/babel-plugin-detective-2.0.0.tgz",
-      "integrity": "sha1-bmQug8IqM1J5dU6+LXVNJjX0nxM=",
-      "dev": true
-    },
-    "babel-plugin-espower": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.3.2.tgz",
-      "integrity": "sha1-VRa4/NsmyfDh2BYHSfbkxl5xJx4=",
-      "dev": true,
-      "requires": {
-        "babel-generator": "6.25.0",
-        "babylon": "6.17.4",
-        "call-matcher": "1.0.1",
-        "core-js": "2.5.0",
-        "espower-location-detector": "1.0.0",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
-      }
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
-    },
-    "babel-plugin-syntax-async-generators": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
-      "dev": true
-    },
-    "babel-plugin-syntax-class-properties": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
-      "dev": true
-    },
-    "babel-plugin-syntax-decorators": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
-      "dev": true
-    },
-    "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
-      "dev": true
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-      "dev": true
-    },
-    "babel-plugin-transform-async-generator-functions": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-generators": "6.13.0",
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-class-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-decorators": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-class": "6.24.1",
-        "babel-plugin-syntax-decorators": "6.13.0",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-types": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1193,27 +825,6 @@
         "regexpu-core": "2.0.0"
       }
     },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.25.0"
-      }
-    },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
@@ -1221,15 +832,6 @@
       "dev": true,
       "requires": {
         "regenerator-transform": "0.9.11"
-      }
-    },
-    "babel-plugin-transform-runtime": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1272,47 +874,6 @@
         "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-regenerator": "6.24.1"
-      }
-    },
-    "babel-preset-es2015-node4": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015-node4/-/babel-preset-es2015-node4-2.1.1.tgz",
-      "integrity": "sha1-4x8pCFm1hhnIz6JB0bC8kA+UHNs=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1"
-      }
-    },
-    "babel-preset-stage-2": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
-      }
-    },
-    "babel-preset-stage-3": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
-      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.23.0"
       }
     },
     "babel-register": {
@@ -1410,18 +971,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
       "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
-      "dev": true
-    },
-    "base64id": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-      "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
-      "dev": true
-    },
-    "batch": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-      "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ=",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -1593,23 +1142,6 @@
         "hoek": "2.16.3"
       }
     },
-    "boxen": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
-      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
-      "dev": true,
-      "requires": {
-        "ansi-align": "1.1.0",
-        "camelcase": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-boxes": "1.0.0",
-        "filled-array": "1.1.0",
-        "object-assign": "4.1.1",
-        "repeating": "2.0.1",
-        "string-width": "1.0.2",
-        "widest-line": "1.0.0"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -1652,100 +1184,6 @@
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
-      }
-    },
-    "browser-sync": {
-      "version": "2.18.13",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.18.13.tgz",
-      "integrity": "sha512-qhdrmgshVGwweogT/bdOKkZDxVxqiF4+9mibaDeAxvDBeoUtdgABk5x7YQ1KCcLRchAfv8AVtp9NuITl5CTNqg==",
-      "dev": true,
-      "requires": {
-        "browser-sync-client": "2.5.1",
-        "browser-sync-ui": "0.6.3",
-        "bs-recipes": "1.3.4",
-        "chokidar": "1.7.0",
-        "connect": "3.5.0",
-        "dev-ip": "1.0.1",
-        "easy-extender": "2.3.2",
-        "eazy-logger": "3.0.2",
-        "emitter-steward": "1.0.0",
-        "fs-extra": "3.0.1",
-        "http-proxy": "1.15.2",
-        "immutable": "3.8.1",
-        "localtunnel": "1.8.3",
-        "micromatch": "2.3.11",
-        "opn": "4.0.2",
-        "portscanner": "2.1.1",
-        "qs": "6.2.1",
-        "resp-modifier": "6.0.2",
-        "rx": "4.1.0",
-        "serve-index": "1.8.0",
-        "serve-static": "1.12.2",
-        "server-destroy": "1.0.1",
-        "socket.io": "1.6.0",
-        "socket.io-client": "1.6.0",
-        "ua-parser-js": "0.7.12",
-        "yargs": "6.4.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
-          "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
-          }
-        }
-      }
-    },
-    "browser-sync-client": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.5.1.tgz",
-      "integrity": "sha1-7BrWmknC4tS2RbGLHAbCmz2a+Os=",
-      "dev": true,
-      "requires": {
-        "etag": "1.8.0",
-        "fresh": "0.3.0"
-      }
-    },
-    "browser-sync-ui": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.3.tgz",
-      "integrity": "sha1-ZApTfBgGiTA9W+krxHa568RBwLw=",
-      "dev": true,
-      "requires": {
-        "async-each-series": "0.1.1",
-        "connect-history-api-fallback": "1.3.0",
-        "immutable": "3.8.1",
-        "server-destroy": "1.0.1",
-        "stream-throttle": "0.1.3",
-        "weinre": "2.0.0-pre-I0Z7U9OV"
       }
     },
     "browserify-aes": {
@@ -1817,18 +1255,6 @@
         "pako": "1.0.5"
       }
     },
-    "bs-recipes": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
-      "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
-      "dev": true
-    },
-    "buf-compare": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
-      "dev": true
-    },
     "buffer": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.7.tgz",
@@ -1877,35 +1303,6 @@
       "requires": {
         "os-homedir": "1.0.2"
       }
-    },
-    "caching-transform": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-      "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-      "dev": true,
-      "requires": {
-        "md5-hex": "1.3.0",
-        "mkdirp": "0.5.1",
-        "write-file-atomic": "1.3.4"
-      }
-    },
-    "call-matcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
-      "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.0",
-        "deep-equal": "1.0.1",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
-      }
-    },
-    "call-signature": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
-      "dev": true
     },
     "callsite": {
       "version": "1.0.0",
@@ -1996,7 +1393,6 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2044,12 +1440,6 @@
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
       }
-    },
-    "clean-yaml-object": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-      "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
-      "dev": true
     },
     "cli-boxes": {
       "version": "1.0.0",
@@ -2126,32 +1516,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "co-with-promise": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
-      "integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "1.0.0"
-      },
-      "dependencies": {
-        "pinkie": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-          "dev": true,
-          "requires": {
-            "pinkie": "1.0.0"
-          }
-        }
-      }
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -2301,27 +1665,6 @@
         }
       }
     },
-    "common-path-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
-      "integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
-      "dev": true
-    },
-    "common-tags": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
-      "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
-    },
     "compare-func": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
@@ -2462,58 +1805,6 @@
           }
         }
       }
-    },
-    "configstore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
-      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
-      "dev": true,
-      "requires": {
-        "dot-prop": "3.0.0",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "os-tmpdir": "1.0.2",
-        "osenv": "0.1.4",
-        "uuid": "2.0.3",
-        "write-file-atomic": "1.3.4",
-        "xdg-basedir": "2.0.0"
-      }
-    },
-    "connect": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
-      "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
-      "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "finalhandler": "0.5.0",
-        "parseurl": "1.3.1",
-        "utils-merge": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "connect-history-api-fallback": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
-      "integrity": "sha1-5R0X+PDvDbkKZP20feMFFVbp8Wk=",
-      "dev": true
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -2829,8 +2120,8 @@
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.1.1",
@@ -2859,8 +2150,8 @@
           "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
           "dev": true,
           "requires": {
-            "is-text-path": "1.0.1",
             "JSONStream": "1.3.1",
+            "is-text-path": "1.0.1",
             "lodash": "4.17.4",
             "meow": "3.7.0",
             "split2": "2.1.1",
@@ -2881,16 +2172,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
-    },
-    "core-assert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
-      "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-      "dev": true,
-      "requires": {
-        "buf-compare": "1.0.1",
-        "is-error": "2.2.1"
-      }
     },
     "core-js": {
       "version": "2.5.0",
@@ -2993,12 +2274,13 @@
       }
     },
     "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
     },
@@ -3178,12 +2460,6 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
-    "date-time": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-      "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-      "dev": true
-    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -3231,12 +2507,6 @@
       "requires": {
         "is-obj": "1.0.1"
       }
-    },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
     },
     "deep-extend": {
       "version": "0.4.2",
@@ -3286,12 +2556,6 @@
         "minimalistic-assert": "1.0.0"
       }
     },
-    "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
-    },
     "detect-file": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
@@ -3309,12 +2573,6 @@
       "requires": {
         "repeating": "2.0.1"
       }
-    },
-    "dev-ip": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
-      "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
-      "dev": true
     },
     "di": {
       "version": "0.0.1",
@@ -3445,52 +2703,11 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.3"
-      }
-    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
-    },
-    "eastasianwidth": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.1.1.tgz",
-      "integrity": "sha1-RNZW3p2kFWlEZzNTZfsxR7hXK3w=",
-      "dev": true
-    },
-    "easy-extender": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
-      "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
-      "dev": true,
-      "requires": {
-        "lodash": "3.10.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
-    },
-    "eazy-logger": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
-      "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
-      "dev": true,
-      "requires": {
-        "tfunk": "3.1.0"
-      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -3535,22 +2752,6 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
-    "emitter-steward": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
-      "integrity": "sha1-80Ea3pdYp1Zd+Eiy2gy70bRsvWQ=",
-      "dev": true
-    },
-    "empower-core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
-      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
-      "dev": true,
-      "requires": {
-        "call-signature": "0.0.2",
-        "core-js": "2.5.0"
-      }
-    },
     "encodeurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
@@ -3563,111 +2764,6 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "0.4.18"
-      }
-    },
-    "engine.io": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
-      "integrity": "sha1-PutfJky3XbvsG6rqJtYfWk6s4qo=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.3.3",
-        "base64id": "0.1.0",
-        "cookie": "0.3.1",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.1",
-        "ws": "1.1.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
-      }
-    },
-    "engine.io-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
-      "integrity": "sha1-e3MOQSdBQIdZbZvjyI0rxf22z1w=",
-      "dev": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.1",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parsejson": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "1.1.1",
-        "xmlhttprequest-ssl": "1.5.3",
-        "yeast": "0.1.2"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
-      }
-    },
-    "engine.io-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
-      "integrity": "sha1-lVTxrjMQfW+9FwylRm0vgz9qB88=",
-      "dev": true,
-      "requires": {
-        "after": "0.8.1",
-        "arraybuffer.slice": "0.0.6",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
-        "has-binary": "0.1.6",
-        "wtf-8": "1.0.0"
-      },
-      "dependencies": {
-        "has-binary": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-          "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
       }
     },
     "ent": {
@@ -3695,15 +2791,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
       "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "4.1.1"
-      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -3754,37 +2841,10 @@
         }
       }
     },
-    "espower-location-detector": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
-      "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
-      "dev": true,
-      "requires": {
-        "is-url": "1.2.2",
-        "path-is-absolute": "1.0.1",
-        "source-map": "0.5.6",
-        "xtend": "4.0.1"
-      }
-    },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
-    },
-    "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.0"
-      }
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "estree-walker": {
@@ -3797,12 +2857,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
-    },
-    "etag": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
       "dev": true
     },
     "event-stream": {
@@ -3952,49 +3006,6 @@
         "os-homedir": "1.0.2"
       }
     },
-    "express": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
-      "integrity": "sha1-TOjqHzY15p5J8Ou0l7aksKUc5vA=",
-      "dev": true,
-      "requires": {
-        "connect": "1.9.2",
-        "mime": "1.2.4",
-        "mkdirp": "0.3.0",
-        "qs": "0.4.2"
-      },
-      "dependencies": {
-        "connect": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
-          "integrity": "sha1-QogKIulDiuWait105Df1iujlKAc=",
-          "dev": true,
-          "requires": {
-            "formidable": "1.0.17",
-            "mime": "1.2.4",
-            "qs": "0.4.2"
-          }
-        },
-        "mime": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
-          "integrity": "sha1-EbX9rynCUJJVF2uArVIClPXekrc=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-          "dev": true
-        },
-        "qs": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz",
-          "integrity": "sha1-PKxMhh43GoycR3CsI82o3mObjl8=",
-          "dev": true
-        }
-      }
-    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -4142,53 +3153,6 @@
         "repeat-string": "1.6.1"
       }
     },
-    "filled-array": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
-      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q=",
-      "dev": true
-    },
-    "finalhandler": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-      "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
-      "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "find-cache-dir": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-      "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-      "dev": true,
-      "requires": {
-        "commondir": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pkg-dir": "1.0.0"
-      }
-    },
     "find-config": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/find-config/-/find-config-0.3.0.tgz",
@@ -4242,12 +3206,6 @@
         "resolve-dir": "0.1.1"
       }
     },
-    "fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-      "dev": true
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -4278,18 +3236,6 @@
         "combined-stream": "1.0.5",
         "mime-types": "2.1.16"
       }
-    },
-    "formidable": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
-      "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk=",
-      "dev": true
-    },
-    "fresh": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-      "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
-      "dev": true
     },
     "from": {
       "version": "0.1.7",
@@ -4328,1018 +3274,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        }
-      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -5395,15 +3329,6 @@
         "normalize-package-data": "2.4.0",
         "parse-github-repo-url": "1.4.0",
         "through2": "2.0.3"
-      }
-    },
-    "get-port": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-2.1.0.tgz",
-      "integrity": "sha1-h4P53OvR7qSVozThpqJR54iHqxo=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "2.0.1"
       }
     },
     "get-stdin": {
@@ -5981,29 +3906,6 @@
         "sparkles": "1.0.0"
       }
     },
-    "got": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
-      "dev": true,
-      "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer2": "0.1.4",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "node-status-codes": "1.0.0",
-        "object-assign": "4.1.1",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "2.0.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.3.3",
-        "timed-out": "3.1.3",
-        "unzip-response": "1.0.2",
-        "url-parse-lax": "1.0.0"
-      }
-    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -6148,12 +4050,6 @@
         }
       }
     },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "dev": true
-    },
     "has-cors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
@@ -6272,17 +4168,6 @@
         "entities": "1.1.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
-      }
-    },
-    "http-errors": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-      "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.2",
-        "statuses": "1.3.1"
       }
     },
     "http-proxy": {
@@ -6417,22 +4302,10 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
-    "ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
-      "dev": true
-    },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true
-    },
-    "immutable": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
-      "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI=",
       "dev": true
     },
     "import-lazy": {
@@ -6826,12 +4699,6 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
-    "irregular-plurals": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
-      "integrity": "sha512-njf5A+Mxb3kojuHd1DzISjjIl+XhyzovXEOyPPSzdQozq/Lf2tN27mOrAAsxEPZxpn6I4MGzs1oo9TxXxPFpaA==",
-      "dev": true
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6886,12 +4753,6 @@
         "is-primitive": "2.0.0"
       }
     },
-    "is-error": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-      "integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
-      "dev": true
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -6921,12 +4782,6 @@
       "requires": {
         "number-is-nan": "1.0.1"
       }
-    },
-    "is-generator-fn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-      "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
@@ -6958,29 +4813,11 @@
         "kind-of": "3.2.2"
       }
     },
-    "is-number-like": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
-      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
-      "dev": true,
-      "requires": {
-        "lodash.isfinite": "3.3.2"
-      }
-    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
-    },
-    "is-observable": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
-      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "0.2.4"
-      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -7054,12 +4891,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
-    "is-windows": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
-      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
       "dev": true
     },
     "isarray": {
@@ -7305,16 +5136,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -7866,36 +5687,12 @@
         "graceful-fs": "4.1.11"
       }
     },
-    "last-line-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
-      "integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
-      "dev": true,
-      "requires": {
-        "through2": "2.0.3"
-      }
-    },
-    "latest-version": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
-      "dev": true,
-      "requires": {
-        "package-json": "2.4.0"
-      }
-    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true,
       "optional": true
-    },
-    "lazy-req": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
-      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
-      "dev": true
     },
     "lcid": {
       "version": "1.0.0",
@@ -8361,26 +6158,11 @@
         "immediate": "3.0.6"
       }
     },
-    "limiter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz",
-      "integrity": "sha512-JIKZ0xb6fZZYa3deZ0BgXCgX6HgV8Nx3mFGeFHmFWW8Fb2c08e0CyE+G3nalpD0xGvGssjGb1UdFr+PprxZEbw==",
-      "dev": true
-    },
     "line-reader": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/line-reader/-/line-reader-0.2.4.tgz",
       "integrity": "sha1-xDkrWH3qOFgMlnhXDm6OSfzlJiI=",
       "dev": true
-    },
-    "linkify-it": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
-      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
-      "dev": true,
-      "requires": {
-        "uc.micro": "1.0.3"
-      }
     },
     "lint-staged": {
       "version": "4.0.3",
@@ -8506,40 +6288,6 @@
         "strip-bom": "2.0.0"
       }
     },
-    "localtunnel": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.3.tgz",
-      "integrity": "sha1-3MWSL9hWUQN9S94k/ZMkjQsk6wU=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "openurl": "1.1.1",
-        "request": "2.81.0",
-        "yargs": "3.29.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.29.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
-          "integrity": "sha1-GquWYOrnnYuPZ1vK7qtu40ws9pw=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
-          }
-        }
-      }
-    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -8635,18 +6383,6 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
-    },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
     "lodash.escape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
@@ -8655,12 +6391,6 @@
       "requires": {
         "lodash._root": "3.0.1"
       }
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -8672,18 +6402,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
-    },
-    "lodash.isfinite": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
-      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
       "dev": true
     },
     "lodash.keys": {
@@ -8880,59 +6598,10 @@
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
-    "markdown-it": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.3.2.tgz",
-      "integrity": "sha512-4J92IhJq1kGoyXddwzzfjr9cEKGexBfFsZooKYMhMLLlWa4+dlSPDUUP7y+xQOCebIj61aLmKlowg//YcdPP1w==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "entities": "1.1.1",
-        "linkify-it": "2.0.3",
-        "mdurl": "1.0.1",
-        "uc.micro": "1.0.3"
-      }
-    },
     "marked": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
       "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
-      "dev": true
-    },
-    "matcher": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-0.1.2.tgz",
-      "integrity": "sha1-7yDL3mTCTFDMYa9bg+4LG4/wAQE=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
-    },
-    "max-timeout": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/max-timeout/-/max-timeout-1.0.0.tgz",
-      "integrity": "sha1-to9povmeC0dv1Msj4gWcp1BxXh8=",
-      "dev": true
-    },
-    "md5-hex": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-      "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-      "dev": true,
-      "requires": {
-        "md5-o-matic": "0.1.1"
-      }
-    },
-    "md5-o-matic": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-      "dev": true
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "dev": true
     },
     "media-typer": {
@@ -9083,15 +6752,6 @@
         "minimist": "0.0.8"
       }
     },
-    "mkdirp-promise": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
-      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
-    },
     "modify-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
@@ -9103,24 +6763,6 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
       "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
       "dev": true
-    },
-    "ms": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-      "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
-      "dev": true
-    },
-    "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true,
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
-      }
     },
     "multipipe": {
       "version": "0.1.2",
@@ -9171,17 +6813,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
       "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
       "dev": true
-    },
-    "mz": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.6.0.tgz",
-      "integrity": "sha1-yLhSHZWN8KTydoAl22nHGe5O8c4=",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
-      }
     },
     "nan": {
       "version": "2.6.2",
@@ -9271,18 +6902,6 @@
         }
       }
     },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-      "dev": true
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
-    },
     "nodeflags": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/nodeflags/-/nodeflags-0.0.1.tgz",
@@ -9303,12 +6922,6 @@
         "abbrev": "1.1.0"
       }
     },
-    "normalize-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-newline/-/normalize-newline-3.0.0.tgz",
-      "integrity": "sha1-HL6oBKukNgAfg5OKsh7AOdaa6dM=",
-      "dev": true
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -9328,18 +6941,6 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "1.0.2"
-      }
-    },
-    "normalize-url": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "prepend-http": "1.0.4",
-        "query-string": "4.3.4",
-        "sort-keys": "1.1.2"
       }
     },
     "npm-path": {
@@ -9404,35 +7005,6 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "nunjucks": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.0.1.tgz",
-      "integrity": "sha1-TedKPlULr2+jNwMj89HHwqhr3E0=",
-      "dev": true,
-      "requires": {
-        "a-sync-waterfall": "1.0.0",
-        "asap": "2.0.6",
-        "chokidar": "1.7.0",
-        "yargs": "3.32.0"
-      },
-      "dependencies": {
-        "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "string-width": "1.0.2",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
-          }
-        }
-      }
-    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -9457,12 +7029,6 @@
       "integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw=",
       "dev": true
     },
-    "object-path": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
-      "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=",
-      "dev": true
-    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -9471,16 +7037,6 @@
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
-      }
-    },
-    "observable-to-promise": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.4.0.tgz",
-      "integrity": "sha1-KK/nFkUwjy1B1x9HrT/s4aN35Ss=",
-      "dev": true,
-      "requires": {
-        "is-observable": "0.2.0",
-        "symbol-observable": "0.2.4"
       }
     },
     "on-finished": {
@@ -9522,13 +7078,22 @@
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
-            "fsevents": "1.1.2",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
             "is-glob": "2.0.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
           }
         },
         "minimist": {
@@ -9545,22 +7110,6 @@
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
-    "openurl": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
-      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
-      "dev": true
-    },
-    "opn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "pinkie-promise": "2.0.1"
-      }
-    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -9569,15 +7118,6 @@
       "requires": {
         "minimist": "0.0.8",
         "wordwrap": "0.0.2"
-      }
-    },
-    "option-chain": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/option-chain/-/option-chain-0.1.1.tgz",
-      "integrity": "sha1-6bgR4AbxwPVIAvKClb/Ilw+Nz70=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1"
       }
     },
     "optionator": {
@@ -9690,27 +7230,6 @@
       "integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno=",
       "dev": true
     },
-    "package-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
-      "integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
-      "dev": true,
-      "requires": {
-        "md5-hex": "1.3.0"
-      }
-    },
-    "package-json": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
-      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
-      "dev": true,
-      "requires": {
-        "got": "5.7.1",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.4.1"
-      }
-    },
     "pad": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pad/-/pad-1.1.0.tgz",
@@ -9771,12 +7290,6 @@
       "requires": {
         "error-ex": "1.3.1"
       }
-    },
-    "parse-ms": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-      "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -9942,41 +7455,11 @@
         "pinkie": "2.0.4"
       }
     },
-    "pkg-conf": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
-      "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2",
-        "load-json-file": "1.1.0",
-        "object-assign": "4.1.1",
-        "symbol": "0.2.3"
-      }
-    },
-    "pkg-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2"
-      }
-    },
     "pkginfo": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
       "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
       "dev": true
-    },
-    "plur": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-      "dev": true,
-      "requires": {
-        "irregular-plurals": "1.3.0"
-      }
     },
     "portfinder": {
       "version": "1.0.13",
@@ -10015,91 +7498,6 @@
         }
       }
     },
-    "portscanner": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
-      "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "is-number-like": "1.0.8"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        }
-      }
-    },
-    "power-assert-context-formatter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
-      "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.0",
-        "power-assert-context-traversal": "1.1.1"
-      }
-    },
-    "power-assert-context-traversal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
-      "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.0",
-        "estraverse": "4.2.0"
-      }
-    },
-    "power-assert-renderer-assertion": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.1.1.tgz",
-      "integrity": "sha1-y/wOd+AIao+Wrz8djme57n4ozpg=",
-      "dev": true,
-      "requires": {
-        "power-assert-renderer-base": "1.1.1",
-        "power-assert-util-string-width": "1.1.1"
-      }
-    },
-    "power-assert-renderer-base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-base/-/power-assert-renderer-base-1.1.1.tgz",
-      "integrity": "sha1-lqZQxv0F7hvB9mtUrWFELIs/Y+s=",
-      "dev": true
-    },
-    "power-assert-renderer-diagram": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
-      "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.0",
-        "power-assert-renderer-base": "1.1.1",
-        "power-assert-util-string-width": "1.1.1",
-        "stringifier": "1.3.0"
-      }
-    },
-    "power-assert-renderer-succinct": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-succinct/-/power-assert-renderer-succinct-1.1.1.tgz",
-      "integrity": "sha1-wqRosjgiq9b4Diq6UyI0ewnfR24=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.0",
-        "power-assert-renderer-diagram": "1.1.2"
-      }
-    },
-    "power-assert-util-string-width": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.1.1.tgz",
-      "integrity": "sha1-vmWet5N/3S5smncmjar2S9W3xZI=",
-      "dev": true,
-      "requires": {
-        "eastasianwidth": "0.1.1"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -10123,31 +7521,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.5.3.tgz",
       "integrity": "sha1-WdrcaDNF7GuI+IuU7Urn4do5S/4=",
       "dev": true
-    },
-    "pretty-hrtime": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-      "dev": true
-    },
-    "pretty-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
-      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2",
-        "parse-ms": "1.0.1",
-        "plur": "1.0.0"
-      },
-      "dependencies": {
-        "plur": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
-          "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
-          "dev": true
-        }
-      }
     },
     "private": {
       "version": "0.1.7",
@@ -10228,22 +7601,6 @@
       "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.1.5.tgz",
       "integrity": "sha1-ZZ3p8s+NzCehSBJ28gU3cnI4LnM=",
       "dev": true
-    },
-    "qs": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-      "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
-      "dev": true
-    },
-    "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
-      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -10359,16 +7716,6 @@
       "dev": true,
       "requires": {
         "mute-stream": "0.0.6"
-      }
-    },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
       }
     },
     "read-cmd-shim": {
@@ -10717,12 +8064,6 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
-    "require-precompiled": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
-      "integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
-      "dev": true
-    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -10738,15 +8079,6 @@
         "path-parse": "1.0.5"
       }
     },
-    "resolve-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
-      "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
-      "dev": true,
-      "requires": {
-        "resolve-from": "2.0.0"
-      }
-    },
     "resolve-dir": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
@@ -10755,22 +8087,6 @@
       "requires": {
         "expand-tilde": "1.2.2",
         "global-modules": "0.2.3"
-      }
-    },
-    "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-      "dev": true
-    },
-    "resp-modifier": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
-      "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "minimatch": "3.0.4"
       }
     },
     "restore-cursor": {
@@ -11202,132 +8518,6 @@
         "semver": "5.4.1"
       }
     },
-    "send": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.2.tgz",
-      "integrity": "sha1-+R+rRAO8+H5xb3DOtdsvV4vcF9Y=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.4",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "fresh": "0.5.0",
-        "http-errors": "1.6.2",
-        "mime": "1.3.4",
-        "ms": "1.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
-          "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.3"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "0.7.3",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-              "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
-              "dev": true
-            }
-          }
-        },
-        "fresh": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-          "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-          "dev": true,
-          "requires": {
-            "depd": "1.1.1",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.3",
-            "statuses": "1.3.1"
-          }
-        },
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
-        },
-        "ms": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz",
-          "integrity": "sha1-Wa3NIu3FQ/e1OBhi0xOHsfS8lHM=",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
-        }
-      }
-    },
-    "serve-index": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
-      "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.3.3",
-        "batch": "0.5.3",
-        "debug": "2.2.0",
-        "escape-html": "1.0.3",
-        "http-errors": "1.5.1",
-        "mime-types": "2.1.16",
-        "parseurl": "1.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "serve-static": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz",
-      "integrity": "sha1-5UbicmCBuBtLzsjpCAjrzdMjr7o=",
-      "dev": true,
-      "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
-        "send": "0.15.2"
-      }
-    },
-    "server-destroy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
-      "dev": true
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -11344,12 +8534,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
-    },
-    "setprototypeof": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-      "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg=",
       "dev": true
     },
     "sha.js": {
@@ -11441,44 +8625,6 @@
         "hoek": "2.16.3"
       }
     },
-    "socket.io": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
-      "integrity": "sha1-PkDZMmN+a9kjmBslyvfFPoO24uE=",
-      "dev": true,
-      "requires": {
-        "debug": "2.3.3",
-        "engine.io": "1.8.0",
-        "has-binary": "0.1.7",
-        "object-assign": "4.1.0",
-        "socket.io-adapter": "0.5.0",
-        "socket.io-client": "1.6.0",
-        "socket.io-parser": "2.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-          "dev": true
-        }
-      }
-    },
     "socket.io-adapter": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
@@ -11489,48 +8635,6 @@
         "socket.io-parser": "2.3.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
-      }
-    },
-    "socket.io-client": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
-      "integrity": "sha1-W2aPT3cTBN/u0XkGRwg4b6ZxeFM=",
-      "dev": true,
-      "requires": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "2.3.3",
-        "engine.io-client": "1.8.0",
-        "has-binary": "0.1.7",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "2.3.1",
-        "to-array": "0.1.4"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
@@ -11710,12 +8814,6 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
-    "stack-utils": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-0.4.0.tgz",
-      "integrity": "sha1-lAy4L8z6hOj/Lz/fKT/ngBa+zNE=",
-      "dev": true
-    },
     "staged-git-files": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
@@ -11769,16 +8867,6 @@
         "xtend": "4.0.1"
       }
     },
-    "stream-throttle": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
-      "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
-      "dev": true,
-      "requires": {
-        "commander": "2.11.0",
-        "limiter": "1.1.2"
-      }
-    },
     "stream-to-observable": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
@@ -11829,21 +8917,6 @@
         }
       }
     },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -11855,15 +8928,13 @@
         "strip-ansi": "3.0.1"
       }
     },
-    "stringifier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
-      "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "core-js": "2.5.0",
-        "traverse": "0.6.6",
-        "type-name": "2.0.2"
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -11955,40 +9026,6 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
-    "symbol": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
-      "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
-      "dev": true
-    },
-    "symbol-observable": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
-      "dev": true
-    },
-    "symlink-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/symlink-dir/-/symlink-dir-1.1.0.tgz",
-      "integrity": "sha512-HrQ50UhvdoWwwC62I82l0U2NTRx9dTQWs5/ay0bRwBqkJQ0f3ruVhQUyLH7hs6NekRsvQgK76fZyUFK7PZsm8A==",
-      "dev": true,
-      "requires": {
-        "@types/mz": "0.0.31",
-        "@types/node": "8.0.20",
-        "graceful-fs": "4.1.11",
-        "is-windows": "1.0.1",
-        "mkdirp-promise": "5.0.1",
-        "mz": "2.6.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.0.20",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.20.tgz",
-          "integrity": "sha512-MnB7YEpmLUyEWRVRhKpRs4swwqITnY8BcVFPoTuCl99SCplI/lLUiU5vcJ/OANDqwkpdIg0pDEM38K22KQT2RA==",
-          "dev": true
-        }
-      }
-    },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
@@ -12063,46 +9100,6 @@
       "integrity": "sha1-0cstFLXQvEW/3Kigikc/aMfrDLw=",
       "dev": true
     },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "tfunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
-      "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "object-path": "0.9.2"
-      }
-    },
-    "the-argv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/the-argv/-/the-argv-1.0.0.tgz",
-      "integrity": "sha1-AIRwUAVzDdhNt1UlPJMa45jblSI=",
-      "dev": true
-    },
-    "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0"
-      }
-    },
-    "thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-      "dev": true,
-      "requires": {
-        "thenify": "3.3.0"
-      }
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -12119,68 +9116,10 @@
         "xtend": "4.0.1"
       }
     },
-    "time-require": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
-      "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-      "dev": true,
-      "requires": {
-        "chalk": "0.4.0",
-        "date-time": "0.1.1",
-        "pretty-ms": "0.2.2",
-        "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
-          }
-        },
-        "parse-ms": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
-          "dev": true
-        },
-        "pretty-ms": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-          "dev": true,
-          "requires": {
-            "parse-ms": "0.1.2"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-          "dev": true
-        }
-      }
-    },
     "time-stamp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-      "dev": true
-    },
-    "timed-out": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
       "dev": true
     },
     "timers-browserify": {
@@ -12228,12 +9167,6 @@
       "requires": {
         "punycode": "1.4.1"
       }
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
     },
     "tree-kill": {
       "version": "1.1.0",
@@ -12470,12 +9403,6 @@
         "mime-types": "2.1.16"
       }
     },
-    "type-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
-      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q=",
-      "dev": true
-    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -12538,18 +9465,6 @@
       "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
       "dev": true
     },
-    "ua-parser-js": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
-      "integrity": "sha1-BMgamb3V3FImPqKdJMa/jUgYpLs=",
-      "dev": true
-    },
-    "uc.micro": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
-      "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI=",
-      "dev": true
-    },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
@@ -12610,22 +9525,10 @@
       "dev": true,
       "optional": true
     },
-    "uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-      "dev": true
-    },
     "ultron": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
-      "dev": true
-    },
-    "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
       "dev": true
     },
     "unicode": {
@@ -12643,17 +9546,6 @@
         "crypto-random-string": "1.0.0"
       }
     },
-    "unique-temp-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
-      "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1",
-        "os-tmpdir": "1.0.2",
-        "uid2": "0.0.3"
-      }
-    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -12665,28 +9557,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
-    },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "dev": true
-    },
-    "update-notifier": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
-      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
-      "dev": true,
-      "requires": {
-        "boxen": "0.6.0",
-        "chalk": "1.1.3",
-        "configstore": "2.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "2.0.0",
-        "lazy-req": "1.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "2.0.0"
-      }
     },
     "url": {
       "version": "0.11.0",
@@ -12859,17 +9729,6 @@
         "defaults": "1.0.3"
       }
     },
-    "weinre": {
-      "version": "2.0.0-pre-I0Z7U9OV",
-      "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
-      "integrity": "sha1-/viqIjkh97QLu71MPtQwL2/QqBM=",
-      "dev": true,
-      "requires": {
-        "express": "2.5.11",
-        "nopt": "3.0.6",
-        "underscore": "1.7.0"
-      }
-    },
     "whatwg-fetch": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
@@ -12907,12 +9766,6 @@
       "requires": {
         "string-width": "1.0.2"
       }
-    },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-      "dev": true
     },
     "winston": {
       "version": "2.1.0",
@@ -12965,65 +9818,11 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
-      }
-    },
-    "write-json-file": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-1.2.0.tgz",
-      "integrity": "sha1-LV3+lqvDyIkFfJOXGqQAXvtUgTQ=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "sort-keys": "1.1.2",
-        "write-file-atomic": "1.3.4"
-      }
-    },
-    "write-pkg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-1.0.0.tgz",
-      "integrity": "sha1-rriqnU14jh2JPfsIVJaLVDqRn1c=",
-      "dev": true,
-      "requires": {
-        "write-json-file": "1.2.0"
-      }
-    },
-    "ws": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
-      "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
-      "dev": true,
-      "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
-      }
-    },
     "wtf-8": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
       "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
       "dev": true
-    },
-    "xdg-basedir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
     },
     "xml2js": {
       "version": "0.4.17",
@@ -13067,52 +9866,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yargs": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-      "dev": true,
-      "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "4.2.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-      "dev": true,
-      "requires": {
-        "camelcase": "3.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        }
-      }
     },
     "yauzl": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "commitizen": "^2.9.6",
     "concurrently": "^3.5.0",
     "cpx": "^1.5.0",
+    "cross-spawn": "^5.1.0",
     "cz-lerna-changelog": "github:patrickarlt/cz-lerna-changelog#3fe7650a2e2e624b1f46e5031c96119759698288",
     "date-fns": "^1.28.5",
     "fetch-mock": "^5.12.1",


### PR DESCRIPTION
Fixes #50 by modifying  _docs/build-typedoc.js_ to run on Windows.

For whatever reason, node child processes that use `spawn` must include `.cmd` in the command name, for example:
```
    const typedoc = spawn(
      "typedoc.cmd",
      ...
    )
```
I'm not sure what effect this will have on Unix.

Also, I found that using `path.sep` to parse the package name was failing because `path.sep` is `'\\'` on Windows, but the string it is parsing uses `/` instead.