### PR TITLE
docs(fix dead links): fixed broken links within declaration page content

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Some useful commands include:
 * [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
 * [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
 * [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
+* [`@esri/arcgis-rest-common-types`](./packages/arcgis-rest-common-types) - Stores objects common across the ArcGIS API.
 
 ### Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ request(url)
     .then(response => {
         console.log(response) // WebMap JSON
     })
-});
 ```
 
 ### API Reference

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -4,7 +4,7 @@
   {%- endif -%}
 
   {%- if type.type === 'reference' and type.id -%}
-    <i><a href="{{ API_TOOLS.findById(data.typedoc, type.id).pageUrl }}">{{type.name}}</a></i>
+    <i><a href="{{ baseUrl + API_TOOLS.findById(data.typedoc, type.id).pageUrl }}">{{type.name}}</a></i>
   {%- elif type.type === 'reference' -%}
     <i>{{type.name}}</i>
   {%- endif -%}
@@ -13,7 +13,7 @@
     <span class="code-face"><span class="text-light-gray">function</span> <span class="text-purple">{{name}}</span> <span class="text-light-gray">(</span>{{ @signatureParams(type.declaration.signatures[0].parameters) }}<span class="text-light-gray">) : </span>{{@type(type.declaration.signatures[0].type)}}</span>
   {%- elif type.type === 'reflection' and type.declaration.id  -%}
     {% set declaration = API_TOOLS.findById(data.typedoc, type.declaration.id) %}
-    <i><a href="{{ declaration.pageUrl }}">{{declaration.name}}</a></i>
+    <i><a href="{{ baseUrl + declaration.pageUrl }}">{{declaration.name}}</a></i>
   {%- elif type.type === 'reflection' -%}
     <i>{{ type.name }}</i>
   {%- endif -%}
@@ -361,11 +361,11 @@
   {% for implementedType in implementedTypes %}
     {% if implementedType.id %}
       {% set base = API_TOOLS.findById(data.typedoc, implementedType.id) %}
-      <li class="code-face {{base.icon}}"><a href="{{ base.pageUrl }}" class="tsd-kind-icon">{{base.name}}</a></li>
+      <li class="code-face {{base.icon}}"><a href="{{ baseUrl + base.pageUrl }}" class="tsd-kind-icon">{{base.name}}</a></li>
     {% elif implementedType.name %}
       {% set base = API_TOOLS.findByName(data.typedoc, implementedType.name) %}
       {% if base %}
-        <li class="code-face {{base.icon}}"><a href="{{ base.pageUrl }}" class="tsd-kind-icon">{{base.name}}</a></li>
+        <li class="code-face {{base.icon}}"><a href="{{ baseUrl + base.pageUrl }}" class="tsd-kind-icon">{{base.name}}</a></li>
       {% elif implementedType.name %}
         <li class="code-face">{{base.name}}</li>
       {% endif %}
@@ -380,11 +380,11 @@
   {% for extendedType in extendedTypes %}
     {% if extendedType.id %}
       {% set base = API_TOOLS.findById(data.typedoc, extendedType.id) %}
-      <li class="code-face {{base.icon}}"><a href="{{ base.pageUrl }}" class="tsd-kind-icon">{{base.name}}</a></li>
+      <li class="code-face {{base.icon}}"><a href="{{ baseUrl + base.pageUrl }}" class="tsd-kind-icon">{{base.name}}</a></li>
     {% elif extendedType.name %}
       {% set base = API_TOOLS.findByName(data.typedoc, extendedType.name) %}
       {% if base %}
-        <li class="code-face {{base.icon}}"><a href="{{ base.pageUrl }}" class="tsd-kind-icon">{{base.name}}</a></li>
+        <li class="code-face {{base.icon}}"><a href="{{ baseUrl + base.pageUrl }}" class="tsd-kind-icon">{{base.name}}</a></li>
       {% elif extendedType.name %}
         <li class="code-face">{{base.name}}</li>
       {% endif %}

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "release:prepare": "lerna publish --skip-git --skip-npm --yes && node ./support/changelog.js",
     "release:review": "git --no-pager diff --word-diff",
     "release:publish": "./support/publish.sh",
-    "c": "git add --all && npm run precommit && git-cz"
+    "c": "npm run precommit && git-cz"
   },
   "repository": {
     "type": "git",

--- a/packages/arcgis-rest-auth/README.md
+++ b/packages/arcgis-rest-auth/README.md
@@ -1,0 +1,69 @@
+[![npm version][npm-img]][npm-url]
+[![build status][travis-img]][travis-url]
+[![apache licensed](https://img.shields.io/badge/license-Apache-green.svg?style=flat-square)](https://raw.githubusercontent.com/Esri/arcgis-rest-js/master/LICENSE)
+
+[npm-img]: https://img.shields.io/npm/v/@esri/arcgis-rest-auth.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/@esri/arcgis-rest-auth
+[travis-img]: https://img.shields.io/travis/Esri/arcgis-rest-js/master.svg?style=flat-square
+[travis-url]: https://travis-ci.org/Esri/arcgis-rest-js
+
+# @esri/arcgis-rest-auth
+
+> Authentication helpers for [`@esri/arcgis-rest-*`](https://github.com/Esri/arcgis-rest-js).
+
+### Example
+
+```bash
+npm install @esri/arcgis-rest-auth
+```
+
+```js
+import { UserSession } from '@esri/arcgis-rest-auth';
+
+const session = new UserSession({
+    username: "casey",
+    password: "123456"
+});
+```
+
+### Related Packages
+
+* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
+* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
+* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
+* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
+* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
+
+### Issues
+
+If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.
+
+If you're looking for help you can also post issues on [GIS Stackexchange](http://gis.stackexchange.com/questions/ask?tags=esri-oss).
+
+### Versioning
+
+For transparency into the release cycle and in striving to maintain backward compatibility, @esri/arcgis-rest-js is maintained under Semantic Versioning guidelines and will adhere to these rules whenever possible.
+
+For more information on SemVer, please visit <http://semver.org/>.
+
+### Contributing
+
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](CONTRIBUTING.md).
+
+### License
+
+Copyright 2017 Esri
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+> http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A copy of the license is available in the repository's [LICENSE](./LICENSE) file.

--- a/packages/arcgis-rest-auth/README.md
+++ b/packages/arcgis-rest-auth/README.md
@@ -26,14 +26,6 @@ const session = new UserSession({
 });
 ```
 
-### Related Packages
-
-* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
-* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
-* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
-* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
-* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
-
 ### Issues
 
 If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -143,8 +143,8 @@ export interface IUserSessionOptions {
 }
 
 /**
- * Used to manage the authentication of ArcGIS Online and ArcGIs Enterprise users
- * in [`request`](/api/arcgis-rest-request/request/). This class also includes several
+ * Used to manage the authentication of ArcGIS Online and ArcGIS Enterprise users
+ * in [`request`](/api/request/request/). This class also includes several
  * helper methods for authenticating users with OAuth 2.0 in both browser and
  * server applications.
  */

--- a/packages/arcgis-rest-common-types/README.md
+++ b/packages/arcgis-rest-common-types/README.md
@@ -24,14 +24,6 @@ const myPoint = { x: -118.409, y: 33.943 } as IPoint
 
 ```
 
-### Related Packages
-
-* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
-* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
-* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
-* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
-* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
-
 ### Issues
 
 If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.

--- a/packages/arcgis-rest-common-types/README.md
+++ b/packages/arcgis-rest-common-types/README.md
@@ -1,0 +1,67 @@
+[![npm version][npm-img]][npm-url]
+[![build status][travis-img]][travis-url]
+[![apache licensed](https://img.shields.io/badge/license-Apache-green.svg?style=flat-square)](https://raw.githubusercontent.com/Esri/arcgis-rest-js/master/LICENSE)
+
+[npm-img]: https://img.shields.io/npm/v/@esri/arcgis-rest-common-types.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/@esri/arcgis-rest-common-types
+[travis-img]: https://img.shields.io/travis/Esri/arcgis-rest-js/master.svg?style=flat-square
+[travis-url]: https://travis-ci.org/Esri/arcgis-rest-js
+
+# @esri/arcgis-rest-common-types
+
+> Common TypeScript types for [`@esri/arcgis-rest-*`](https://github.com/Esri/arcgis-rest-js) packages.
+
+### Example
+
+```bash
+npm install @esri/arcgis-rest-common-types
+```
+
+```ts
+import { IPoint } from '@esri/arcgis-rest-common-types';
+
+const myPoint = { x: -118.409, y: 33.943 } as IPoint
+
+```
+
+### Related Packages
+
+* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
+* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
+* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
+* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
+* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
+
+### Issues
+
+If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.
+
+If you're looking for help you can also post issues on [GIS Stackexchange](http://gis.stackexchange.com/questions/ask?tags=esri-oss).
+
+### Versioning
+
+For transparency into the release cycle and in striving to maintain backward compatibility, @esri/arcgis-rest-js is maintained under Semantic Versioning guidelines and will adhere to these rules whenever possible.
+
+For more information on SemVer, please visit <http://semver.org/>.
+
+### Contributing
+
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](CONTRIBUTING.md).
+
+### License
+
+Copyright 2017 Esri
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+> http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A copy of the license is available in the repository's [LICENSE](./LICENSE) file.

--- a/packages/arcgis-rest-geocoder/README.md
+++ b/packages/arcgis-rest-geocoder/README.md
@@ -1,0 +1,69 @@
+[![npm version][npm-img]][npm-url]
+[![build status][travis-img]][travis-url]
+[![apache licensed](https://img.shields.io/badge/license-Apache-green.svg?style=flat-square)](https://raw.githubusercontent.com/Esri/arcgis-rest-js/master/LICENSE)
+
+[npm-img]: https://img.shields.io/npm/v/@esri/arcgis-rest-geocoder.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/@esri/arcgis-rest-geocoder
+[travis-img]: https://img.shields.io/travis/Esri/arcgis-rest-js/master.svg?style=flat-square
+[travis-url]: https://travis-ci.org/Esri/arcgis-rest-js
+
+# @esri/arcgis-rest-groups
+
+> Geocoding helpers for [`@esri/arcgis-rest-request`](https://github.com/Esri/arcgis-rest-js).
+
+### Example
+
+```bash
+npm install @esri/arcgis-rest-geocoder
+```
+
+```js
+import { geocode } from '@esri/arcgis-rest-geocoder';
+
+geocode("LAX")
+  .then((response) => {
+    response.candidates[0].location; // => { x: -118.409, y: 33.943, spatialReference: { wkid: 4326 }  }
+  });
+```
+
+### Related Packages
+
+* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
+* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
+* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
+* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
+* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
+
+### Issues
+
+If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.
+
+If you're looking for help you can also post issues on [GIS Stackexchange](http://gis.stackexchange.com/questions/ask?tags=esri-oss).
+
+### Versioning
+
+For transparency into the release cycle and in striving to maintain backward compatibility, @esri/arcgis-rest-js is maintained under Semantic Versioning guidelines and will adhere to these rules whenever possible.
+
+For more information on SemVer, please visit <http://semver.org/>.
+
+### Contributing
+
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](CONTRIBUTING.md).
+
+### License
+
+Copyright 2017 Esri
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+> http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A copy of the license is available in the repository's [LICENSE](./LICENSE) file.

--- a/packages/arcgis-rest-geocoder/README.md
+++ b/packages/arcgis-rest-geocoder/README.md
@@ -26,14 +26,6 @@ geocode("LAX")
   });
 ```
 
-### Related Packages
-
-* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
-* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
-* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
-* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
-* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
-
 ### Issues
 
 If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.

--- a/packages/arcgis-rest-groups/README.md
+++ b/packages/arcgis-rest-groups/README.md
@@ -1,0 +1,69 @@
+[![npm version][npm-img]][npm-url]
+[![build status][travis-img]][travis-url]
+[![apache licensed](https://img.shields.io/badge/license-Apache-green.svg?style=flat-square)](https://raw.githubusercontent.com/Esri/arcgis-rest-js/master/LICENSE)
+
+[npm-img]: https://img.shields.io/npm/v/@esri/arcgis-rest-groups.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/@esri/arcgis-rest-groups
+[travis-img]: https://img.shields.io/travis/Esri/arcgis-rest-js/master.svg?style=flat-square
+[travis-url]: https://travis-ci.org/Esri/arcgis-rest-js
+
+# @esri/arcgis-rest-groups
+
+> A module for working with groups in the ArcGIS REST API that runs in Node.js and modern browsers.
+
+### Example
+
+```bash
+npm install @esri/arcgis-rest-groups
+```
+
+```js
+import { searchGroups } from '@esri/arcgis-rest-groups';
+
+searchGroups({q:"water"})
+    .then(response => {
+        console.log(response.results.length) // 10
+    });
+```
+
+### Related Packages
+
+* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
+* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
+* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
+* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
+* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
+
+### Issues
+
+If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.
+
+If you're looking for help you can also post issues on [GIS Stackexchange](http://gis.stackexchange.com/questions/ask?tags=esri-oss).
+
+### Versioning
+
+For transparency into the release cycle and in striving to maintain backward compatibility, @esri/arcgis-rest-js is maintained under Semantic Versioning guidelines and will adhere to these rules whenever possible.
+
+For more information on SemVer, please visit <http://semver.org/>.
+
+### Contributing
+
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](CONTRIBUTING.md).
+
+### License
+
+Copyright 2017 Esri
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+> http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A copy of the license is available in the repository's [LICENSE](./LICENSE) file.

--- a/packages/arcgis-rest-groups/README.md
+++ b/packages/arcgis-rest-groups/README.md
@@ -26,14 +26,6 @@ searchGroups({q:"water"})
     });
 ```
 
-### Related Packages
-
-* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
-* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
-* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
-* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
-* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
-
 ### Issues
 
 If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.

--- a/packages/arcgis-rest-items/README.md
+++ b/packages/arcgis-rest-items/README.md
@@ -28,14 +28,6 @@ getItem(itemId)
     });
 ```
 
