### PR TITLE
Fix incorrect types in arcgis-rest-feture-service and get branch coverage back to 100%

### DIFF
--- a/packages/arcgis-rest-feature-service/src/features.ts
+++ b/packages/arcgis-rest-feature-service/src/features.ts
@@ -40,7 +40,7 @@ export interface IStatisticDefinition {
 export interface IQueryFeaturesParams {
   // TODO: are _any_ of these required?
   where?: string;
-  objectIds?: [number];
+  objectIds?: number[];
   geometry?: IGeometry;
   geometryType?: esriGeometryType;
   // NOTE: either WKID or ISpatialReference
@@ -56,7 +56,7 @@ export interface IQueryFeaturesParams {
     | "esriSpatialRelWithin";
   relationParam?: string;
   // NOTE: either time=1199145600000 or time=1199145600000, 1230768000000
-  time?: Date | [Date];
+  time?: Date | Date[];
   distance?: number;
   units?:
     | "esriSRUnit_Meter"
@@ -65,7 +65,7 @@ export interface IQueryFeaturesParams {
     | "esriSRUnit_Kilometer"
     | "esriSRUnit_NauticalMile"
     | "esriSRUnit_USNauticalMile";
-  outFields?: "*" | [string];
+  outFields?: "*" | string[];
   returnGeometry?: boolean;
   maxAllowableOffset?: number;
   geometryPrecision?: number;
@@ -78,7 +78,7 @@ export interface IQueryFeaturesParams {
   returnExtentOnly?: boolean;
   orderByFields?: string;
   groupByFieldsForStatistics?: string;
-  outStatistics?: [IStatisticDefinition];
+  outStatistics?: IStatisticDefinition[];
   returnZ?: boolean;
   returnM?: boolean;
   multipatchOption?: "xyFootprint";

--- a/packages/arcgis-rest-feature-service/src/features.ts
+++ b/packages/arcgis-rest-feature-service/src/features.ts
@@ -5,7 +5,8 @@ import {
   IFeature,
   IField,
   IGeometry,
-  ISpatialReference
+  ISpatialReference,
+  IFeatureSet
 } from "@esri/arcgis-rest-common-types";
 import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 
@@ -105,13 +106,8 @@ export interface IQueryFeaturesRequestOptions extends IRequestOptions {
   params?: IQueryFeaturesParams;
 }
 
-export interface IQueryFeaturesResponse {
-  objectIdFieldName: string;
-  globalIdFieldName: string;
-  geometryType: esriGeometryType;
-  spatialReference: ISpatialReference;
-  fields: [IField];
-  features: [IFeature];
+export interface IQueryFeaturesResponse extends IFeatureSet {
+  exceededTransferLimit?: boolean;
 }
 
 /**

--- a/packages/arcgis-rest-feature-service/test/features.test.ts
+++ b/packages/arcgis-rest-feature-service/test/features.test.ts
@@ -25,15 +25,41 @@ describe("feature", () => {
   });
 
   it("should supply default query parameters", done => {
-    const params = {
+    const requestOptions = {
       url:
         "https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Landscape_Trees/FeatureServer/0"
     };
     fetchMock.once("*", queryResponse);
-    queryFeatures(params).then(response => {
+    queryFeatures(requestOptions).then(response => {
       expect(fetchMock.called()).toBeTruthy();
       const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(`${params.url}/query?f=json&where=1%3D1&outFields=*`);
+      expect(url).toEqual(
+        `${requestOptions.url}/query?f=json&where=1%3D1&outFields=*`
+      );
+      expect(options.method).toBe("GET");
+      // expect(response.attributes.FID).toEqual(42);
+      done();
+    });
+  });
+
+  it("should use passed in query parameters", done => {
+    const requestOptions = {
+      url:
+        "https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Landscape_Trees/FeatureServer/0",
+      params: {
+        where: "Condition='Poor'",
+        outFields: ["FID", "Tree_ID", "Cmn_Name", "Condition"]
+      }
+    };
+    fetchMock.once("*", queryResponse);
+    queryFeatures(requestOptions).then(response => {
+      expect(fetchMock.called()).toBeTruthy();
+      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+      expect(url).toEqual(
+        `${
+          requestOptions.url
+        }/query?f=json&where=Condition%3D'Poor'&outFields=FID%2CTree_ID%2CCmn_Name%2CCondition`
+      );
       expect(options.method).toBe("GET");
       // expect(response.attributes.FID).toEqual(42);
       done();


### PR DESCRIPTION
Looks like I noticed `IFeatureSet` in common types before, but forgot to use it.