### PR TITLE
add more common types

### DIFF
--- a/demos/batch-geocoder-node/package-lock.json
+++ b/demos/batch-geocoder-node/package-lock.json
@@ -1,38 +1,7 @@
 {
-  "name": "batch-geocoder",
-  "version": "0.0.1",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
-    "@esri/arcgis-rest-auth": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-1.0.2.tgz",
-      "integrity": "sha512-OAWEUDLLCmbgU0u0m3rfc6KKjfzbpNyn2/CfATdFpbPKBdGQAUcYRPboBvt7sKgId2uAH2OZuq7ktz2SSkf8qQ==",
-      "requires": {
-        "tslib": "1.8.1"
-      }
-    },
-    "@esri/arcgis-rest-common-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-common-types/-/arcgis-rest-common-types-1.0.2.tgz",
-      "integrity": "sha512-Ff9qduwKc45VacrcNvgTbZm8/Rr0caqNtLvP0heEx+rDEpuMQqyupWFEqxleLBKFWzEJrhQq+BH7ZTStrtDgfQ=="
-    },
-    "@esri/arcgis-rest-geocoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-geocoder/-/arcgis-rest-geocoder-1.0.2.tgz",
-      "integrity": "sha512-wcbw/8ufvFTnu3YouiiBDh70iXSXrGhBk2A8WxepuYD0VTWPDHgwOFz/rp1OhpI6ZLSl9NtgqSRVDZuDpqjjyA==",
-      "requires": {
-        "tslib": "1.8.1"
-      }
-    },
-    "@esri/arcgis-rest-request": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.0.2.tgz",
-      "integrity": "sha512-P44FP5Tf6GAOzN+H3UjuSwBJRwux4JxoiEc6BIvDnI2hTO0REl/ie89MESilR74Gv+9PlPEuAuF+ojEKGg0q2g==",
-      "requires": {
-        "tslib": "1.8.1"
-      }
-    },
     "async": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
@@ -130,11 +99,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.3.6.tgz",
       "integrity": "sha1-lWbtoOyrE6/LdApiOBxpn0hssUU="
