### PR TITLE
fix(request): ensure request is passed through as a request parameter

### DIFF
--- a/packages/arcgis-rest-request/src/utils/process-params.ts
+++ b/packages/arcgis-rest-request/src/utils/process-params.ts
@@ -47,7 +47,7 @@ export function processParams(params: any): any {
 
   Object.keys(params).forEach(key => {
     const param = params[key];
-    if (!param && param !== 0) {
+    if (!param && param !== 0 && typeof param !== "boolean") {
       return;
     }
     const type = param.constructor.name;

--- a/packages/arcgis-rest-request/test/utils/process-params.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-params.test.ts
@@ -79,11 +79,13 @@ describe("processParams", () => {
 
   it("should stringify booleans", () => {
     const params = {
-      foo: true
+      foo: true,
+      bar: false
     };
 
     const expected = {
-      foo: "true"
+      foo: "true",
+      bar: "false"
     };
 
     expect(processParams(params)).toEqual(expected);


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-request

ISSUES CLOSED: #142 

i fully grant there may be a tidier way to do this. 

if we were to test for `params.hasOwnProperty(key)` like we do in Esri Leaflet, we wouldn't be able to handle { "foo": null }
