### PR TITLE
prepend base url to API reference search results

### DIFF
--- a/docs/src/api/_layout.html
+++ b/docs/src/api/_layout.html
@@ -10,7 +10,7 @@
 {% block main %}
   <div class="grid-container trailer-1 leader-1">
     <div class="column-6">
-    <api-search>
+    <api-search base-url="{{baseUrl}}">
       <ul class="list-plain">
         {% for package in data.typedoc.packages %}
         <li class="{{ package.icon }}">

--- a/docs/src/js/api-search.js
+++ b/docs/src/js/api-search.js
@@ -31,6 +31,7 @@ Vue.component("api-search", {
       searchTerm: ""
     };
   },
+  props: ['baseUrl'],
   methods: {
     highlightText: function(text, matches) {
       return matches
@@ -60,12 +61,10 @@ Vue.component("api-search", {
 
     search: function(text) {
       return this.index.search(text).map(result => {
-        // append gh-pages subdirectory on live site
-        const BASE_URL = (window && window.location.origin === "http://localhost:3000") ? "" : "/arcgis-rest-js";
         return {
           title: this.highlightText(result.item.title, result.matches),
           icon: result.item.icon,
-          url: BASE_URL + result.item.url
+          url: this.baseUrl + result.item.url
         };
       });
     },

--- a/docs/src/js/api-search.js
+++ b/docs/src/js/api-search.js
@@ -60,10 +60,12 @@ Vue.component("api-search", {
 
     search: function(text) {
       return this.index.search(text).map(result => {
+        // append gh-pages subdirectory on live site
+        const BASE_URL = (window && window.location.origin === "http://localhost:3000") ? "" : "/arcgis-rest-js";
         return {
           title: this.highlightText(result.item.title, result.matches),
           icon: result.item.icon,
-          url: result.item.url
+          url: BASE_URL + result.item.url
         };
       });
     },


### PR DESCRIPTION
STR:
1. launch https://esri.github.io/arcgis-rest-js/api/
2. search for `h` and select `HTTPMethods` from the list of suggestions

if anyone has a more _elegant_ solution than checking `window.location.origin` in a Vue component, i'm all 👂 s