-    },
-    "tslib": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
-      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
     },
     "whatwg-fetch": {
       "version": "2.0.3",

--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -105,6 +105,14 @@ export interface IExtent {
 /**
  *
  */
+export interface IHasZM {
+  hasZ?: boolean;
+  hasM?: boolean;
+}
+
+/**
+ *
+ */
 export interface IFeatureSet extends IHasZM {
   objectIdFieldName?: string; // optional
   globalIdFieldName?: string; // optional
@@ -124,14 +132,6 @@ export interface IFont {
   style?: "italic" | "normal" | "oblique";
   weight?: "bold" | "bolder" | "lighter" | "normal";
   decoration?: "line-through" | "underline" | "none";
-}
-
-/**
- *
- */
-export interface IHasZM {
-  hasZ?: boolean;
-  hasM?: boolean;
 }
 
 /**
@@ -176,6 +176,14 @@ export interface IOldCircularArc {
 /**
  *
  */
+export interface ISymbol {
+  type: SymbolType;
+  style?: string;
+}
+
+/**
+ *
+ */
 export interface IMarkerSymbol extends ISymbol {
   angle?: number;
   xoffset?: number;
@@ -200,6 +208,20 @@ export interface IPagingParams {
 /**
  *
  */
+export interface IPictureSourced {
+  url?: string; // Relative URL for static layers and full URL for dynamic layers. Access relative URL using http://<mapservice-url>/<layerId1>/images/<imageUrl11>
+  imageData?: string; // "<base64EncodedImageData>";
+  contentType?: string;
+  width?: number;
+  height?: number;
+  angle?: number;
+  xoffset?: number;
+  yoffset?: number;
+}
+
+/**
+ *
+ */
 export interface IPictureFillSymbol extends ISymbol, IPictureSourced {
   type: "esriPFS";
   outline?: ISimpleLineSymbol; // if outline has been specified
@@ -212,20 +234,6 @@ export interface IPictureFillSymbol extends ISymbol, IPictureSourced {
  */
 export interface IPictureMarkerSymbol extends IMarkerSymbol, IPictureSourced {
   type: "esriPMS";
-}
-
-/**
- *
- */
-export interface IPictureSourced {
-  url?: string; // Relative URL for static layers and full URL for dynamic layers. Access relative URL using http://<mapservice-url>/<layerId1>/images/<imageUrl11>
-  imageData?: string; // "<base64EncodedImageData>";
-  contentType?: string;
-  width?: number;
-  height?: number;
-  angle?: number;
-  xoffset?: number;
-  yoffset?: number;
 }
 
 /**
@@ -364,14 +372,6 @@ export interface ISpatialReference {
   latestVcsWkid?: number;
   wkt?: string;
   latestWkt?: string;
-}
-
-/**
- *
- */
-export interface ISymbol {
-  type: SymbolType;
-  style?: string;
 }
 
 /**

--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -4,7 +4,7 @@
 /**
  * an arc can be represented as a JSON curve object
  */
-export interface Arc {
+export interface IArc {
   a: [
     Position, // End point: x, y, <z>, <m>
     Position2D, // Center point: center_x, center_y
@@ -19,14 +19,14 @@ export interface Arc {
 /**
  * a bezier curve can be represented as a JSON curve object
  */
-export interface BezierCurve {
+export interface IBezierCurve {
   b: [Position, Position2D, Position2D];
 }
 
 /**
  * a circular arc can be represented as a JSON curve object
  */
-export interface CircularArc {
+export interface ICircularArc {
   c: [Position, Position2D];
 }
 
@@ -38,20 +38,20 @@ export type Color = [number, number, number, number];
 /**
  *
  */
-export type ElipticArc = Arc;
+export type ElipticArc = IArc;
 
 /**
  * a spatial entity and its corresponding properties
  */
-export interface Feature {
-  geometry?: Geometry;
+export interface IFeature {
+  geometry?: IGeometry;
   attributes?: any;
 }
 
 /**
  *
  */
-export interface Field {
+export interface IField {
   name: string;
   type: string;
   alias?: string;
@@ -61,14 +61,14 @@ export interface Field {
 /**
  * a building block for discrete geometries
  */
-export interface Geometry {
-  spatialReference?: SpatialReference;
+export interface IGeometry {
+  spatialReference?: ISpatialReference;
 }
 
 /**
  * An envelope is a rectangle defined by a range of values for each coordinate and attribute.
  */
-export interface Envelope extends Geometry {
+export interface IEnvelope extends IGeometry {
   xmin: number;
   xmax: number;
   ymin: number;
@@ -92,22 +92,33 @@ export type esriGeometryType =
   | "esriGeometryEnvelope";
 
 /**
- *
+ * Extents are used to define rectangles and bounding boxes.
  */
-export interface FeatureSet extends HasZM {
-  objectIdFieldName?: string; // optional
-  globalIdFieldName?: string; // optional
-  displayFieldName?: string; // optional
-  geometryType?: esriGeometryType; // for feature layers only
-  spatialReference?: SpatialReference; // for feature layers only.
-  fields?: Field[];
-  features: Feature[];
+export interface IExtent {
+  xmin: number;
+  ymin: number;
+  xmax: number;
+  ymax: number;
+  spatialReference?: ISpatialReference;
 }
 
 /**
  *
  */
-export interface Font {
+export interface IFeatureSet extends IHasZM {
+  objectIdFieldName?: string; // optional
+  globalIdFieldName?: string; // optional
+  displayFieldName?: string; // optional
+  geometryType?: esriGeometryType; // for feature layers only
+  spatialReference?: ISpatialReference; // for feature layers only.
+  fields?: IField[];
+  features: IFeature[];
+}
+
+/**
+ *
+ */
+export interface IFont {
   family?: string; // "<fontFamily>";
   size?: number; // <fontSize>;
   style?: "italic" | "normal" | "oblique";
@@ -116,20 +127,9 @@ export interface Font {
 }
 
 /**
- * Extents are used to define rectangles and bounding boxes.
- */
-export interface Extent {
-  xmin: number;
-  ymin: number;
-  xmax: number;
-  ymax: number;
-  spatialReference?: SpatialReference;
-}
-
-/**
  *
  */
-export interface HasZM {
+export interface IHasZM {
   hasZ?: boolean;
   hasM?: boolean;
 }
@@ -137,7 +137,7 @@ export interface HasZM {
 /**
  * Portal Item
  */
-export interface Item {
+export interface IItem {
   id?: string;
   owner: string;
   title: string;
@@ -159,12 +159,12 @@ export interface Item {
 /**
  *
  */
-export type JsonCurve = CircularArc | Arc | OldCircularArc | BezierCurve;
+export type JsonCurve = ICircularArc | IArc | IOldCircularArc | IBezierCurve;
 
 /**
  *
  */
-export interface OldCircularArc {
+export interface IOldCircularArc {
   a: [
     Position, // End point: x, y, <z>, <m>
     Position2D, // Center point: center_x, center_y
@@ -176,7 +176,7 @@ export interface OldCircularArc {
 /**
  *
  */
-export interface MarkerSymbol extends Symbol {
+export interface IMarkerSymbol extends ISymbol {
   angle?: number;
   xoffset?: number;
   yoffset?: number;
@@ -185,14 +185,14 @@ export interface MarkerSymbol extends Symbol {
 /**
  * A multipoint contains an array of points.
  */
-export interface Multipoint extends HasZM, Geometry {
+export interface IMultipoint extends IHasZM, IGeometry {
   points: Position[];
 }
 
 /**
  * Params for paging operations
  */
-export interface PagingParams {
+export interface IPagingParams {
   start?: number;
   num?: number;
 }
@@ -200,9 +200,9 @@ export interface PagingParams {
 /**
  *
  */
-export interface PictureFillSymbol extends Symbol, PictureSourced {
+export interface IPictureFillSymbol extends ISymbol, IPictureSourced {
   type: "esriPFS";
-  outline?: SimpleLineSymbol; // if outline has been specified
+  outline?: ISimpleLineSymbol; // if outline has been specified
   xscale?: number;
   yscale?: number;
 }
@@ -210,14 +210,14 @@ export interface PictureFillSymbol extends Symbol, PictureSourced {
 /**
  *
  */
-export interface PictureMarkerSymbol extends MarkerSymbol, PictureSourced {
+export interface IPictureMarkerSymbol extends IMarkerSymbol, IPictureSourced {
   type: "esriPMS";
 }
 
 /**
  *
  */
-export interface PictureSourced {
+export interface IPictureSourced {
   url?: string; // Relative URL for static layers and full URL for dynamic layers. Access relative URL using http://<mapservice-url>/<layerId1>/images/<imageUrl11>
   imageData?: string; // "<base64EncodedImageData>";
   contentType?: string;
@@ -231,7 +231,7 @@ export interface PictureSourced {
 /**
  * A simple point geometry, with spatial reference defined.
  */
-export interface Point extends HasZM, Geometry {
+export interface IPoint extends IHasZM, IGeometry {
   x: number;
   y: number;
 }
@@ -239,28 +239,28 @@ export interface Point extends HasZM, Geometry {
 /**
  *
  */
-export interface Polyline extends HasZM, Geometry {
+export interface IPolyline extends IHasZM, IGeometry {
   paths: Position[][];
 }
 
 /**
  *
  */
-export interface PolylineWithCurves extends HasZM, Geometry {
+export interface IPolylineWithCurves extends IHasZM, IGeometry {
   curvePaths: Array<Array<Position | JsonCurve>>;
 }
 
 /**
  *
  */
-export interface Polygon extends HasZM, Geometry {
+export interface IPolygon extends IHasZM, IGeometry {
   rings: Position[][];
 }
 
 /**
  *
  */
-export interface PolygonWithCurves extends HasZM, Geometry {
+export interface IPolygonWithCurves extends IHasZM, IGeometry {
   curveRings: Array<Array<Position | JsonCurve>>;
 }
 
@@ -326,17 +326,17 @@ export type SymbolType =
 /**
  *
  */
-export interface SimpleFillSymbol extends Symbol {
+export interface ISimpleFillSymbol extends ISymbol {
   type: "esriSFS";
   style?: SimpleFillSymbolStyle;
   color?: Color;
-  outline?: SimpleLineSymbol; // if outline has been specified
+  outline?: ISimpleLineSymbol; // if outline has been specified
 }
 
 /**
  *
  */
-export interface SimpleLineSymbol extends Symbol {
+export interface ISimpleLineSymbol extends ISymbol {
   type: "esriSLS";
   style?: SimpleLineSymbolStyle;
   color?: Color;
@@ -346,28 +346,22 @@ export interface SimpleLineSymbol extends Symbol {
 /**
  *
  */
-export interface SimpleMarkerSymbol extends MarkerSymbol {
+export interface ISimpleMarkerSymbol extends IMarkerSymbol {
   type: "esriSMS";
   style?: SimpleMarkerSymbolStyle;
   color?: Color;
   size?: number;
-  outline?: SimpleLineSymbol;
+  outline?: ISimpleLineSymbol;
 }
 
 /**
  * Spatial reference systems define mathematical transformations and coordinate systems for displaying spatial information in 2D and 3D.
  */
-export interface SpatialReferenceWkid {
-  wkid: number;
+export interface ISpatialReference {
+  wkid?: number;
   latestWkid?: number;
   vcsWkid?: number;
   latestVcsWkid?: number;
-}
-
-/**
- *
- */
-export interface SpatialReferenceWkt {
   wkt?: string;
   latestWkt?: string;
 }
@@ -375,12 +369,7 @@ export interface SpatialReferenceWkt {
 /**
  *
  */
-export type SpatialReference = SpatialReferenceWkt | SpatialReferenceWkid;
-
-/**
- *
- */
-export interface Symbol {
+export interface ISymbol {
   type: SymbolType;
   style?: string;
 }
@@ -388,7 +377,7 @@ export interface Symbol {
 /**
  *
  */
-export interface TextSymbol extends MarkerSymbol {
+export interface ITextSymbol extends IMarkerSymbol {
   type: "esriTS";
   color?: Color;
   backgroundColor?: Color;
@@ -400,6 +389,6 @@ export interface TextSymbol extends MarkerSymbol {
   horizontalAlignment?: "left" | "right" | "center" | "justify";
   rightToLeft?: boolean;
   kerning?: boolean;
-  font?: Font;
+  font?: IFont;
   text?: string; // only applicable when specified as a client-side graphic.
 }

--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -2,45 +2,142 @@
  * Apache-2.0 */
 
 /**
- * Spatial reference systems define mathematical transformations and coordinate systems for displaying spatial information in 2D and 3D.
+ * an arc can be represented as a JSON curve object
  */
-export interface ISpatialReference {
-  wkid: number;
-  latestWkid?: number;
+export interface Arc {
+  a: [
+    Position, // End point: x, y, <z>, <m>
+    Position2D, // Center point: center_x, center_y
+    number, // minor
+    number, // clockwise
+    number, // rotation
+    number, // axis
+    number // ratio
+  ];
+}
+
+/**
+ * a bezier curve can be represented as a JSON curve object
+ */
+export interface BezierCurve {
+  b: [Position, Position2D, Position2D];
+}
+
+/**
+ * a circular arc can be represented as a JSON curve object
+ */
+export interface CircularArc {
+  c: [Position, Position2D];
+}
+
+/**
+ *
+ */
+export type Color = [number, number, number, number];
+
+/**
+ *
+ */
+export type ElipticArc = Arc;
+
+/**
+ * a spatial entity and its corresponding properties
+ */
+export interface Feature {
+  geometry?: Geometry;
+  attributes?: any;
+}
+
+/**
+ *
+ */
+export interface Field {
+  name: string;
+  type: string;
+  alias?: string;
+  length?: number;
+}
+
+/**
+ * a building block for discrete geometries
+ */
+export interface Geometry {
+  spatialReference?: SpatialReference;
+}
+
+/**
+ * An envelope is a rectangle defined by a range of values for each coordinate and attribute.
+ */
+export interface Envelope extends Geometry {
+  xmin: number;
+  xmax: number;
+  ymin: number;
+  ymax: number;
+
+  zmin?: number;
+  zmax?: number;
+
+  mmin?: number;
+  mmax?: number;
+}
+
+/**
+ *
+ */
+export type esriGeometryType =
+  | "esriGeometryPoint"
+  | "esriGeometryMultipoint"
+  | "esriGeometryPolyline"
+  | "esriGeometryPolygon"
+  | "esriGeometryEnvelope";
+
+/**
+ *
+ */
+export interface FeatureSet extends HasZM {
+  objectIdFieldName?: string; // optional
+  globalIdFieldName?: string; // optional
+  displayFieldName?: string; // optional
+  geometryType?: esriGeometryType; // for feature layers only
+  spatialReference?: SpatialReference; // for feature layers only.
+  fields?: Field[];
+  features: Feature[];
+}
+
+/**
+ *
+ */
+export interface Font {
+  family?: string; // "<fontFamily>";
+  size?: number; // <fontSize>;
+  style?: "italic" | "normal" | "oblique";
+  weight?: "bold" | "bolder" | "lighter" | "normal";
+  decoration?: "line-through" | "underline" | "none";
 }
 
 /**
  * Extents are used to define rectangles and bounding boxes.
  */
-export interface IExtent {
+export interface Extent {
   xmin: number;
   ymin: number;
   xmax: number;
   ymax: number;
-  spatialReference?: ISpatialReference;
+  spatialReference?: SpatialReference;
 }
 
 /**
- * A simple point geometry, with spatial reference defined.
+ *
  */
-export interface IPoint {
-  x: number;
-  y: number;
-  spatialReference?: ISpatialReference;
-}
-
-/**
- * Params for paging operations
- */
-export interface IPagingParams {
-  start?: number;
-  num?: number;
+export interface HasZM {
+  hasZ?: boolean;
+  hasM?: boolean;
 }
 
 /**
  * Portal Item
  */
-export interface IItem {
+export interface Item {
   id?: string;
   owner: string;
   title: string;
@@ -57,4 +154,252 @@ export interface IItem {
   properties?: any;
   url?: string;
   [key: string]: any;
+}
+
+/**
+ *
+ */
+export type JsonCurve = CircularArc | Arc | OldCircularArc | BezierCurve;
+
+/**
+ *
+ */
+export interface OldCircularArc {
+  a: [
+    Position, // End point: x, y, <z>, <m>
+    Position2D, // Center point: center_x, center_y
+    number, // minor
+    number // clockwise
+  ];
+}
+
+/**
+ *
+ */
+export interface MarkerSymbol extends Symbol {
+  angle?: number;
+  xoffset?: number;
+  yoffset?: number;
+}
+
+/**
+ * A multipoint contains an array of points.
+ */
+export interface Multipoint extends HasZM, Geometry {
+  points: Position[];
+}
+
+/**
+ * Params for paging operations
+ */
+export interface PagingParams {
+  start?: number;
+  num?: number;
+}
+
+/**
+ *
+ */
+export interface PictureFillSymbol extends Symbol, PictureSourced {
+  type: "esriPFS";
+  outline?: SimpleLineSymbol; // if outline has been specified
+  xscale?: number;
+  yscale?: number;
+}
+
+/**
+ *
+ */
+export interface PictureMarkerSymbol extends MarkerSymbol, PictureSourced {
+  type: "esriPMS";
+}
+
+/**
+ *
+ */
+export interface PictureSourced {
+  url?: string; // Relative URL for static layers and full URL for dynamic layers. Access relative URL using http://<mapservice-url>/<layerId1>/images/<imageUrl11>
+  imageData?: string; // "<base64EncodedImageData>";
+  contentType?: string;
+  width?: number;
+  height?: number;
+  angle?: number;
+  xoffset?: number;
+  yoffset?: number;
+}
+
+/**
+ * A simple point geometry, with spatial reference defined.
+ */
+export interface Point extends HasZM, Geometry {
+  x: number;
+  y: number;
+}
+
+/**
+ *
+ */
+export interface Polyline extends HasZM, Geometry {
+  paths: Position[][];
+}
+
+/**
+ *
+ */
+export interface PolylineWithCurves extends HasZM, Geometry {
+  curvePaths: Array<Array<Position | JsonCurve>>;
+}
+
+/**
+ *
+ */
+export interface Polygon extends HasZM, Geometry {
+  rings: Position[][];
+}
+
+/**
+ *
+ */
+export interface PolygonWithCurves extends HasZM, Geometry {
+  curveRings: Array<Array<Position | JsonCurve>>;
+}
+
+/**
+ *
+ */
+export type Position =
+  | Position2D
+  | [number, number, number]
+  | [number, number, number, number];
+
+/**
+ *
+ */
+export type Position2D = [number, number];
+
+/**
+ *
+ */
+export type SimpleMarkerSymbolStyle =
+  | "esriSMSCircle"
+  | "esriSMSCross"
+  | "esriSMSDiamond"
+  | "esriSMSSquare"
+  | "esriSMSX"
+  | "esriSMSTriangle";
+
+/**
+ *
+ */
+export type SimpleLineSymbolStyle =
+  | "esriSLSDash"
+  | "esriSLSDashDot"
+  | "esriSLSDashDotDot"
+  | "esriSLSDot"
+  | "esriSLSNull"
+  | "esriSLSSolid";
+
+/**
+ *
+ */
+export type SimpleFillSymbolStyle =
+  | "esriSFSBackwardDiagonal"
+  | "esriSFSCross"
+  | "esriSFSDiagonalCross"
+  | "esriSFSForwardDiagonal"
+  | "esriSFSHorizontal"
+  | "esriSFSNull"
+  | "esriSFSSolid"
+  | "esriSFSVertical";
+
+/**
+ *
+ */
+export type SymbolType =
+  | "esriSLS"
+  | "esriSMS"
+  | "esriSFS"
+  | "esriPMS"
+  | "esriPFS"
+  | "esriTS";
+
+/**
+ *
+ */
+export interface SimpleFillSymbol extends Symbol {
+  type: "esriSFS";
+  style?: SimpleFillSymbolStyle;
+  color?: Color;
+  outline?: SimpleLineSymbol; // if outline has been specified
+}
+
+/**
+ *
+ */
+export interface SimpleLineSymbol extends Symbol {
+  type: "esriSLS";
+  style?: SimpleLineSymbolStyle;
+  color?: Color;
+  width?: number;
+}
+
+/**
+ *
+ */
+export interface SimpleMarkerSymbol extends MarkerSymbol {
+  type: "esriSMS";
+  style?: SimpleMarkerSymbolStyle;
+  color?: Color;
+  size?: number;
+  outline?: SimpleLineSymbol;
+}
+
+/**
+ * Spatial reference systems define mathematical transformations and coordinate systems for displaying spatial information in 2D and 3D.
+ */
+export interface SpatialReferenceWkid {
+  wkid: number;
+  latestWkid?: number;
+  vcsWkid?: number;
+  latestVcsWkid?: number;
+}
+
+/**
+ *
+ */
+export interface SpatialReferenceWkt {
+  wkt?: string;
+  latestWkt?: string;
+}
+
+/**
+ *
+ */
+export type SpatialReference = SpatialReferenceWkt | SpatialReferenceWkid;
+
+/**
+ *
+ */
+export interface Symbol {
+  type: SymbolType;
+  style?: string;
+}
+
+/**
+ *
+ */
+export interface TextSymbol extends MarkerSymbol {
+  type: "esriTS";
+  color?: Color;
+  backgroundColor?: Color;
+  borderLineSize?: number; // <size>;
+  borderLineColor?: Color;
+  haloSize?: number; // <size>;
+  haloColor?: Color;
+  verticalAlignment?: "baseline" | "top" | "middle" | "bottom";
+  horizontalAlignment?: "left" | "right" | "center" | "justify";
+  rightToLeft?: boolean;
+  kerning?: boolean;
+  font?: Font;
+  text?: string; // only applicable when specified as a client-side graphic.
 }

--- a/packages/arcgis-rest-geocoder/src/geocoder.ts
+++ b/packages/arcgis-rest-geocoder/src/geocoder.ts
@@ -5,9 +5,9 @@ import { request, IRequestOptions, IParams } from "@esri/arcgis-rest-request";
 import { IAuthenticatedRequestOptions } from "@esri/arcgis-rest-auth";
 
 import {
-  Extent,
-  SpatialReferenceWkid,
-  Point
+  IExtent,
+  ISpatialReference,
+  IPoint
 } from "@esri/arcgis-rest-common-types";
 
 // https always
@@ -35,7 +35,7 @@ export interface IAddressBulk {
   countryCode?: string;
 }
 
-export interface Location {
+export interface ILocation {
   latitude?: number;
   longitude?: number;
   lat?: number;
@@ -43,17 +43,17 @@ export interface Location {
 }
 
 function isLocationArray(
-  coords: Location | Point | [number, number]
+  coords: ILocation | IPoint | [number, number]
 ): coords is [number, number] {
   return (coords as [number, number]).length === 2;
 }
 
 function isLocation(
-  coords: Location | Point | [number, number]
-): coords is Location {
+  coords: ILocation | IPoint | [number, number]
+): coords is ILocation {
   return (
-    (coords as Location).latitude !== undefined ||
-    (coords as Location).lat !== undefined
+    (coords as ILocation).latitude !== undefined ||
+    (coords as ILocation).lat !== undefined
   );
 }
 
@@ -116,11 +116,11 @@ export interface IBulkGeocodeRequestOptions extends IEndpointRequestOptions {
 }
 
 export interface IGeocodeResponse {
-  spatialReference: SpatialReferenceWkid;
+  spatialReference: ISpatialReference;
   candidates: Array<{
     address: string;
-    location: Point;
-    extent: Extent;
+    location: IPoint;
+    extent: IExtent;
     attributes: object;
   }>;
 }
@@ -129,7 +129,7 @@ export interface IReverseGeocodeResponse {
   address: {
     [key: string]: any;
   };
-  location: Point;
+  location: IPoint;
 }
 
 export interface ISuggestResponse {
@@ -141,10 +141,10 @@ export interface ISuggestResponse {
 }
 
 export interface IBulkGeocodeResponse {
-  spatialReference: SpatialReferenceWkid;
+  spatialReference: ISpatialReference;
   locations: Array<{
     address: string;
-    location: Point;
+    location: IPoint;
     score: number;
     attributes: object;
   }>;
@@ -205,8 +205,8 @@ export function geocode(
     response => {
       const sr = response.spatialReference;
       response.candidates.forEach(function(candidate: {
-        location: Point;
-        extent: Extent;
+        location: IPoint;
+        extent: IExtent;
       }) {
         candidate.location.spatialReference = sr;
         candidate.extent.spatialReference = sr;
@@ -279,7 +279,7 @@ export function suggest(
  * @returns A Promise that will resolve with the data from the response.
  */
 export function reverseGeocode(
-  coords: Point | Location | [number, number],
+  coords: IPoint | ILocation | [number, number],
   requestOptions?: IEndpointRequestOptions
 ): Promise<IReverseGeocodeResponse> {
   const options: IGeocodeRequestOptions = {
@@ -356,7 +356,7 @@ export function bulkGeocode(
   return request(options.endpoint + "geocodeAddresses", requestOptions).then(
     response => {
       const sr = response.spatialReference;
-      response.locations.forEach(function(address: { location: Point }) {
+      response.locations.forEach(function(address: { location: IPoint }) {
         address.location.spatialReference = sr;
       });
       return response;

--- a/packages/arcgis-rest-geocoder/src/geocoder.ts
+++ b/packages/arcgis-rest-geocoder/src/geocoder.ts
@@ -2,7 +2,7 @@
  * Apache-2.0 */
 
 import { request, IRequestOptions, IParams } from "@esri/arcgis-rest-request";
-import { IAuthenticatedRequestOptions } from "@esri/arcgis-rest-auth";
+// import { IAuthenticatedRequestOptions } from "@esri/arcgis-rest-auth";
 
 import {
   IExtent,

--- a/packages/arcgis-rest-groups/src/groups.ts
+++ b/packages/arcgis-rest-groups/src/groups.ts
@@ -7,10 +7,10 @@ import {
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 
-import { PagingParams, Item } from "@esri/arcgis-rest-common-types";
+import { IPagingParams, IItem } from "@esri/arcgis-rest-common-types";
 
 export interface IPagingParamsRequestOptions extends IRequestOptions {
-  paging: PagingParams;
+  paging: IPagingParams;
 }
 
 export interface IGroupIdRequestOptions extends IRequestOptions {
@@ -32,7 +32,7 @@ export interface IGroupRequestOptions extends IRequestOptions {
   group: IGroup;
 }
 
-export interface IGroupSearchRequest extends PagingParams {
+export interface IGroupSearchRequest extends IPagingParams {
   q: string;
   sortField?: string;
   sortOrder?: string;
@@ -56,7 +56,7 @@ export interface IGroupContentResult {
   start: number;
   num: number;
   nextStart: number;
-  items: Item[];
+  items: IItem[];
 }
 
 export interface IGroupUsersResult {

--- a/packages/arcgis-rest-groups/src/groups.ts
+++ b/packages/arcgis-rest-groups/src/groups.ts
@@ -3,7 +3,7 @@
 import {
   request,
   IRequestOptions,
-  IParams,
+  // IParams,
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 

--- a/packages/arcgis-rest-groups/src/groups.ts
+++ b/packages/arcgis-rest-groups/src/groups.ts
@@ -7,10 +7,10 @@ import {
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 
-import { IPagingParams, IItem } from "@esri/arcgis-rest-common-types";
+import { PagingParams, Item } from "@esri/arcgis-rest-common-types";
 
 export interface IPagingParamsRequestOptions extends IRequestOptions {
-  paging: IPagingParams;
+  paging: PagingParams;
 }
 
 export interface IGroupIdRequestOptions extends IRequestOptions {
@@ -32,7 +32,7 @@ export interface IGroupRequestOptions extends IRequestOptions {
   group: IGroup;
 }
 
-export interface IGroupSearchRequest extends IPagingParams {
+export interface IGroupSearchRequest extends PagingParams {
   q: string;
   sortField?: string;
   sortOrder?: string;
@@ -56,7 +56,7 @@ export interface IGroupContentResult {
   start: number;
   num: number;
   nextStart: number;
-  items: IItem[];
+  items: Item[];
 }
 
 export interface IGroupUsersResult {
@@ -210,8 +210,9 @@ export function createGroup(
 export function updateGroup(
   requestOptions: IGroupRequestOptions
 ): Promise<any> {
-  const url = `${getPortalUrl(requestOptions)}/community/groups/${requestOptions
-    .group.id}/update`;
+  const url = `${getPortalUrl(requestOptions)}/community/groups/${
+    requestOptions.group.id
+  }/update`;
   // default to a POST request
   const options: IGroupRequestOptions = {
     ...{ httpMethod: "POST" },
@@ -230,9 +231,9 @@ export function updateGroup(
 export function removeGroup(
   requestOptions: IGroupIdRequestOptions
 ): Promise<any> {
-  const url = `${getPortalUrl(
-    requestOptions
-  )}/community/groups/${requestOptions.id}/delete`;
+  const url = `${getPortalUrl(requestOptions)}/community/groups/${
+    requestOptions.id
+  }/delete`;
   // default to a POST request
   const options: IGroupIdRequestOptions = {
     ...{ httpMethod: "POST" },
@@ -249,9 +250,9 @@ export function removeGroup(
 export function protectGroup(
   requestOptions: IGroupIdRequestOptions
 ): Promise<any> {
-  const url = `${getPortalUrl(
-    requestOptions
-  )}/community/groups/${requestOptions.id}/protect`;
+  const url = `${getPortalUrl(requestOptions)}/community/groups/${
+    requestOptions.id
+  }/protect`;
   // default to a POST request
   const options: IGroupIdRequestOptions = {
     ...{ httpMethod: "POST" },
@@ -268,9 +269,9 @@ export function protectGroup(
 export function unprotectGroup(
   requestOptions: IGroupIdRequestOptions
 ): Promise<any> {
-  const url = `${getPortalUrl(
-    requestOptions
-  )}/community/groups/${requestOptions.id}/unprotect`;
+  const url = `${getPortalUrl(requestOptions)}/community/groups/${
+    requestOptions.id
+  }/unprotect`;
   // default to a POST request
   const options: IGroupIdRequestOptions = {
     ...{ httpMethod: "POST" },

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -7,12 +7,12 @@ import {
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 
-import { Extent, Item, PagingParams } from "@esri/arcgis-rest-common-types";
+import { IExtent, IItem, IPagingParams } from "@esri/arcgis-rest-common-types";
 
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 export interface IItemRequestOptions extends IUserRequestOptions {
-  item: Item;
+  item: IItem;
 }
 
 // * @param id - Item Id
@@ -54,7 +54,7 @@ export interface IItemResourceRequestOptions extends IItemIdRequestOptions {
 }
 
 export interface IItemCrudRequestOptions extends IUserRequestOptions {
-  item: Item;
+  item: IItem;
   /**
    * Item owner username (by default authentication session will be used).
    */
@@ -66,7 +66,7 @@ export interface IItemCrudRequestOptions extends IUserRequestOptions {
 }
 
 // this interface still needs to be docced
-export interface ISearchRequest extends PagingParams {
+export interface ISearchRequest extends IPagingParams {
   q: string;
   [key: string]: any;
   // start: number;
@@ -86,7 +86,7 @@ export interface ISearchResult {
   start: number;
   num: number;
   nextStart: number;
-  results: Item[];
+  results: IItem[];
 }
 
 /**
@@ -199,7 +199,7 @@ export function addItemJsonData(
 export function getItem(
   id: string,
   requestOptions?: IRequestOptions
-): Promise<Item> {
+): Promise<IItem> {
   const url = `${getPortalUrl(requestOptions)}/content/items/${id}`;
 
   // default to a GET request
@@ -363,7 +363,7 @@ export function removeItemResource(
  * @param item IItem to be serialized
  * @returns a formatted json object to be sent to Portal
  */
-function serializeItem(item: Item): any {
+function serializeItem(item: IItem): any {
   // create a clone so we're not messing with the original
   const clone = JSON.parse(JSON.stringify(item));
   // join keywords and tags...

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -7,12 +7,12 @@ import {
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 
-import { IExtent, IItem, IPagingParams } from "@esri/arcgis-rest-common-types";
+import { Extent, Item, PagingParams } from "@esri/arcgis-rest-common-types";
 
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 export interface IItemRequestOptions extends IUserRequestOptions {
-  item: IItem;
+  item: Item;
 }
 
 // * @param id - Item Id
@@ -54,7 +54,7 @@ export interface IItemResourceRequestOptions extends IItemIdRequestOptions {
 }
 
 export interface IItemCrudRequestOptions extends IUserRequestOptions {
-  item: IItem;
+  item: Item;
   /**
    * Item owner username (by default authentication session will be used).
    */
@@ -66,7 +66,7 @@ export interface IItemCrudRequestOptions extends IUserRequestOptions {
 }
 
 // this interface still needs to be docced
-export interface ISearchRequest extends IPagingParams {
+export interface ISearchRequest extends PagingParams {
   q: string;
   [key: string]: any;
   // start: number;
@@ -86,7 +86,7 @@ export interface ISearchResult {
   start: number;
   num: number;
   nextStart: number;
-  results: IItem[];
+  results: Item[];
 }
 
 /**
@@ -176,9 +176,9 @@ export function addItemJsonData(
 ): Promise<any> {
   const owner = requestOptions.owner || requestOptions.authentication.username;
 
-  const url = `${getPortalUrl(
-    requestOptions
-  )}/content/users/${owner}/items/${requestOptions.id}/update`;
+  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
+    requestOptions.id
+  }/update`;
 
   // Portal API requires that the 'data' be stringified and POSTed in
   // a `text` form field. It can also be sent with the `.create` call by sending
@@ -199,7 +199,7 @@ export function addItemJsonData(
 export function getItem(
   id: string,
   requestOptions?: IRequestOptions
-): Promise<IItem> {
+): Promise<Item> {
   const url = `${getPortalUrl(requestOptions)}/content/items/${id}`;
 
   // default to a GET request
@@ -240,8 +240,9 @@ export function getItemData(
  * @returns A Promise that resolves with the status of the operation.
  */
 export function updateItem(requestOptions: IItemRequestOptions): Promise<any> {
-  const url = `${getPortalUrl(requestOptions)}/content/users/${requestOptions
-    .item.owner}/items/${requestOptions.item.id}/update`;
+  const url = `${getPortalUrl(requestOptions)}/content/users/${
+    requestOptions.item.owner
+  }/items/${requestOptions.item.id}/update`;
 
   // serialize the item into something Portal will accept
   requestOptions.params = serializeItem(requestOptions.item);
@@ -259,9 +260,9 @@ export function removeItem(
   requestOptions: IItemIdRequestOptions
 ): Promise<any> {
   const owner = requestOptions.owner || requestOptions.authentication.username;
-  const url = `${getPortalUrl(
-    requestOptions
-  )}/content/users/${owner}/items/${requestOptions.id}/delete`;
+  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
+    requestOptions.id
+  }/delete`;
   return request(url, requestOptions);
 }
 
@@ -275,9 +276,9 @@ export function protectItem(
   requestOptions: IItemIdRequestOptions
 ): Promise<any> {
   const owner = requestOptions.owner || requestOptions.authentication.username;
-  const url = `${getPortalUrl(
-    requestOptions
-  )}/content/users/${owner}/items/${requestOptions.id}/protect`;
+  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
+    requestOptions.id
+  }/protect`;
   return request(url, requestOptions);
 }
 
@@ -291,9 +292,9 @@ export function unprotectItem(
   requestOptions: IItemIdRequestOptions
 ): Promise<any> {
   const owner = requestOptions.owner || requestOptions.authentication.username;
-  const url = `${getPortalUrl(
-    requestOptions
-  )}/content/users/${owner}/items/${requestOptions.id}/unprotect`;
+  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
+    requestOptions.id
+  }/unprotect`;
   return request(url, requestOptions);
 }
 
@@ -306,9 +307,9 @@ export function unprotectItem(
 export function getItemResources(
   requestOptions: IItemIdRequestOptions
 ): Promise<any> {
-  const url = `${getPortalUrl(
-    requestOptions
-  )}/content/items/${requestOptions.id}/resources`;
+  const url = `${getPortalUrl(requestOptions)}/content/items/${
+    requestOptions.id
+  }/resources`;
 
   requestOptions.params = { num: 1000 };
 
@@ -325,9 +326,9 @@ export function updateItemResource(
   requestOptions: IItemResourceRequestOptions
 ): Promise<any> {
   const owner = requestOptions.owner || requestOptions.authentication.username;
-  const url = `${getPortalUrl(
-    requestOptions
-  )}/content/users/${owner}/items/${requestOptions.id}/updateResources`;
+  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
+    requestOptions.id
+  }/updateResources`;
 
   requestOptions.params = {
     fileName: requestOptions.content,
@@ -347,9 +348,9 @@ export function removeItemResource(
   requestOptions: IItemResourceRequestOptions
 ): Promise<any> {
   const owner = requestOptions.owner || requestOptions.authentication.username;
-  const url = `${getPortalUrl(
-    requestOptions
-  )}/content/users/${owner}/items/${requestOptions.id}/removeResources`;
+  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
+    requestOptions.id
+  }/removeResources`;
 
   requestOptions.params = { resource: requestOptions.resource };
   return request(url, requestOptions);
@@ -362,7 +363,7 @@ export function removeItemResource(
  * @param item IItem to be serialized
  * @returns a formatted json object to be sent to Portal
  */
-function serializeItem(item: IItem): any {
+function serializeItem(item: Item): any {
   // create a clone so we're not messing with the original
   const clone = JSON.parse(JSON.stringify(item));
   // join keywords and tags...

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -3,11 +3,10 @@
 import {
   request,
   IRequestOptions,
-  IParams,
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 
-import { IExtent, IItem, IPagingParams } from "@esri/arcgis-rest-common-types";
+import { IItem, IPagingParams } from "@esri/arcgis-rest-common-types";
 
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 

--- a/packages/arcgis-rest-items/test/items.test.ts
+++ b/packages/arcgis-rest-items/test/items.test.ts
@@ -31,8 +31,8 @@ import {
   RemoveItemResourceResponse
 } from "./mocks/resources";
 
-import { UserSession, IFetchTokenResponse } from "@esri/arcgis-rest-auth";
-import { TOMORROW, YESTERDAY } from "@esri/arcgis-rest-auth/test/utils";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { TOMORROW } from "@esri/arcgis-rest-auth/test/utils";
 import { encodeParam } from "@esri/arcgis-rest-request";
 
 describe("search", () => {

--- a/packages/arcgis-rest-items/test/mocks/item.ts
+++ b/packages/arcgis-rest-items/test/mocks/item.ts
@@ -1,11 +1,11 @@
-import { Item } from "@esri/arcgis-rest-common-types";
+import { IItem } from "@esri/arcgis-rest-common-types";
 
 export const ItemSuccessResponse: any = {
   success: true,
   id: "3efakeitemid0000"
 };
 
-export const ItemResponse: Item = {
+export const ItemResponse: IItem = {
   id: "4bc",
   owner: "jeffvader",
   title: "DS Plans",

--- a/packages/arcgis-rest-items/test/mocks/item.ts
+++ b/packages/arcgis-rest-items/test/mocks/item.ts
@@ -1,11 +1,11 @@
-import { IItem } from "@esri/arcgis-rest-common-types";
+import { Item } from "@esri/arcgis-rest-common-types";
 
 export const ItemSuccessResponse: any = {
   success: true,
   id: "3efakeitemid0000"
 };
 
-export const ItemResponse: IItem = {
+export const ItemResponse: Item = {
   id: "4bc",
   owner: "jeffvader",
   title: "DS Plans",

--- a/packages/arcgis-rest-items/test/mocks/search.ts
+++ b/packages/arcgis-rest-items/test/mocks/search.ts
@@ -1,5 +1,5 @@
 import { ISearchResult } from "../../src/items";
-import { Item } from "@esri/arcgis-rest-common-types";
+import { IItem } from "@esri/arcgis-rest-common-types";
 
 export const SearchResponse: ISearchResult = {
   query: "",

--- a/packages/arcgis-rest-items/test/mocks/search.ts
+++ b/packages/arcgis-rest-items/test/mocks/search.ts
@@ -1,5 +1,4 @@
 import { ISearchResult } from "../../src/items";
-import { IItem } from "@esri/arcgis-rest-common-types";
 
 export const SearchResponse: ISearchResult = {
   query: "",

--- a/packages/arcgis-rest-items/test/mocks/search.ts
+++ b/packages/arcgis-rest-items/test/mocks/search.ts
@@ -1,5 +1,5 @@
 import { ISearchResult } from "../../src/items";
-import { IItem } from "@esri/arcgis-rest-common-types";
+import { Item } from "@esri/arcgis-rest-common-types";
 
 export const SearchResponse: ISearchResult = {
   query: "",

--- a/packages/arcgis-rest-request/src/utils/ArcGISAuthError.ts
+++ b/packages/arcgis-rest-request/src/utils/ArcGISAuthError.ts
@@ -1,12 +1,7 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import {
-  request,
-  IRequestOptions,
-  IParams,
-  IAuthenticationManager
-} from "../request";
+import { request, IRequestOptions, IAuthenticationManager } from "../request";
 import { ArcGISRequestError } from "./ArcGISRequestError";
 
 export type IRetryAuthError = (

--- a/packages/arcgis-rest-request/src/utils/ArcGISRequestError.ts
+++ b/packages/arcgis-rest-request/src/utils/ArcGISRequestError.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IRequestOptions, IParams } from "../request";
+import { IRequestOptions } from "../request";
 
 // TypeScript 2.1 no longer allows you to extend built in types. See https://github.com/Microsoft/TypeScript/issues/12790#issuecomment-265981442
 // and https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work

--- a/packages/arcgis-rest-request/src/utils/get-portal.ts
+++ b/packages/arcgis-rest-request/src/utils/get-portal.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, IRequestOptions, IParams } from "../request";
+import { request, IRequestOptions } from "../request";
 
 import { getPortalUrl } from "./get-portal-url";
 

--- a/packages/arcgis-rest-request/test/utils/get-portal-url.test.ts
+++ b/packages/arcgis-rest-request/test/utils/get-portal-url.test.ts
@@ -1,4 +1,4 @@
-import { getPortalUrl, IRequestOptions } from "../../src/index";
+import { getPortalUrl } from "../../src/index";
 
 describe("getPortalUrl", () => {
   it("should default to arcgis.com", () => {

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,6 @@
     "ordered-imports": ["any"],
     "only-arrow-functions": [false],
     "object-literal-sort-keys": false,
-    "interface-name": [false, "always-prefix"]
+    "interface-name": [true, "always-prefix"]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,7 @@
     "strict-type-predicates": false,
     "ordered-imports": ["any"],
     "only-arrow-functions": [false],
-    "object-literal-sort-keys": false
+    "object-literal-sort-keys": false,
+    "interface-name": [false, "always-prefix"]
   }
 }


### PR DESCRIPTION
porting a whole load of interfaces and types originally written by @JeffJacobson :tada: 

AFFECTS PACKAGES:
@esri/arcgis-rest-common-types
@esri/arcgis-rest-geocoder
@esri/arcgis-rest-groups
@esri/arcgis-rest-items
batch-geocoder

BREAKING CHANGE:
no longer prefacing interface names with an `I`

maybe its just the ArcObjects phobia talking, but 5 minutes into this port i started to agree with [@tomwayson](https://github.com/Esri/arcgis-rest-js/issues/107#issuecomment-367217416). A quick look at the TypeScript Language [Specification](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#7.1) made it clear that its not a universally agreed upon convention.

i'm planning on tackling #104 soon so it makes sense to me to rip off the proverbial esri-loader band-aid here too and just release a `2.0.0` if everyone else agrees.

for now, the associated linter rule is turned [`off`](https://palantir.github.io/tslint/rules/interface-name/) because we're still using the `I` outside common-types.