### PR TITLE
fix(oauth): check for window parent correctly in oauth without popup

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -338,7 +338,7 @@ export class UserSession implements IAuthenticationManager {
         return undefined;
       }
 
-      if (win.parent) {
+      if (win !== win.parent) {
         win.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`](error, oauthInfo);
         win.close();
         return undefined;
@@ -592,12 +592,12 @@ export class UserSession implements IAuthenticationManager {
     }
 
     if (!this._pendingTokenRequests[this.portal]) {
-      this._pendingTokenRequests[
-        this.portal
-      ] = this.refreshSession().then(session => {
-        this._pendingTokenRequests[this.portal] = null;
-        return session.token;
-      });
+      this._pendingTokenRequests[this.portal] = this.refreshSession().then(
+        session => {
+          this._pendingTokenRequests[this.portal] = null;
+          return session.token;
+        }
+      );
     }
 
     return this._pendingTokenRequests[this.portal];

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -483,6 +483,9 @@ describe("UserSession", () => {
         location: {
           href:
             "https://example-app.com/redirect-uri#access_token=token&expires_in=1209600&username=casey"
+        },
+        get parent() {
+          return this;
         }
       };
 
@@ -566,6 +569,9 @@ describe("UserSession", () => {
         location: {
           href:
             "https://example-app.com/redirect-uri#error=Invalid_Signin&error_description=Invalid_Signin"
+        },
+        get parent() {
+          return this;
         }
       };
 


### PR DESCRIPTION
window.parent is equal to itself when there is no parent (see https://developer.mozilla.org/en-US/docs/Web/API/Window/parent), so it will always be truthy. Need to check
that the window has a separate parent instead.

Currently, if you set `popup` to false when doing oauth through the UserSession, you'll get an error when calling `completeOauth2` because it tries to run 
```
win.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`](error, oauthInfo);
```
at [UserSession:342](https://github.com/Esri/arcgis-rest-js/blob/master/packages/arcgis-rest-auth/src/UserSession.ts#L342)

AFFECTS PACKAGES:
@esri/arcgis-rest-auth
  