### PR TITLE
Fix more release automation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - December 21st 2017
+
+### Other Changes
+
+* Bug Fixes
+   * **release-automation**: fix issues uncovered by 1st release [`e6329f5`](https://github.com/Esri/arcgis-rest-js/commit/e6329f587509a9e35df5c8f8bb4cbc287724552c)
+
 ## [1.0.0] - December 21st 2017
 
 Initial Public Release
 
+[1.0.0]: https://github.com/Esri/arcgis-rest-js/compare/265d6aed1856d3ae1ff81f03ce85aba449b01f21...v1.0.0 "v1.0.0"
+[1.0.1]: https://github.com/Esri/arcgis-rest-js/compare/v1.0.0...v1.0.1 "v1.0.1"
+[1.0.0]: https://github.com/Esri/arcgis-rest-js/compare/v1.0.1...1.0.0 "1.0.0"
+[HEAD]: https://github.com/Esri/arcgis-rest-js/compare/1.0.0...HEAD "Unreleased Changes"

--- a/demos/express/package.json
+++ b/demos/express/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@esri/arcgis-rest-demo-express",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Demo of @esri/arcgis-rest-* packages in an Express server",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.0.0",
-    "@esri/arcgis-rest-request": "^1.0.0",
+    "@esri/arcgis-rest-auth": "^1.0.1",
+    "@esri/arcgis-rest-request": "^1.0.1",
     "express": "^4.15.4",
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-form-data": "^1.0.0"

--- a/demos/geocoder/package.json
+++ b/demos/geocoder/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@esri/arcgis-rest-geocoder-vanilla",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Vanilla JavaScript demo of @esri/arcgis-rest-geocoder",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.0.0",
-    "@esri/arcgis-rest-geocoder": "^1.0.0",
-    "@esri/arcgis-rest-request": "^1.0.0"
+    "@esri/arcgis-rest-auth": "^1.0.1",
+    "@esri/arcgis-rest-geocoder": "^1.0.1",
+    "@esri/arcgis-rest-request": "^1.0.1"
   },
   "devDependencies": {
     "http-server": "*"

--- a/demos/vanilla/package.json
+++ b/demos/vanilla/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@esri/arcgis-rest-demo-vanilla",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Vanilla JavaScript demo of @esri/arcgis-rest-* packages",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.0.0",
-    "@esri/arcgis-rest-request": "^1.0.0"
+    "@esri/arcgis-rest-auth": "^1.0.1",
+    "@esri/arcgis-rest-request": "^1.0.1"
   },
   "devDependencies": {
     "http-server": "*"

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*",
     "demos/*"
   ],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "precommit": "lint-staged",
     "bootstrap": "lerna bootstrap",
     "postinstall": "npm run bootstrap",
-    "prerelease:prepare": "lerna bootstrap && npm test",
+    "prerelease:prepare": "git fetch --all && lerna bootstrap && npm test",
     "release:prepare": "lerna publish --skip-git --skip-npm --yes && node ./support/changelog.js",
     "release:review": "git --no-pager diff --word-diff",
     "release:publish": "./support/publish.sh",

--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-auth",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Authentication helpers for @esri/arcgis-rest-*.",
   "main": "dist/node/index.js",
   "browser": "dist/browser/arcgis-rest-auth.umd.js",
@@ -12,10 +12,10 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "^1.0.0"
+    "@esri/arcgis-rest-request": "^1.0.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-request": "^1.0.0"
+    "@esri/arcgis-rest-request": "^1.0.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-common-types/package.json
+++ b/packages/arcgis-rest-common-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-common-types",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Common TypeScript types for @esri/arcgis-rest-* packages.",
   "types": "dist/types/index.d.ts",
   "author": "",

