### PR TITLE
fix(request): ensure falsy request parameters like zero are passed through

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.tabSize": 2
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,7 @@
       }
     },
     "acetate": {
-      "version": "github:patrickarlt/acetate#ea99518d1dccd8bf470aebdbf31b95453a999c4b",
+      "version": "github:patrickarlt/acetate#423112df9307548027c410f2fdf76fac931b7db7",
       "dev": true,
       "requires": {
         "async": "2.6.0",
@@ -160,6 +160,7 @@
         "chokidar": "1.7.0",
         "common-tags": "1.6.0",
         "es6-promisify": "5.0.0",
+        "eslint-plugin-prettier": "2.6.0",
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "highlight.js": "9.12.0",
@@ -3736,6 +3737,16 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
+      "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
@@ -3977,6 +3988,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -6826,6 +6843,12 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
       "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+      "dev": true
+    },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
       "dev": true
     },
     "jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "lint-staged": {
     "*.ts": [
-      "prettier --write --parser typescript",
+      "prettier --write --parser typescript --tab-width 2 --use-tabs false",
       "tslint",
       "git add"
     ]

--- a/packages/arcgis-rest-request/src/utils/process-params.ts
+++ b/packages/arcgis-rest-request/src/utils/process-params.ts
@@ -1,5 +1,5 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
- * Apache-2.0 */
+* Apache-2.0 */
 
 /**
  * Checks parameters to see if we should use FormData to send the request
@@ -47,7 +47,7 @@ export function processParams(params: any): any {
 
   Object.keys(params).forEach(key => {
     const param = params[key];
-    if (!param) {
+    if (!param && param !== 0) {
       return;
     }
     const type = param.constructor.name;
@@ -80,7 +80,7 @@ export function processParams(params: any): any {
         value = param;
         break;
     }
-    if (value) {
+    if (value || value === 0) {
       newParams[key] = value;
     }
   });

--- a/packages/arcgis-rest-request/test/utils/process-params.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-params.test.ts
@@ -89,13 +89,18 @@ describe("processParams", () => {
     expect(processParams(params)).toEqual(expected);
   });
 
-  it("should exclude null and undefined", () => {
+  it("should exclude null and undefined, but not a zero", () => {
     const params: any = {
       foo: null,
-      bar: undefined
+      bar: undefined,
+      baz: 0
     };
 
-    expect(processParams(params)).toEqual({});
+    const expected = {
+      baz: 0
+    };
+
+    expect(processParams(params)).toEqual(expected);
   });
 
   it("should not require form data for simple requests", () => {


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-request

ISSUES CLOSED: #142 

don't ask me why i had to add two flags with [default values](https://prettier.io/docs/en/options.html) to get prettier to _stop_ re-indenting every line in all the files i was editing.

i. have. no. idea.