### PR TITLE
fix(auth): decode username when parsing response from OAuth

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -376,7 +376,7 @@ export class UserSession implements IAuthenticationManager {
     const expires = new Date(
       Date.now() + parseInt(match[2], 10) * 1000 - 60 * 1000
     );
-    const username = match[3];
+    const username = decodeURIComponent(match[3]);
 
     return completeSignIn(null, {
       token,

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -488,7 +488,7 @@ describe("UserSession", () => {
       const MockWindow = {
         location: {
           href:
-            "https://example-app.com/redirect-uri#access_token=token&expires_in=1209600&username=c@sey&persist=true"
+            "https://example-app.com/redirect-uri#access_token=token&expires_in=1209600&username=c%40sey&persist=true"
         },
         get parent() {
           return this;
@@ -527,7 +527,7 @@ describe("UserSession", () => {
         },
         location: {
           href:
-            "https://example-app.com/redirect-uri#access_token=token&expires_in=1209600&username=c@sey"
+            "https://example-app.com/redirect-uri#access_token=token&expires_in=1209600&username=c%40sey"
         }
       };
 
@@ -557,7 +557,7 @@ describe("UserSession", () => {
         },
         location: {
           href:
-            "https://example-app.com/redirect-uri#access_token=token&expires_in=1209600&username=c@sey"
+            "https://example-app.com/redirect-uri#access_token=token&expires_in=1209600&username=c%40sey"
         }
       };
 


### PR DESCRIPTION
Usernames with @ symbols are returned from OAuth as %40, so we need to decode them with
decodeURIComponent.

AFFECTS PACKAGES:
@esri/arcgis-rest-auth

ISSUES CLOSED: #165