### PR TITLE
Fix owner argument for gh-release

### DIFF
--- a/support/publish.sh
+++ b/support/publish.sh
@@ -24,4 +24,4 @@ zip -r $TEMP_FOLDER.zip $TEMP_FOLDER
 rm -rf $TEMP_FOLDER
 
 # Run gh-release to create a new release with our changelog changes and ZIP archive
-gh-release --t v$VERSION --repo arcgis-rest-js --owner ArcGIS -a $TEMP_FOLDER.zip
+gh-release --t v$VERSION --repo arcgis-rest-js --owner Esri -a $TEMP_FOLDER.zip


### PR DESCRIPTION
Set owner to Esri for `gh-release` command. Follow up for #57.