### PR TITLE
Fix #108

### DIFF
--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -103,7 +103,7 @@ export function request(
   requestOptions: IRequestOptions = { params: { f: "json" } }
 ): Promise<any> {
   const options: IRequestOptions = {
-    ...{ httpMethod: "POST", fetch: fetch.bind(Function("return this")()) },
+    ...{ httpMethod: "POST", fetch },
     ...requestOptions
   };
 
@@ -133,6 +133,10 @@ export function request(
         ", "
       )} modules at the root of your application to add these to the global scope. See http://bit.ly/2BXbqzq for more info.`
     );
+  }
+
+  if (options.fetch === fetch) {
+    options.fetch = fetch.bind(Function("return this")());
   }
 
   const { httpMethod, authentication } = options;


### PR DESCRIPTION
@tomwayson this SHOULD prevent `request` from throwing an error when calling `request` with a custom `fetch` with no global `fetch` defined. I didn't test this in IE but I can get to it tomorrow if you can't do it today.

Fix #108 