### PR TITLE
docs(links): fix remaining 404s in docs

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -144,7 +144,7 @@ export interface IUserSessionOptions {
 
 /**
  * Used to manage the authentication of ArcGIS Online and ArcGIS Enterprise users
- * in [`request`](/api/request/request/). This class also includes several
+ * in `request`. This class also includes several
  * helper methods for authenticating users with OAuth 2.0 in both browser and
  * server applications.
  */
@@ -592,12 +592,12 @@ export class UserSession implements IAuthenticationManager {
     }
 
     if (!this._pendingTokenRequests[this.portal]) {
-      this._pendingTokenRequests[
-        this.portal
-      ] = this.refreshSession().then(session => {
-        this._pendingTokenRequests[this.portal] = null;
-        return session.token;
-      });
+      this._pendingTokenRequests[this.portal] = this.refreshSession().then(
+        session => {
+          this._pendingTokenRequests[this.portal] = null;
+          return session.token;
+        }
+      );
     }
 
     return this._pendingTokenRequests[this.portal];

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -33,7 +33,7 @@ export interface IParams {
 }
 
 /**
- * Options for the [`request()`](/api/arcgis-core/request/) method.
+ * Options for the `request()` method.
  */
 export interface IRequestOptions {
   /**

--- a/packages/arcgis-rest-request/src/utils/check-for-errors.ts
+++ b/packages/arcgis-rest-request/src/utils/check-for-errors.ts
@@ -5,7 +5,7 @@ import { ArcGISRequestError } from "./ArcGISRequestError";
 import { ArcGISAuthError } from "./ArcGISAuthError";
 import { IRequestOptions, IParams } from "../request";
 /**
- * Checks a JSON response from the ArcGIS REST API for errors. If there are no errors this will return the `data` it is passed in. If there is an error it will throw. With a [`ArcGISRequestError`](/api/arcgis-core/ArcGISRequestError/) or [`ArcGISAuthError`](/api/arcgis-core/ArcGISAuthError/).
+ * Checks for errors in a JSON response from the ArcGIS REST API. If there are no errors, it will return the `data` passed in. If there is an error, it will throw an `ArcGISRequestError` or `ArcGISAuthError`.
  *
  * @param data The response JSON to check for errors.
  * @param url The url of the original request


### PR DESCRIPTION
ISSUES CLOSED: #92 

Removes the in-comment links for now. If we are going to have in-comment links in the future, it will have to be in a way that allows injecting a base url so it works locally and on the github pages.