### PR TITLE
chore(npm packages): remove test files and tsconfig.json from npm tar…

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,3 +24,5 @@ Using TypeScript allows us to add type information to request params and respons
 TypeScript compiles to JavaScript so you can use @esri/arcgis-rest-js in any JavaScript project. However if you use TypeScript you will get the benefits of type checking for free.
 
 We also _really_ like TypeScript because it supports exporting to both [ES 2015 modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) (use `import`/`export`) and [UMD](http://davidbcalhoun.com/2014/what-is-amd-commonjs-and-umd/) modules. This allows us to support a wide variety of module loaders and bundlers, including Browserify, Webpack, RequireJS, and Dojo 1 and 2.
+
+We include [`tslib`](https://www.npmjs.com/package/tslib) as a dependency of individual npm packages to make usage of `_extends` and `_assign` in our compiled code more concise.

--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -8,10 +8,7 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
-  "files": [
-    "src/**",
-    "dist/**"
-  ],
+  "files": [ "dist/**" ],
   "dependencies": {
     "tslib": "^1.7.1"
   },

--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -8,6 +8,10 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
+  "files": [
+    "src/**",
+    "dist/**"
+  ],
   "dependencies": {
     "tslib": "^1.7.1"
   },

--- a/packages/arcgis-rest-common-types/package.json
+++ b/packages/arcgis-rest-common-types/package.json
@@ -5,6 +5,7 @@
   "types": "dist/types/index.d.ts",
   "author": "",
   "license": "Apache-2.0",
+  "files": [],
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:esm",

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -8,10 +8,7 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
-  "files": [
-    "src/**",
-    "dist/**"
-  ],
+  "files": [ "dist/**" ],
   "dependencies": {
     "tslib": "^1.7.1"
   },

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -8,6 +8,10 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
+  "files": [
+    "src/**",
+    "dist/**"
+  ],
   "dependencies": {
     "tslib": "^1.7.1"
   },

--- a/packages/arcgis-rest-geocoder/package.json
+++ b/packages/arcgis-rest-geocoder/package.json
@@ -8,10 +8,7 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
-  "files": [
-    "src/**",
-    "dist/**"
-  ],
+  "files": [ "dist/**" ],
   "dependencies": {
     "tslib": "^1.7.1"
   },

--- a/packages/arcgis-rest-geocoder/package.json
+++ b/packages/arcgis-rest-geocoder/package.json
@@ -8,6 +8,10 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
+  "files": [
+    "src/**",
+    "dist/**"
+  ],
   "dependencies": {
     "tslib": "^1.7.1"
   },

--- a/packages/arcgis-rest-groups/package.json
+++ b/packages/arcgis-rest-groups/package.json
@@ -8,10 +8,7 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
-  "files": [
-    "src/**",
-    "dist/**"
-  ],
+  "files": [ "dist/**" ],
   "dependencies": {
     "tslib": "^1.7.1"
   },

--- a/packages/arcgis-rest-groups/package.json
+++ b/packages/arcgis-rest-groups/package.json
@@ -8,6 +8,10 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
+  "files": [
+    "src/**",
+    "dist/**"
+  ],
   "dependencies": {
     "tslib": "^1.7.1"
   },

--- a/packages/arcgis-rest-items/package.json
+++ b/packages/arcgis-rest-items/package.json
@@ -8,10 +8,7 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
-  "files": [
-    "src/**",
-    "dist/**"
-  ],
+  "files": [ "dist/**" ],
   "dependencies": {
     "tslib": "^1.7.1"
   },

--- a/packages/arcgis-rest-items/package.json
+++ b/packages/arcgis-rest-items/package.json
@@ -8,6 +8,10 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
+  "files": [
+    "src/**",
+    "dist/**"
+  ],
   "dependencies": {
     "tslib": "^1.7.1"
   },

--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -11,6 +11,10 @@
   "dependencies": {
     "tslib": "^1.7.1"
   },
+  "files": [
+    "src/**",
+    "dist/**"
+  ],
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:umd && npm run build:esm",

--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -11,10 +11,7 @@
   "dependencies": {
     "tslib": "^1.7.1"
   },
-  "files": [
-    "src/**",
-    "dist/**"
-  ],
+  "files": [ "dist/**" ],
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:umd && npm run build:esm",


### PR DESCRIPTION
…balls

since we are distributing built types, UMDs, ES6 modules (with types) and common JS modules for node, it seems safe to remove the tsconfig.json entirely, especially since its incomplete.

there's no need to specify "README.md" or "package.json" or whatever is listed as "main". they are [_always_](https://docs.npmjs.com/files/package.json) included. this change drops the tests too to further shrink the bundles.

this will also solve problems like unintentionally shipping cruft like this:
https://unpkg.com/@esri/arcgis-rest-request@1.0.3/.rpt2_cache/

AFFECTS PACKAGES:
@esri/arcgis-rest-auth
@esri/arcgis-rest-common-types
@esri/arcgis-rest-feature-service
@esri/arcgis-rest-geocoder
@esri/arcgis-rest-groups
@esri/arcgis-rest-items
@esri/arcgis-rest-request

ISSUES CLOSED: #132