--- a/packages/arcgis-rest-geocoder/package.json
+++ b/packages/arcgis-rest-geocoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-geocoder",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Geocoding helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/browser/arcgis-rest-geocoder.umd.js",
@@ -12,14 +12,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.0.0",
-    "@esri/arcgis-rest-common-types": "^1.0.0",
-    "@esri/arcgis-rest-request": "^1.0.0"
+    "@esri/arcgis-rest-auth": "^1.0.1",
+    "@esri/arcgis-rest-common-types": "^1.0.1",
+    "@esri/arcgis-rest-request": "^1.0.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.0.0",
-    "@esri/arcgis-rest-common-types": "^1.0.0",
-    "@esri/arcgis-rest-request": "^1.0.0"
+    "@esri/arcgis-rest-auth": "^1.0.1",
+    "@esri/arcgis-rest-common-types": "^1.0.1",
+    "@esri/arcgis-rest-request": "^1.0.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-groups/package.json
+++ b/packages/arcgis-rest-groups/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-groups",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Portal Group helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/browser/arcgis-rest-groups.umd.js",
@@ -12,14 +12,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.0.0",
-    "@esri/arcgis-rest-common-types": "^1.0.0",
-    "@esri/arcgis-rest-request": "^1.0.0"
+    "@esri/arcgis-rest-auth": "^1.0.1",
+    "@esri/arcgis-rest-common-types": "^1.0.1",
+    "@esri/arcgis-rest-request": "^1.0.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.0.0",
-    "@esri/arcgis-rest-common-types": "^1.0.0",
-    "@esri/arcgis-rest-request": "^1.0.0"
+    "@esri/arcgis-rest-auth": "^1.0.1",
+    "@esri/arcgis-rest-common-types": "^1.0.1",
+    "@esri/arcgis-rest-request": "^1.0.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-items/package.json
+++ b/packages/arcgis-rest-items/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-items",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Portal Item helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/browser/arcgis-rest-items.umd.js",
@@ -12,14 +12,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.0.0",
-    "@esri/arcgis-rest-common-types": "^1.0.0",
-    "@esri/arcgis-rest-request": "^1.0.0"
+    "@esri/arcgis-rest-auth": "^1.0.1",
+    "@esri/arcgis-rest-common-types": "^1.0.1",
+    "@esri/arcgis-rest-request": "^1.0.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.0.0",
-    "@esri/arcgis-rest-common-types": "^1.0.0",
-    "@esri/arcgis-rest-request": "^1.0.0"
+    "@esri/arcgis-rest-auth": "^1.0.1",
+    "@esri/arcgis-rest-common-types": "^1.0.1",
+    "@esri/arcgis-rest-request": "^1.0.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-request",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Common methods and utilities for @esri/arcgis-rest-* packages.",
   "main": "dist/node/index.js",
   "browser": "dist/browser/arcgis-rest-request.umd.js",

--- a/support/changelog.js
+++ b/support/changelog.js
@@ -337,52 +337,52 @@ function filterReleases(releases) {
 }
 
 getReleases()
-  .then(logStep)
   .then(releases => filterReleases(releases))
   .then(releases => pairReleases(releases))
-  .then(pairs =>
-    Promise.all(pairs.map(([from, to]) => getCommitData(from, to)))
-  )
-  .then(releaseData => processCommitMessages(releaseData))
-  .then(releaseData => findReleasedPackages(releaseData))
-  .then(releaseData => groupCommitsByPackage(releaseData))
-  .then(releaseData => buildMarkdown(releaseData))
-  .then(newVersion => {
-    return Promise.all([
-      getReleases().then(pairReleases),
-      getChangelogData(),
-      Promise.resolve(newVersion)
-    ]);
-  })
-  .then(([pairs, changelog, newVersion]) => {
-    const links = pairs.map(([from, to]) => {
-      to = to === "HEAD" ? getPackageVersion() : to;
-      return {
-        ref: to.replace("v", ""),
-        title: to,
-        href: `${repo}/compare/${from}...${to}`
-      };
-    });
+  .then(logStep);
+// .then(pairs =>
+//   Promise.all(pairs.map(([from, to]) => getCommitData(from, to)))
+// )
+// .then(releaseData => processCommitMessages(releaseData))
+// .then(releaseData => findReleasedPackages(releaseData))
+// .then(releaseData => groupCommitsByPackage(releaseData))
+// .then(releaseData => buildMarkdown(releaseData))
+// .then(newVersion => {
+//   return Promise.all([
+//     getReleases().then(pairReleases),
+//     getChangelogData(),
+//     Promise.resolve(newVersion)
+//   ]);
+// })
+// .then(([pairs, changelog, newVersion]) => {
+//   const links = pairs.map(([from, to]) => {
+//     to = to === "HEAD" ? getPackageVersion() : to;
+//     return {
+//       ref: to.replace("v", ""),
+//       title: to,
+//       href: `${repo}/compare/${from}...${to}`
+//     };
+//   });
 
-    if (links.length) {
-      links.push({
-        ref: "HEAD",
-        title: "Unreleased Changes",
-        href: `${repo}/compare/${_.last(links).title}...HEAD`
-      });
-    }
+//   if (links.length) {
+//     links.push({
+//       ref: "HEAD",
+//       title: "Unreleased Changes",
+//       href: `${repo}/compare/${_.last(links).title}...HEAD`
+//     });
+//   }
 
-    const rendered = nunjucks.renderString(changeLogTemplate, {
-      title: changelog.title,
-      description: changelog.description,
-      oldVersions: changelog.versions,
-      newVersion: newVersion,
-      links,
-      repo
-    });
+//   const rendered = nunjucks.renderString(changeLogTemplate, {
+//     title: changelog.title,
+//     description: changelog.description,
+//     oldVersions: changelog.versions,
+//     newVersion: newVersion,
+//     links,
+//     repo
+//   });
 
-    writeFile("CHANGELOG.md", rendered, function(e) {});
-  })
-  .catch(error => {
-    console.error(error.stack);
-  });
+//   writeFile("CHANGELOG.md", rendered, function(e) {});
+// })
+// .catch(error => {
+//   console.error(error.stack);
+// });

