### PR TITLE
scrollbar for long words in <tables> instead of overflow

### DIFF
--- a/docs/src/_layout.html
+++ b/docs/src/_layout.html
@@ -71,7 +71,7 @@
       </div>
     </footer>
 
-    <script src="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.0.0-rc.7/js/calcite-web.min.js"></script>
+    <script src="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.0.0-rc.9/js/calcite-web.min.js"></script>
 
     <script>
        calcite.init()

--- a/docs/src/sass/style.scss
+++ b/docs/src/sass/style.scss
@@ -153,3 +153,10 @@ a > code {
   clear: right;
   margin: 0;
 }
+
+/** only apply to tables inside <main> for sanity **/
+main table {
+  overflow: auto; /** show a scrollbar automatically**/
+  display: inline-block; /**  display span as a block **/
+  border: none;
+}


### PR DESCRIPTION
the only downside i can see to the change i'm proposing is that it collapses other tables when they don't have enough content.

![screenshot 2018-03-27 16 30 37](https://user-images.githubusercontent.com/3011734/38000504-b86c6640-31dc-11e8-8ef5-ed4a48f4056e.png)
