### PR TITLE
chore(all READMEs): add links to API reference sections

### DIFF
--- a/packages/arcgis-rest-auth/README.md
+++ b/packages/arcgis-rest-auth/README.md
@@ -14,6 +14,7 @@
 ### Example
 
 ```bash
+npm install @esri/arcgis-rest-request
 npm install @esri/arcgis-rest-auth
 ```
 
@@ -25,6 +26,8 @@ const session = new UserSession({
     password: "123456"
 });
 ```
+
+### [API Reference](https://esri.github.io/arcgis-rest-js/api/auth/)
 
 ### Issues
 

--- a/packages/arcgis-rest-common-types/README.md
+++ b/packages/arcgis-rest-common-types/README.md
@@ -24,6 +24,8 @@ const myPoint = { x: -118.409, y: 33.943 } as IPoint
 
 ```
 
+### [API Reference](https://esri.github.io/arcgis-rest-js/api/common-types/)
+
 ### Issues
 
 If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.

--- a/packages/arcgis-rest-feature-service/README.md
+++ b/packages/arcgis-rest-feature-service/README.md
@@ -14,6 +14,7 @@
 ### Example
 
 ```bash
+npm install @esri/arcgis-rest-request
 npm install @esri/arcgis-rest-feature-service
 ```
 
@@ -31,6 +32,8 @@ getFeature(params)
     console.log(feature.attributes.FID); // 42
   });
 ```
+
+### [API Reference](https://esri.github.io/arcgis-rest-js/api/feature-service/)
 
 ### Issues
 

--- a/packages/arcgis-rest-geocoder/README.md
+++ b/packages/arcgis-rest-geocoder/README.md
@@ -14,6 +14,7 @@
 ### Example
 
 ```bash
+npm install @esri/arcgis-rest-request
 npm install @esri/arcgis-rest-geocoder
 ```
 
@@ -25,6 +26,8 @@ geocode("LAX")
     response.candidates[0].location; // => { x: -118.409, y: 33.943, spatialReference: { wkid: 4326 }  }
   });
 ```
+
+### [API Reference](https://esri.github.io/arcgis-rest-js/api/geocoder/)
 
 ### Issues
 

--- a/packages/arcgis-rest-groups/README.md
+++ b/packages/arcgis-rest-groups/README.md
@@ -14,6 +14,7 @@
 ### Example
 
 ```bash
+npm install @esri/arcgis-rest-request
 npm install @esri/arcgis-rest-groups
 ```
 
@@ -25,6 +26,8 @@ searchGroups({q:"water"})
         console.log(response.results.length) // 10
     });
 ```
+
+### [API Reference](https://esri.github.io/arcgis-rest-js/api/groups/)
 
 ### Issues
 

--- a/packages/arcgis-rest-items/README.md
+++ b/packages/arcgis-rest-items/README.md
@@ -14,6 +14,7 @@
 ### Example
 
 ```bash
+npm install @esri/arcgis-rest-request
 npm install @esri/arcgis-rest-items
 ```
 
@@ -27,6 +28,8 @@ getItem(itemId)
         console.log(response.title) // World Topographic Map
     });
 ```
+
+### [API Reference](https://esri.github.io/arcgis-rest-js/api/items/)
 
 ### Issues
 

--- a/packages/arcgis-rest-request/README.md
+++ b/packages/arcgis-rest-request/README.md
@@ -28,6 +28,8 @@ request(url)
     });
 ```
 
+### [API Reference](https://esri.github.io/arcgis-rest-js/api/request/)
+
 ### Issues
 
 If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-auth
@esri/arcgis-rest-common-types
@esri/arcgis-rest-feature-service
@esri/arcgis-rest-geocoder
@esri/arcgis-rest-groups
@esri/arcgis-rest-items
@esri/arcgis-rest-request

ISSUES CLOSED: #148