-### Related Packages
-
-* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
-* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
-* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
-* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
-* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
-
 ### Issues
 
 If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.

--- a/packages/arcgis-rest-items/README.md
+++ b/packages/arcgis-rest-items/README.md
@@ -1,0 +1,71 @@
+[![npm version][npm-img]][npm-url]
+[![build status][travis-img]][travis-url]
+[![apache licensed](https://img.shields.io/badge/license-Apache-green.svg?style=flat-square)](https://raw.githubusercontent.com/Esri/arcgis-rest-js/master/LICENSE)
+
+[npm-img]: https://img.shields.io/npm/v/@esri/arcgis-rest-items.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/@esri/arcgis-rest-items
+[travis-img]: https://img.shields.io/travis/Esri/arcgis-rest-js/master.svg?style=flat-square
+[travis-url]: https://travis-ci.org/Esri/arcgis-rest-js
+
+# @esri/arcgis-rest-items
+
+> A module for working with content in the ArcGIS REST API that runs in Node.js and modern browsers.
+
+### Example
+
+```bash
+npm install @esri/arcgis-rest-items
+```
+
+```js
+import { getItem } from '@esri/arcgis-rest-items';
+
+const itemId = "30e5fe3149c34df1ba922e6f5bbf808f";
+
+getItem(itemId)
+    .then(response => {
+        console.log(response.title) // World Topographic Map
+    });
+```
+
+### Related Packages
+
+* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
+* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
+* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
+* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
+* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
+
+### Issues
+
+If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.
+
+If you're looking for help you can also post issues on [GIS Stackexchange](http://gis.stackexchange.com/questions/ask?tags=esri-oss).
+
+### Versioning
+
+For transparency into the release cycle and in striving to maintain backward compatibility, @esri/arcgis-rest-js is maintained under Semantic Versioning guidelines and will adhere to these rules whenever possible.
+
+For more information on SemVer, please visit <http://semver.org/>.
+
+### Contributing
+
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](CONTRIBUTING.md).
+
+### License
+
+Copyright 2017 Esri
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+> http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A copy of the license is available in the repository's [LICENSE](./LICENSE) file.

--- a/packages/arcgis-rest-request/README.md
+++ b/packages/arcgis-rest-request/README.md
@@ -28,14 +28,6 @@ request(url)
     });
 ```
 
-### Related Packages
-
-* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
-* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
-* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
-* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
-* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
-
 ### Issues
 
 If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.

--- a/packages/arcgis-rest-request/README.md
+++ b/packages/arcgis-rest-request/README.md
@@ -1,0 +1,71 @@
+[![npm version][npm-img]][npm-url]
+[![build status][travis-img]][travis-url]
+[![apache licensed](https://img.shields.io/badge/license-Apache-green.svg?style=flat-square)](https://raw.githubusercontent.com/Esri/arcgis-rest-js/master/LICENSE)
+
+[npm-img]: https://img.shields.io/npm/v/@esri/arcgis-rest-request.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/@esri/arcgis-rest-request
+[travis-img]: https://img.shields.io/travis/Esri/arcgis-rest-js/master.svg?style=flat-square
+[travis-url]: https://travis-ci.org/Esri/arcgis-rest-js
+
+# @esri/arcgis-rest-request
+
+> A module for making requests to the ArcGIS REST API that runs in Node.js and modern browsers.
+
+### Example
+
+```bash
+npm install @esri/arcgis-rest-request
+```
+
+```js
+import { request } from '@esri/arcgis-rest-request';
+
+const url = "https://www.arcgis.com/sharing/rest/content/items/43a8e51789044d9480a20089a84129ad/data";
+
+request(url)
+    .then(response => {
+        console.log(response) // WebMap JSON
+    });
+```
+
+### Related Packages
+
+* [`@esri/arcgis-rest-request`](./packages/arcgis-rest-request/) - Underpins other packages and supports making low-level requests.
+* [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
+* [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
+* [`@esri/arcgis-rest-items`](./packages/arcgis-rest-items) - Methods for working with ArcGIS Online/Enterprise content.
+* [`@esri/arcgis-rest-groups`](./packages/arcgis-rest-groups) - Methods for working with ArcGIS Online/Enterprise groups.
+
+### Issues
+
+If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.
+
+If you're looking for help you can also post issues on [GIS Stackexchange](http://gis.stackexchange.com/questions/ask?tags=esri-oss).
+
+### Versioning
+
+For transparency into the release cycle and in striving to maintain backward compatibility, @esri/arcgis-rest-js is maintained under Semantic Versioning guidelines and will adhere to these rules whenever possible.
+
+For more information on SemVer, please visit <http://semver.org/>.
+
+### Contributing
+
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](CONTRIBUTING.md).
+
+### License
+
+Copyright 2017 Esri
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+> http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A copy of the license is available in the repository's [LICENSE](./LICENSE) file.


### PR DESCRIPTION
fixes a few dozen dead links within the page body of individual declarations.

#### full disclosure: i just blindly added `BASE_URL +` to everything that looked like a link.

after selectively staging a few files and running `npm run c` i noticed that it bundles its own `git add --all` command. i think it'd be preferable if it didn't.

also including READMEs to resolve #81 and fixed a couple typos