### PR TITLE
let consumers specify GET w/ max URL length; if exceeded, use POST

### DIFF
--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -113,6 +113,30 @@ describe("request()", () => {
       });
   });
 
+  it("should switch from GET to POST when url is longer than specified", done => {
+    fetchMock.once("*", SharingRestInfo);
+    const restInfoUrl = "https://www.arcgis.com/sharing/rest/info";
+
+    request(restInfoUrl, {
+      httpMethod: "GET",
+      // typically consumers would base maxUrlLength on browser/server limits
+      // but for testing, we use an artificially low limit
+      // like this one that assumes no parameters will be added
+      maxUrlLength: restInfoUrl.length
+    })
+      .then(response => {
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual("https://www.arcgis.com/sharing/rest/info");
+        expect(options.method).toBe("POST");
+        expect(options.body).toContain("f=json");
+        expect(response).toEqual(SharingRestInfo);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
   it("should use the `authentication` option to authenticate a request", done => {
     fetchMock.once("*", WebMapAsText);
 


### PR DESCRIPTION
I think this is a pretty elegant solution to the debate we've been having in #66 if I do say so myself. I think we let the consumer specify the limit. Only if they pass `httpMethod: 'GET'` _and_ the new `maxUrlLength: charLimitForMyBrowserOrServer`, will it switch to 'POST' if the limit is exceeded. That gets us off the hook for maintaining a limit.

resolves #66 