--- a/support/changelog.js
+++ b/support/changelog.js
@@ -339,50 +339,49 @@ function filterReleases(releases) {
 getReleases()
   .then(releases => filterReleases(releases))
   .then(releases => pairReleases(releases))
-  .then(logStep);
-// .then(pairs =>
-//   Promise.all(pairs.map(([from, to]) => getCommitData(from, to)))
-// )
-// .then(releaseData => processCommitMessages(releaseData))
-// .then(releaseData => findReleasedPackages(releaseData))
-// .then(releaseData => groupCommitsByPackage(releaseData))
-// .then(releaseData => buildMarkdown(releaseData))
-// .then(newVersion => {
-//   return Promise.all([
-//     getReleases().then(pairReleases),
-//     getChangelogData(),
-//     Promise.resolve(newVersion)
-//   ]);
-// })
-// .then(([pairs, changelog, newVersion]) => {
-//   const links = pairs.map(([from, to]) => {
-//     to = to === "HEAD" ? getPackageVersion() : to;
-//     return {
-//       ref: to.replace("v", ""),
-//       title: to,
-//       href: `${repo}/compare/${from}...${to}`
-//     };
-//   });
+  .then(pairs =>
+    Promise.all(pairs.map(([from, to]) => getCommitData(from, to)))
+  )
+  .then(releaseData => processCommitMessages(releaseData))
+  .then(releaseData => findReleasedPackages(releaseData))
+  .then(releaseData => groupCommitsByPackage(releaseData))
+  .then(releaseData => buildMarkdown(releaseData))
+  .then(newVersion => {
+    return Promise.all([
+      getReleases().then(pairReleases),
+      getChangelogData(),
+      Promise.resolve(newVersion)
+    ]);
+  })
+  .then(([pairs, changelog, newVersion]) => {
+    const links = pairs.map(([from, to]) => {
+      to = to === "HEAD" ? getPackageVersion() : to;
+      return {
+        ref: to.replace("v", ""),
+        title: to,
+        href: `${repo}/compare/${from}...${to}`
+      };
+    });
 
-//   if (links.length) {
-//     links.push({
-//       ref: "HEAD",
-//       title: "Unreleased Changes",
-//       href: `${repo}/compare/${_.last(links).title}...HEAD`
-//     });
-//   }
+    if (links.length) {
+      links.push({
+        ref: "HEAD",
+        title: "Unreleased Changes",
+        href: `${repo}/compare/${_.last(links).title}...HEAD`
+      });
+    }
 
-//   const rendered = nunjucks.renderString(changeLogTemplate, {
-//     title: changelog.title,
-//     description: changelog.description,
-//     oldVersions: changelog.versions,
-//     newVersion: newVersion,
-//     links,
-//     repo
-//   });
+    const rendered = nunjucks.renderString(changeLogTemplate, {
+      title: changelog.title,
+      description: changelog.description,
+      oldVersions: changelog.versions,
+      newVersion: newVersion,
+      links,
+      repo
+    });
 
-//   writeFile("CHANGELOG.md", rendered, function(e) {});
-// })
-// .catch(error => {
-//   console.error(error.stack);
-// });
+    writeFile("CHANGELOG.md", rendered, function(e) {});
+  })
+  .catch(error => {
+    console.error(error.stack);
+  });

--- a/support/publish.sh
+++ b/support/publish.sh
@@ -21,22 +21,6 @@ git tag v$VERSION
 git push https://github.com/Esri/arcgis-rest-js.git master
 git push --tags
 
-# checkout temp branch for release
-git checkout -b release-v$VERSION
-
-# add built files to the release commit
-git add packages/*/dist -f
-
-# commit the built files
-git commit -am"Publish v$VERSION" --no-verify
-
-# tag the release
-git tag v$VERSION
-
-# push the release commit and tag to github
-git push https://github.com/Esri/arcgis-rest-js.git release-v$VERSION
-git push --tags
-
 # publish each package on npm
 lerna publish --skip-git --yes --repo-version $VERSION
 
@@ -52,8 +36,3 @@ gh-release --t v$VERSION --repo arcgis-rest-js --owner Esri -a $TEMP_FOLDER.zip
 
 # Delete the ZIP archive
 rm $TEMP_FOLDER.zip
-
-# checkout master and delete release branch locally and on GitHub
-git checkout master
-git branch -D release-v$VERSION
-git push upstream :release-v$VERSION

--- a/support/publish.sh
+++ b/support/publish.sh
@@ -5,14 +5,16 @@ VERSION=$(node --eval "console.log(require('./lerna.json').version);")
 
 # commit the changes from `npm run release:prepare`
 git add --all
-git commit -am "Prepare v$VERSION" --no-verify
+git commit -am "v$VERSION" --no-verify
 
 # incriment the package.json version to the lerna version so gh-release works
-npm version $VERSION --allow-same-version
+npm version $VERSION --allow-same-version --no-git-tag-version
 
 # amend the changes from `npm version` to the release commit
 git add --all
-git commit -am "Prepare v$VERSION" --no-verify --amend
+git commit -am "v$VERSION" --no-verify --amend
+
+git tag v$VERSION
 
 # push the changes and tag to github
 git push https://github.com/Esri/arcgis-rest-js.git master


### PR DESCRIPTION
While testing release automation I accidentally published v1.0.1 to NPM. This PR updates all teh necessary files. Once this gets merged I'll publish 1.0.2 and deprecate 1.0.1 to finish cleaning stuff up.