### PR TITLE
adding three more item resource methods

### DIFF
--- a/packages/arcgis-rest-geocoder/src/geocoder.ts
+++ b/packages/arcgis-rest-geocoder/src/geocoder.ts
@@ -41,7 +41,6 @@ export interface IAddressBulk extends IAddress {
   OBJECTID: number;
 }
 
-// not using this, yet....
 export interface ILocation {
   latitude?: number;
   longitude?: number;
@@ -203,9 +202,9 @@ export function geocode(
  * ```
  *
  * @param partialText - The string to pass to the endpoint.
+ * @param requestParams - Additional parameters to pass to the endpoint.
  * @param requestOptions - Additional options for the request including authentication.
- * @param params - Additional parameters to pass to the endpoint.
- * @returns A Promise that will resolve with the data from the request.
+ * @returns A Promise that will resolve with the data from the response.
  */
 export function suggest(
   partialText: string,
@@ -244,8 +243,10 @@ export function suggest(
  * reverseGeocode({ x: -13181226, y: 4021085, spatialReference: { wkid: 3857 })
  * ```
  *
- * @param params - The parameters to pass to the endpoint.
- * @returns A Promise that will resolve with the data from the request.
+ * @param coordinates - the location you'd like to associate an address with.
+ * @param requestParams - Additional parameters to pass to the endpoint.
+ * @param requestOptions - Additional options for the request including authentication.
+ * @returns A Promise that will resolve with the data from the response.
  */
 export function reverseGeocode(
   coords: IPoint | ILocation | [number, number],
@@ -297,9 +298,10 @@ export function reverseGeocode(
  *   });
  * ```
  *
- * @param params - The parameters to pass to the geocoder.
+ * @param addresses - The array of addresses you'd like to find the locations of
  * @param requestOptions - Additional options to pass to the geocoder.
- * @returns A Promise that will resolve with the data from the request.
+ * @param requestParams - Additional parameters to pass through in the request to the geocoder.
+ * @returns A Promise that will resolve with the data from the response.
  */
 export function bulkGeocode(
   addresses: IAddressBulk[],
@@ -355,8 +357,8 @@ export function bulkGeocode(
  *   });
  * ```
  *
- * @param IGeocodeRequestOptions - A custom geocoding service to fetch metadata from.
- * @returns A Promise that will resolve with the data from the request.
+ * @param requestOptions - Request options can contain a custom geocoding service to fetch metadata from.
+ * @returns A Promise that will resolve with the data from the response.
  */
 export function serviceInfo(
   requestOptions?: IGeocodeRequestOptions

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -27,16 +27,16 @@ export interface ISearchResult {
 
 /**
  * Search for items via the portal api
- * 
+ *
  * ```js
  * import { searchItems } from '@esri/arcgis-rest-items';
- * 
+ *
  * searchItems({q:'water'})
  * .then((results) => {
  *  console.log(response.results.total); // 355
  * })
  * ```
- * 
+ *
  * @param searchForm - Search request
  * @param requestOptions - Options for the request
  * @returns A Promise that will resolve with the data from the response.
@@ -60,7 +60,7 @@ export function searchItems(
 
 /**
  * Create an item in a folder
- * 
+ *
  * @param owner - owner name
  * @param item - item object
  * @param folder - optional folder to create the item in
@@ -89,7 +89,7 @@ export function createItemInFolder(
 
 /**
  * Create an Item in the user's root folder
- * 
+ *
  * @param owner - owner name
  * @param item - the item
  * @param requestOptions - Options for the request
@@ -105,7 +105,7 @@ export function createItem(
 
 /**
  * Send json to an item to be stored as the `/data` resource
- * 
+ *
  * @param id - Item Id
  * @param owner - Item owner username
  * @param data - Javascript object to store
@@ -136,7 +136,7 @@ export function addItemJsonData(
 }
 /**
  * Get an item by id
- * 
+ *
  * @param id - Item Id
  * @param requestOptions - Options for the request
  * @returns A Promise that will resolve with the data from the response.
@@ -155,10 +155,10 @@ export function getItem(
 }
 
 /**
- * Get the /data for an item. 
+ * Get the /data for an item.
  * Note: Some items do not return json from /data
  * and this method will throw if that is the case.
- * 
+ *
  * @param id - Item Id
  * @param requestOptions - Options for the request
  * @returns A Promise that will resolve with the json data for the item.
@@ -178,32 +178,28 @@ export function getItemData(
 
 /**
  * Update an Item
- * 
+ *
  * @param item - The item to update.
  * @param requestOptions - Options for the request.
  * @returns A Promise that resolves with the status of the operation.
  */
 export function updateItem(
   item: IItem,
-  requestOptions?: IRequestOptions
+  requestOptions: IRequestOptions
 ): Promise<any> {
   const url = `${getPortalUrl(
     requestOptions
   )}/content/users/${item.owner}/items/${item.id}/update`;
 
-  const options: IRequestOptions = {
-    ...{ httpMethod: "POST" },
-    ...requestOptions
-  };
   // serialize the item into something Portal will accept
   const requestParams = serializeItem(item);
 
-  return request(url, requestParams, options);
+  return request(url, requestParams, requestOptions);
 }
 
 /**
  * Remove an item from the portal
- * 
+ *
  * @param id - guid item id
  * @param owner - string owner username
  * @param requestOptions - Options for the request
@@ -217,17 +213,12 @@ export function removeItem(
   const url = `${getPortalUrl(
     requestOptions
   )}/content/users/${owner}/items/${id}/delete`;
-  // default to a POST request
-  const options: IRequestOptions = {
-    ...{ httpMethod: "POST" },
-    ...requestOptions
-  };
-  return request(url, null, options);
+  return request(url, null, requestOptions);
 }
 
 /**
  * Protect an item
- * 
+ *
  * @param id - guid item id
  * @param owner - string owner username
  * @param requestOptions - Options for the request
@@ -241,17 +232,12 @@ export function protectItem(
   const url = `${getPortalUrl(
     requestOptions
   )}/content/users/${owner}/items/${id}/protect`;
-  // default to a POST request
-  const options: IRequestOptions = {
-    ...{ httpMethod: "POST" },
-    ...requestOptions
-  };
-  return request(url, null, options);
+  return request(url, null, requestOptions);
 }
 
 /**
  * Unprotect an item
- * 
+ *
  * @param id - guid item id
  * @param owner - string owner username
  * @param requestOptions - Options for the request
@@ -265,18 +251,80 @@ export function unprotectItem(
   const url = `${getPortalUrl(
     requestOptions
   )}/content/users/${owner}/items/${id}/unprotect`;
-  // default to a POST request
-  const options: IRequestOptions = {
-    ...{ httpMethod: "POST" },
-    ...requestOptions
+  return request(url, null, requestOptions);
+}
+
+/**
+ * Get the resources associated with an item
+ *
+ * @param id - guid item id
+ * @param requestOptions - Options for the request
+ * @returns A Promise to unprotect an item.
+ */
+export function getItemResources(
+  id: string,
+  requestOptions: IRequestOptions
+): Promise<any> {
+  const url = `${getPortalUrl(requestOptions)}/content/items/${id}/resources`;
+
+  return request(url, { num: 1000 }, requestOptions);
+}
+
+/**
+ * Update a resource associated with an item
+ *
+ * @param id - guid item id
+ * @param owner - string owner username
+ * @param name - new resource filename
+ * @param content - text input to be added as a file resource
+ * @param requestOptions - Options for the request
+ * @returns A Promise to unprotect an item.
+ */
+export function updateItemResource(
+  id: string,
+  owner: string,
+  name: string,
+  content: string,
+  requestOptions: IRequestOptions
+): Promise<any> {
+  const url = `${getPortalUrl(
+    requestOptions
+  )}/content/users/${owner}/items/${id}/updateResources`;
+
+  const params = {
+    fileName: name,
+    text: content
   };
-  return request(url, null, options);
+
+  return request(url, params, requestOptions);
+}
+
+/**
+ * Remove a resource associated with an item
+ *
+ * @param id - guid item id
+ * @param owner - guid item id
+ * @param resource - guid item id
+ * @param requestOptions - Options for the request
+ * @returns A Promise to unprotect an item.
+ */
+export function removeItemResource(
+  id: string,
+  owner: string,
+  resource: string,
+  requestOptions: IRequestOptions
+): Promise<any> {
+  const url = `${getPortalUrl(
+    requestOptions
+  )}/content/users/${owner}/items/${id}/removeResources`;
+
+  return request(url, { resource }, requestOptions);
 }
 
 /**
  * Serialize an item into a json format accepted by the Portal API
  * for create and update operations
- * 
+ *
  * @param item IItem to be serialized
  * @returns a formatted json object to be sent to Portal
  */

--- a/packages/arcgis-rest-items/test/items.test.ts
+++ b/packages/arcgis-rest-items/test/items.test.ts
@@ -8,17 +8,27 @@ import {
   updateItem,
   addItemJsonData,
   protectItem,
-  unprotectItem
+  unprotectItem,
+  getItemResources,
+  updateItemResource,
+  removeItemResource
 } from "../src/index";
 
 import * as fetchMock from "fetch-mock";
 
+import { SearchResponse } from "./mocks/search";
+
 import {
-  SearchResponse,
   ItemSuccessResponse,
   ItemResponse,
   ItemDataResponse
-} from "./mocks/responses";
+} from "./mocks/item";
+
+import {
+  GetItemResourcesResponse,
+  UpdateItemResourceResponse,
+  RemoveItemResourceResponse
+} from "./mocks/resources";
 
 describe("search", () => {
   let paramsSpy: jasmine.Spy;
@@ -373,6 +383,74 @@ describe("search", () => {
           );
           expect(options.method).toBe("POST");
           expect(paramsSpy).toHaveBeenCalledWith("f", "json");
+          expect(paramsSpy).toHaveBeenCalledWith("token", "fake-token");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("get item resources", done => {
+      fetchMock.once("*", GetItemResourcesResponse);
+      getItemResources("3ef", MOCK_REQOPTS)
+        .then(response => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/resources"
+          );
+          expect(options.method).toBe("POST");
+          expect(paramsSpy).toHaveBeenCalledWith("f", "json");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("update an item resource", done => {
+      fetchMock.once("*", UpdateItemResourceResponse);
+      updateItemResource(
+        "3ef",
+        "dbouwman",
+        "image/banner.png",
+        "jumbotron",
+        MOCK_REQOPTS
+      )
+        .then(response => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/updateResources"
+          );
+          expect(options.method).toBe("POST");
+          expect(paramsSpy).toHaveBeenCalledWith("f", "json");
+          expect(paramsSpy).toHaveBeenCalledWith(
+            "fileName",
+            "image/banner.png"
+          );
+          expect(paramsSpy).toHaveBeenCalledWith("text", "jumbotron");
+          expect(paramsSpy).toHaveBeenCalledWith("token", "fake-token");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should remove a resource", done => {
+      fetchMock.once("*", RemoveItemResourceResponse);
+      removeItemResource("3ef", "dbouwman", "image/banner.png", MOCK_REQOPTS)
+        .then(response => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/removeResources"
+          );
+          expect(options.method).toBe("POST");
+          expect(paramsSpy).toHaveBeenCalledWith("f", "json");
+          expect(paramsSpy).toHaveBeenCalledWith(
+            "resource",
+            "image/banner.png"
+          );
           expect(paramsSpy).toHaveBeenCalledWith("token", "fake-token");
           done();
         })

--- a/packages/arcgis-rest-items/test/mocks/item.ts
+++ b/packages/arcgis-rest-items/test/mocks/item.ts
@@ -1,0 +1,27 @@
+import { IItem } from "../../src/items";
+
+export const ItemSuccessResponse: any = {
+  success: true,
+  id: "3efakeitemid0000"
+};
+
+export const ItemResponse: IItem = {
+  id: "4bc",
+  owner: "jeffvader",
+  title: "DS Plans",
+  description: "The plans",
+  snippet: "Yeah these are the ones",
+  tags: ["plans", "star dust"],
+  type: "Web Map",
+  typeKeywords: ["Javascript", "hubSiteApplication"],
+  properties: {
+    parentId: "3eb"
+  }
+};
+
+export const ItemDataResponse: any = {
+  source: "3ef",
+  values: {
+    key: "value"
+  }
+};

--- a/packages/arcgis-rest-items/test/mocks/item.ts
+++ b/packages/arcgis-rest-items/test/mocks/item.ts
@@ -1,4 +1,4 @@
-import { IItem } from "../../src/items";
+import { IItem } from "@esri/arcgis-rest-common-types";
 
 export const ItemSuccessResponse: any = {
   success: true,

--- a/packages/arcgis-rest-items/test/mocks/resources.ts
+++ b/packages/arcgis-rest-items/test/mocks/resources.ts
@@ -1,0 +1,28 @@
+export const GetItemResourcesResponse: any = {
+  total: 3,
+  start: 1,
+  num: 3,
+  nextStart: -1,
+  resources: [
+    {
+      resource: "image/banner.jpg"
+    },
+    {
+      resource: "image/logo.jpg"
+    },
+    {
+      resource: "text/desc.txt"
+    }
+  ]
+};
+
+export const RemoveItemResourceResponse: any = {
+  success: true
+};
+
+export const UpdateItemResourceResponse: any = {
+  success: true,
+  itemId: "0c66beb52dff4994be67937cdadbdbf1",
+  owner: "jsmith",
+  folder: null
+};

--- a/packages/arcgis-rest-items/test/mocks/search.ts
+++ b/packages/arcgis-rest-items/test/mocks/search.ts
@@ -58,29 +58,3 @@ export const SearchResponse: ISearchResult = {
     }
   ]
 };
-
-export const ItemSuccessResponse: any = {
-  success: true,
-  id: "3efakeitemid0000"
-};
-
-export const ItemResponse: IItem = {
-  id: "4bc",
-  owner: "jeffvader",
-  title: "DS Plans",
-  description: "The plans",
-  snippet: "Yeah these are the ones",
-  tags: ["plans", "star dust"],
-  type: "Web Map",
-  typeKeywords: ["Javascript", "hubSiteApplication"],
-  properties: {
-    parentId: "3eb"
-  }
-};
-
-export const ItemDataResponse: any = {
-  source: "3ef",
-  values: {
-    key: "value"
-  }
-};


### PR DESCRIPTION
* fixed updateItem() to make passing authentication mandatory
* simplified a few other existing methods that already default to POST
* added new methods
  * `getItemResources`
  * `updateItemResource`
  * `removeItemResource`
* in test suite, broke out item responses into multiple files