### PR TITLE
throw ArcGISAuthError instead of Error when unable to refresh a token

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -522,7 +522,7 @@ export class UserSession implements IAuthenticationManager {
       return this.refreshWithRefreshToken();
     }
 
-    return Promise.reject(new Error("Unable to refresh token."));
+    return Promise.reject(new ArcGISAuthError("Unable to refresh token."));
   }
 
   /**

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1,5 +1,9 @@
 import { UserSession, IFetchTokenResponse } from "../src/index";
-import { ArcGISRequestError, ErrorTypes } from "@esri/arcgis-rest-request";
+import {
+  ArcGISRequestError,
+  ArcGISAuthError,
+  ErrorTypes
+} from "@esri/arcgis-rest-request";
 import * as fetchMock from "fetch-mock";
 import { YESTERDAY, TOMORROW } from "./utils";
 
@@ -350,6 +354,8 @@ describe("UserSession", () => {
       });
 
       session.refreshSession().catch(e => {
+        expect(e instanceof ArcGISAuthError).toBeTruthy();
+        expect(e.name).toBe("ArcGISAuthError");
         expect(e.message).toBe("Unable to refresh token.");
         done();
       });


### PR DESCRIPTION
Fix #56