### PR TITLE
have travis push doc updates when a release is tagged

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,13 @@ before_script:
   - npm run bootstrap
 script:
   - npm run test:node
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  on:
+    branch: master
+  local-dir: docs/build
+  target_branch: gh-pages # default
+before_deploy:
+ - npm run docs:build

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "release:prepare": "lerna publish --skip-git --skip-npm --yes && node ./support/changelog.js",
     "release:review": "git --no-pager diff --word-diff",
     "release:publish": "./support/publish.sh",
-    "postrelease:publish": "npm run docs:deploy",
     "c": "npm run precommit && git-cz"
   },
   "repository": {


### PR DESCRIPTION
second attempt at #88 

it seems more appropriate to only have travis build the doc and push updates to the live site when a release is tagged.

this will require us to update the site manually when a doc bug has been patched. but i think this is preferable to having new API documentation land too soon.

