### PR TITLE
refactor(geocoder): use a more descriptive method to fetch metadata

### DIFF
--- a/packages/arcgis-rest-geocoder/src/geocoder.ts
+++ b/packages/arcgis-rest-geocoder/src/geocoder.ts
@@ -384,7 +384,7 @@ export function bulkGeocode(
  * @param requestOptions - Request options can contain a custom geocoding service to fetch metadata from.
  * @returns A Promise that will resolve with the data from the response.
  */
-export function getGeocodeService(
+export function geocodeService(
   requestOptions?: IEndpointRequestOptions
 ): Promise<IGeocodeServiceInfoResponse> {
   const url = (requestOptions && requestOptions.endpoint) || worldGeocoder;
@@ -399,7 +399,7 @@ export function getGeocodeService(
 }
 
 /**
- * Deprecated. Please use `getGeocoderServiceInfo()` instead.
+ * Deprecated. Please use `geocodeService()` instead.
  *
  * @param requestOptions - Request options can contain a custom geocoding service to fetch metadata from.
  * @returns A Promise that will resolve with the data from the response.
@@ -410,7 +410,7 @@ export function serviceInfo(
   warn(
     "serviceInfo() will be deprecated in the next major release. please use getGeocoderServiceInfo() instead."
   );
-  return getGeocodeService(requestOptions);
+  return geocodeService(requestOptions);
 }
 
 export default {

--- a/packages/arcgis-rest-geocoder/src/geocoder.ts
+++ b/packages/arcgis-rest-geocoder/src/geocoder.ts
@@ -384,11 +384,18 @@ export function bulkGeocode(
  * @param requestOptions - Request options can contain a custom geocoding service to fetch metadata from.
  * @returns A Promise that will resolve with the data from the response.
  */
-export function getGeocoderServiceInfo(
-  requestOptions?: IGeocodeRequestOptions
+export function getGeocodeService(
+  requestOptions?: IEndpointRequestOptions
 ): Promise<IGeocodeServiceInfoResponse> {
   const url = (requestOptions && requestOptions.endpoint) || worldGeocoder;
-  return request(url, requestOptions);
+
+  const options: IEndpointRequestOptions = {
+    httpMethod: "GET",
+    maxUrlLength: 2000,
+    ...requestOptions
+  };
+
+  return request(url, options);
 }
 
 /**
@@ -398,12 +405,12 @@ export function getGeocoderServiceInfo(
  * @returns A Promise that will resolve with the data from the response.
  */
 export function serviceInfo(
-  requestOptions?: IGeocodeRequestOptions
+  requestOptions?: IEndpointRequestOptions
 ): Promise<IGeocodeServiceInfoResponse> {
   warn(
     "serviceInfo() will be deprecated in the next major release. please use getGeocoderServiceInfo() instead."
   );
-  return getGeocoderServiceInfo(requestOptions);
+  return getGeocodeService(requestOptions);
 }
 
 export default {

--- a/packages/arcgis-rest-geocoder/src/geocoder.ts
+++ b/packages/arcgis-rest-geocoder/src/geocoder.ts
@@ -1,7 +1,12 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, IRequestOptions, IParams } from "@esri/arcgis-rest-request";
+import {
+  request,
+  IRequestOptions,
+  IParams,
+  warn
+} from "@esri/arcgis-rest-request";
 // import { IAuthenticatedRequestOptions } from "@esri/arcgis-rest-auth";
 
 import {
@@ -368,9 +373,9 @@ export function bulkGeocode(
  * Used to fetch metadata from a geocoding service.
  *
  * ```js
- * import { serviceInfo } from '@esri/arcgis-geocoder';
+ * import { getGeocoderServiceInfo } from '@esri/arcgis-geocoder';
  *
- * serviceInfo()
+ * getGeocoderServiceInfo()
  *   .then((response) => {
  *     response.serviceDescription; // => 'World Geocoder'
  *   });
@@ -379,11 +384,26 @@ export function bulkGeocode(
  * @param requestOptions - Request options can contain a custom geocoding service to fetch metadata from.
  * @returns A Promise that will resolve with the data from the response.
  */
-export function serviceInfo(
+export function getGeocoderServiceInfo(
   requestOptions?: IGeocodeRequestOptions
 ): Promise<IGeocodeServiceInfoResponse> {
   const url = (requestOptions && requestOptions.endpoint) || worldGeocoder;
   return request(url, requestOptions);
+}
+
+/**
+ * Deprecated. Please use `getGeocoderServiceInfo()` instead.
+ *
+ * @param requestOptions - Request options can contain a custom geocoding service to fetch metadata from.
+ * @returns A Promise that will resolve with the data from the response.
+ */
+export function serviceInfo(
+  requestOptions?: IGeocodeRequestOptions
+): Promise<IGeocodeServiceInfoResponse> {
+  warn(
+    "serviceInfo() will be deprecated in the next major release. please use getGeocoderServiceInfo() instead."
+  );
+  return getGeocoderServiceInfo(requestOptions);
 }
 
 export default {

--- a/packages/arcgis-rest-geocoder/src/geocoder.ts
+++ b/packages/arcgis-rest-geocoder/src/geocoder.ts
@@ -155,7 +155,7 @@ export interface IBulkGeocodeResponse {
   }>;
 }
 
-export interface IGeocodeServiceInfoResponse {
+export interface IGetGeocodeServiceResponse {
   currentVersion: number;
   serviceDescription: string;
   addressFields: any[];
@@ -384,9 +384,9 @@ export function bulkGeocode(
  * @param requestOptions - Request options can contain a custom geocoding service to fetch metadata from.
  * @returns A Promise that will resolve with the data from the response.
  */
-export function geocodeService(
+export function getGeocodeService(
   requestOptions?: IEndpointRequestOptions
-): Promise<IGeocodeServiceInfoResponse> {
+): Promise<IGetGeocodeServiceResponse> {
   const url = (requestOptions && requestOptions.endpoint) || worldGeocoder;
 
   const options: IEndpointRequestOptions = {
@@ -399,18 +399,18 @@ export function geocodeService(
 }
 
 /**
- * Deprecated. Please use `geocodeService()` instead.
+ * Deprecated. Please use `getGeocodeService()` instead.
  *
  * @param requestOptions - Request options can contain a custom geocoding service to fetch metadata from.
  * @returns A Promise that will resolve with the data from the response.
  */
 export function serviceInfo(
   requestOptions?: IEndpointRequestOptions
-): Promise<IGeocodeServiceInfoResponse> {
+): Promise<IGetGeocodeServiceResponse> {
   warn(
     "serviceInfo() will be deprecated in the next major release. please use getGeocoderServiceInfo() instead."
   );
-  return geocodeService(requestOptions);
+  return getGeocodeService(requestOptions);
 }
 
 export default {

--- a/packages/arcgis-rest-geocoder/test/geocoder.test.ts
+++ b/packages/arcgis-rest-geocoder/test/geocoder.test.ts
@@ -4,7 +4,7 @@ import {
   reverseGeocode,
   bulkGeocode,
   serviceInfo,
-  getGeocoderServiceInfo
+  getGeocodeService
 } from "../src/index";
 
 import * as fetchMock from "fetch-mock";
@@ -344,61 +344,10 @@ describe("geocode", () => {
       });
   });
 
-  it("should retrieve metadata from the World Geocoding Service using the old method name", done => {
-    fetchMock.once("*", SharingInfo);
-
-    // intercept deprecation warning
-    console.warn = jasmine.createSpy("warning");
-
-    serviceInfo()
-      .then(response => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        // expect(response).toEqual(SharingInfo); // need to fix something in order introspect the whole response
-        expect(response.currentVersion).toEqual(10.41);
-        expect(response.serviceDescription).toEqual(
-          "Sample geocoder for San Diego, California, USA"
-        );
-        done();
-      })
-      .catch(e => {
-        fail(e);
-      });
-  });
-
   it("should retrieve metadata from the World Geocoding Service", done => {
     fetchMock.once("*", SharingInfo);
 
-    getGeocoderServiceInfo()
-      .then(response => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        // expect(response).toEqual(SharingInfo); // need to fix something in order introspect the whole response
-        expect(response.currentVersion).toEqual(10.41);
-        expect(response.serviceDescription).toEqual(
-          "Sample geocoder for San Diego, California, USA"
-        );
-        done();
-      })
-      .catch(e => {
-        fail(e);
-      });
-  });
-
-  it("should make GET request for metadata from the World Geocoding Service", done => {
-    fetchMock.once("*", SharingInfo);
-
-    getGeocoderServiceInfo({ httpMethod: "GET" })
+    getGeocodeService()
       .then(response => {
         expect(fetchMock.called()).toEqual(true);
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
@@ -406,6 +355,30 @@ describe("geocode", () => {
           "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/?f=json"
         );
         expect(options.method).toBe("GET");
+        // expect(response).toEqual(SharingInfo); // need to fix something in order introspect the whole response
+        expect(response.currentVersion).toEqual(10.41);
+        expect(response.serviceDescription).toEqual(
+          "Sample geocoder for San Diego, California, USA"
+        );
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
+  it("should make POST request for metadata from the World Geocoding Service", done => {
+    fetchMock.once("*", SharingInfo);
+
+    getGeocodeService({ httpMethod: "POST" })
+      .then(response => {
+        expect(fetchMock.called()).toEqual(true);
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/"
+        );
+        expect(options.method).toBe("POST");
+        expect(options.body).toContain("f=json");
         // expect(paramsSpy).toHaveBeenCalledWith("f", "json");
         // expect(response).toEqual(SharingInfo); // need to fix something in order introspect the whole response
         expect(response.currentVersion).toEqual(10.41);
@@ -422,17 +395,42 @@ describe("geocode", () => {
   it("should retrieve metadata from custom geocoding services", done => {
     fetchMock.once("*", SharingInfo);
 
-    getGeocoderServiceInfo({ endpoint: customGeocoderUrl })
+    getGeocodeService({ endpoint: customGeocoderUrl })
       .then(response => {
         expect(fetchMock.called()).toEqual(true);
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
         expect(url).toEqual(
-          "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/"
+          "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/?f=json"
         );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
+        expect(options.method).toBe("GET");
         // how to introspect the whole response?
         // expect(response).toEqual(SharingInfo);
+        expect(response.currentVersion).toEqual(10.41);
+        expect(response.serviceDescription).toEqual(
+          "Sample geocoder for San Diego, California, USA"
+        );
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
+  it("should retrieve metadata from the World Geocoding Service using the old method name", done => {
+    fetchMock.once("*", SharingInfo);
+
+    // intercept deprecation warning
+    console.warn = jasmine.createSpy("warning");
+
+    serviceInfo()
+      .then(response => {
+        expect(fetchMock.called()).toEqual(true);
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/?f=json"
+        );
+        expect(options.method).toBe("GET");
+        // expect(response).toEqual(SharingInfo); // need to fix something in order introspect the whole response
         expect(response.currentVersion).toEqual(10.41);
         expect(response.serviceDescription).toEqual(
           "Sample geocoder for San Diego, California, USA"

--- a/packages/arcgis-rest-geocoder/test/geocoder.test.ts
+++ b/packages/arcgis-rest-geocoder/test/geocoder.test.ts
@@ -4,7 +4,7 @@ import {
   reverseGeocode,
   bulkGeocode,
   serviceInfo,
-  geocodeService
+  getGeocodeService
 } from "../src/index";
 
 import * as fetchMock from "fetch-mock";
@@ -347,7 +347,7 @@ describe("geocode", () => {
   it("should retrieve metadata from the World Geocoding Service", done => {
     fetchMock.once("*", SharingInfo);
 
-    geocodeService()
+    getGeocodeService()
       .then(response => {
         expect(fetchMock.called()).toEqual(true);
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
@@ -370,7 +370,7 @@ describe("geocode", () => {
   it("should make POST request for metadata from the World Geocoding Service", done => {
     fetchMock.once("*", SharingInfo);
 
-    geocodeService({ httpMethod: "POST" })
+    getGeocodeService({ httpMethod: "POST" })
       .then(response => {
         expect(fetchMock.called()).toEqual(true);
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
@@ -395,7 +395,7 @@ describe("geocode", () => {
   it("should retrieve metadata from custom geocoding services", done => {
     fetchMock.once("*", SharingInfo);
 
-    geocodeService({ endpoint: customGeocoderUrl })
+    getGeocodeService({ endpoint: customGeocoderUrl })
       .then(response => {
         expect(fetchMock.called()).toEqual(true);
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");

--- a/packages/arcgis-rest-geocoder/test/geocoder.test.ts
+++ b/packages/arcgis-rest-geocoder/test/geocoder.test.ts
@@ -4,7 +4,7 @@ import {
   reverseGeocode,
   bulkGeocode,
   serviceInfo,
-  getGeocodeService
+  geocodeService
 } from "../src/index";
 
 import * as fetchMock from "fetch-mock";

--- a/packages/arcgis-rest-geocoder/test/geocoder.test.ts
+++ b/packages/arcgis-rest-geocoder/test/geocoder.test.ts
@@ -347,7 +347,7 @@ describe("geocode", () => {
   it("should retrieve metadata from the World Geocoding Service", done => {
     fetchMock.once("*", SharingInfo);
 
-    getGeocodeService()
+    geocodeService()
       .then(response => {
         expect(fetchMock.called()).toEqual(true);
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
@@ -370,7 +370,7 @@ describe("geocode", () => {
   it("should make POST request for metadata from the World Geocoding Service", done => {
     fetchMock.once("*", SharingInfo);
 
-    getGeocodeService({ httpMethod: "POST" })
+    geocodeService({ httpMethod: "POST" })
       .then(response => {
         expect(fetchMock.called()).toEqual(true);
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
@@ -395,7 +395,7 @@ describe("geocode", () => {
   it("should retrieve metadata from custom geocoding services", done => {
     fetchMock.once("*", SharingInfo);
 
-    getGeocodeService({ endpoint: customGeocoderUrl })
+    geocodeService({ endpoint: customGeocoderUrl })
       .then(response => {
         expect(fetchMock.called()).toEqual(true);
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -108,7 +108,8 @@ export function request(
   requestOptions: IRequestOptions = { params: { f: "json" } }
 ): Promise<any> {
   const options: IRequestOptions = {
-    ...{ httpMethod: "POST", fetch },
+    httpMethod: "POST",
+    fetch,
     ...requestOptions
   };
 

--- a/packages/arcgis-rest-request/src/utils/check-for-errors.ts
+++ b/packages/arcgis-rest-request/src/utils/check-for-errors.ts
@@ -54,3 +54,12 @@ export function checkForErrors(
 
   return response;
 }
+
+/**
+ * Method used internally to surface messages to developers.
+ */
+export function warn(message: string) {
+  if (console && console.warn) {
+    console.warn.apply(console, [message]);
+  }
+}

--- a/packages/arcgis-rest-request/test/utils/check-for-errors.test.ts
+++ b/packages/arcgis-rest-request/test/utils/check-for-errors.test.ts
@@ -92,8 +92,10 @@ describe("warn", () => {
 
 describe("warn", () => {
   it("should carry on gracefully when no console is available", () => {
+    const realConsoleWarn = console.warn;
     console.warn = undefined;
     warn("Danger Will Robinson!");
     expect(console.warn).toBe(undefined);
+    console.warn = realConsoleWarn;
   });
 });

--- a/packages/arcgis-rest-request/test/utils/check-for-errors.test.ts
+++ b/packages/arcgis-rest-request/test/utils/check-for-errors.test.ts
@@ -1,5 +1,6 @@
 import {
   checkForErrors,
+  warn,
   ArcGISRequestError,
   ArcGISAuthError
 } from "../../src/index";
@@ -78,5 +79,21 @@ describe("checkForErrors", () => {
     expect(() => {
       checkForErrors(ArcGISServerTokenRequired);
     }).toThrowError(ArcGISAuthError, "GWM_0003: Token Required");
+  });
+});
+
+describe("warn", () => {
+  it("should bubble up deprecation warnings", () => {
+    console.warn = jasmine.createSpy("warning");
+    warn("Danger Will Robinson!");
+    expect(console.warn).toHaveBeenCalledWith("Danger Will Robinson!");
+  });
+});
+
+describe("warn", () => {
+  it("should carry on gracefully when no console is available", () => {
+    console.warn = undefined;
+    warn("Danger Will Robinson!");
+    expect(console.warn).toBe(undefined);
   });
 });


### PR DESCRIPTION
and set up previous method to be deprecated in next major release

AFFECTS PACKAGES:
@esri/arcgis-rest-geocoder
@esri/arcgis-rest-request

ISSUES CLOSED: #122