### PR TITLE
refactor(items): make passing an owner optional in item methods

### DIFF
--- a/packages/arcgis-rest-auth/src/AuthenticatedRequestOptions.ts
+++ b/packages/arcgis-rest-auth/src/AuthenticatedRequestOptions.ts
@@ -1,0 +1,25 @@
+import { ApplicationSession } from "./ApplicationSession";
+import { UserSession } from "./UserSession";
+
+import { IRequestOptions } from "@esri/arcgis-rest-request";
+
+/**
+ * Used internally by packages for requests that require authentication.
+ */
+export interface IAuthenticatedRequestOptions extends IRequestOptions {
+  authentication: UserSession | ApplicationSession;
+}
+
+/**
+ * Used internally by packages for requests that require user authentication.
+ */
+export interface IUserRequestOptions extends IRequestOptions {
+  authentication: UserSession;
+}
+
+/**
+ * Used internally by packages for requests that require application authentication.
+ */
+export interface IApplicationRequestOptions extends IRequestOptions {
+  authentication: ApplicationSession;
+}

--- a/packages/arcgis-rest-auth/src/index.ts
+++ b/packages/arcgis-rest-auth/src/index.ts
@@ -2,3 +2,4 @@ export * from "./ApplicationSession";
 export * from "./UserSession";
 export * from "./fetchToken";
 export * from "./generateToken";
+export * from "./AuthenticatedRequestOptions";

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -9,7 +9,7 @@ import {
 
 import { IExtent, IItem } from "@esri/arcgis-rest-common-types";
 
-import { UserSession } from "@esri/arcgis-rest-auth";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 export interface ISearchRequest {
   q: string;
@@ -25,10 +25,6 @@ export interface ISearchResult {
   num: number;
   nextStart: number;
   results: IItem[];
-}
-
-export interface IUserSessionRequestOptions extends IRequestOptions {
-  authentication: UserSession;
 }
 
 /**
@@ -75,7 +71,7 @@ export function searchItems(
 export function createItemInFolder(
   item: IItem,
   folder: string,
-  requestOptions: IUserSessionRequestOptions,
+  requestOptions: IUserRequestOptions,
   owner?: string
 ): Promise<any> {
   const itemOwner = owner || requestOptions.authentication.username;
@@ -103,7 +99,7 @@ export function createItemInFolder(
  */
 export function createItem(
   item: IItem,
-  requestOptions: IUserSessionRequestOptions,
+  requestOptions: IUserRequestOptions,
   owner?: string
 ): Promise<any> {
   const itemOwner = owner || requestOptions.authentication.username;
@@ -122,7 +118,7 @@ export function createItem(
 export function addItemJsonData(
   id: string,
   data: any,
-  requestOptions: IUserSessionRequestOptions,
+  requestOptions: IUserRequestOptions,
   owner?: string
 ): Promise<any> {
   const itemOwner = owner || requestOptions.authentication.username;
@@ -216,7 +212,7 @@ export function updateItem(
  */
 export function removeItem(
   id: string,
-  requestOptions: IUserSessionRequestOptions,
+  requestOptions: IUserRequestOptions,
   owner?: string
 ): Promise<any> {
   const itemOwner = owner || requestOptions.authentication.username;
@@ -236,7 +232,7 @@ export function removeItem(
  */
 export function protectItem(
   id: string,
-  requestOptions: IUserSessionRequestOptions,
+  requestOptions: IUserRequestOptions,
   owner?: string
 ): Promise<any> {
   const itemOwner = owner || requestOptions.authentication.username;
@@ -256,7 +252,7 @@ export function protectItem(
  */
 export function unprotectItem(
   id: string,
-  requestOptions: IUserSessionRequestOptions,
+  requestOptions: IUserRequestOptions,
   owner?: string
 ): Promise<any> {
   const itemOwner = owner || requestOptions.authentication.username;
@@ -297,7 +293,7 @@ export function updateItemResource(
   id: string,
   name: string,
   content: string,
-  requestOptions: IUserSessionRequestOptions,
+  requestOptions: IUserRequestOptions,
   owner?: string
 ): Promise<any> {
   const itemOwner = owner || requestOptions.authentication.username;
@@ -325,7 +321,7 @@ export function updateItemResource(
 export function removeItemResource(
   id: string,
   resource: string,
-  requestOptions: IUserSessionRequestOptions,
+  requestOptions: IUserRequestOptions,
   owner?: string
 ): Promise<any> {
   const itemOwner = owner || requestOptions.authentication.username;

--- a/packages/arcgis-rest-items/test/items.test.ts
+++ b/packages/arcgis-rest-items/test/items.test.ts
@@ -31,18 +31,7 @@ import {
 } from "./mocks/resources";
 
 import { UserSession, IFetchTokenResponse } from "@esri/arcgis-rest-auth";
-
-const TOMORROW = (function() {
-  const now = new Date();
-  now.setDate(now.getDate() + 1);
-  return now;
-})();
-
-export const YESTERDAY = (function() {
-  const now = new Date();
-  now.setDate(now.getDate() - 1);
-  return now;
-})();
+import { TOMORROW, YESTERDAY } from "@esri/arcgis-rest-auth/test/utils";
 
 describe("search", () => {
   let paramsSpy: jasmine.Spy;
@@ -136,13 +125,6 @@ describe("search", () => {
 
   describe("Authenticated methods", () => {
     // setup a UserSession to use in all these tests
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
-      portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
-
     const MOCK_USER_SESSION = new UserSession({
       clientId: "clientId",
       redirectUri: "https://example-app.com/redirect-uri",
@@ -160,10 +142,6 @@ describe("search", () => {
       authentication: MOCK_USER_SESSION
     };
 
-    const MOCK_REQOPTS = {
-      authentication: MOCK_AUTH
-    };
-
     it("search should use the portal and token from Auth Manager", done => {
       fetchMock.once("*", SearchResponse);
 
@@ -171,7 +149,7 @@ describe("search", () => {
         {
           q: "DC AND typekeywords:hubSiteApplication"
         },
-        MOCK_REQOPTS
+        MOCK_USER_REQOPTS
       )
         .then(response => {
           expect(fetchMock.called()).toEqual(true);
@@ -190,7 +168,7 @@ describe("search", () => {
     it("should return an item by id using a token", done => {
       fetchMock.once("*", ItemResponse);
 
-      getItem("3ef", MOCK_REQOPTS)
+      getItem("3ef", MOCK_USER_REQOPTS)
         .then(response => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
@@ -207,7 +185,7 @@ describe("search", () => {
     it("should return an item data by id using a token", done => {
       fetchMock.once("*", ItemDataResponse);
 
-      getItemData("3ef", MOCK_REQOPTS)
+      getItemData("3ef", MOCK_USER_REQOPTS)
         .then(response => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
@@ -375,7 +353,7 @@ describe("search", () => {
           }
         }
       };
-      updateItem(fakeItem, MOCK_REQOPTS)
+      updateItem(fakeItem, MOCK_USER_REQOPTS)
         .then(response => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
@@ -456,7 +434,7 @@ describe("search", () => {
 
     it("get item resources", done => {
       fetchMock.once("*", GetItemResourcesResponse);
-      getItemResources("3ef", MOCK_REQOPTS)
+      getItemResources("3ef", MOCK_USER_REQOPTS)
         .then(response => {
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(


### PR DESCRIPTION
one option to address @noahmulfinger's excellent feedback in #73

AFFECTS PACKAGES:
@esri/arcgis-rest-items