### PR TITLE
feat(new users package): add rest-users with a single method

### DIFF
--- a/packages/arcgis-rest-auth/src/authenticated-request-options.ts
+++ b/packages/arcgis-rest-auth/src/authenticated-request-options.ts
@@ -14,5 +14,8 @@ export interface IAuthenticatedRequestOptions extends IRequestOptions {
  * Used internally by packages for requests that require authentication.
  */
 export interface IUserRequestOptions extends IRequestOptions {
+  /**
+   * A session representing a logged in user.
+   */
   authentication: UserSession;
 }

--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -392,3 +392,40 @@ export interface ITextSymbol extends IMarkerSymbol {
   font?: IFont;
   text?: string; // only applicable when specified as a client-side graphic.
 }
+
+/**
+ * An ArcGIS Online or Enterprise user
+ */
+export interface IUser {
+  username?: string;
+  fullName?: string;
+  availableCredits?: number;
+  assignedCredits?: number;
+  firstName?: string;
+  lastName?: string;
+  preferredView?: any;
+  description?: string;
+  email?: string;
+  idpUsername?: string;
+  favGroupId?: string;
+  lastLogin?: number;
+  mfaEnabled?: boolean;
+  access?: string;
+  storageUsage?: number;
+  storageQuota?: number;
+  orgId?: string;
+  role?: "org_admin" | "org_publisher" | "org_user";
+  privileges?: string[];
+  roleId?: string;
+  level?: string;
+  disabled?: boolean;
+  units?: string;
+  tags?: string[];
+  culture?: string;
+  region?: string;
+  thumbnail?: string;
+  created?: number;
+  modified?: number;
+  groups?: object[];
+  provider?: "arcgis" | "enterprise" | "facebook" | "google";
+}

--- a/packages/arcgis-rest-users/README.md
+++ b/packages/arcgis-rest-users/README.md
@@ -20,9 +20,19 @@ npm install @esri/arcgis-rest-users
 ```js
 import { getUser } from '@esri/arcgis-rest-groups';
 
-getUser("johnqpublic")
+getUser("jsmith")
     .then(response => {
-        console.log(response) // {}
+        /*
+        {
+            firstName: "John",
+            lastName: "Smith",
+            tags: ["GIS Analyst", "City of Redlands"],
+            thumbnail: "myProfile.jpg",
+            created: 1258501046000,
+            modified: 1290625562000,
+             d eetc.
+        };
+        */
     });
 ```
 

--- a/packages/arcgis-rest-users/README.md
+++ b/packages/arcgis-rest-users/README.md
@@ -1,0 +1,61 @@
+[![npm version][npm-img]][npm-url]
+[![build status][travis-img]][travis-url]
+[![apache licensed](https://img.shields.io/badge/license-Apache-green.svg?style=flat-square)](https://raw.githubusercontent.com/Esri/arcgis-rest-js/master/LICENSE)
+
+[npm-img]: https://img.shields.io/npm/v/@esri/arcgis-rest-users.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/@esri/arcgis-rest-users
+[travis-img]: https://img.shields.io/travis/Esri/arcgis-rest-js/master.svg?style=flat-square
+[travis-url]: https://travis-ci.org/Esri/arcgis-rest-js
+
+# @esri/arcgis-rest-users
+
+> A module for working with users in the ArcGIS REST API that runs in Node.js and modern browsers.
+
+### Example
+
+```bash
+npm install @esri/arcgis-rest-users
+```
+
+```js
+import { getUser } from '@esri/arcgis-rest-groups';
+
+getUser("johnqpublic")
+    .then(response => {
+        console.log(response) // {}
+    });
+```
+
+### Issues
+
+If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/arcgis-rest-js/issues) first.  Have you found a new bug?  Want to request a new feature?  We'd [**love**](https://github.com/Esri/arcgis-rest-js/issues/new) to hear from you.
+
+If you're looking for help you can also post issues on [GIS Stackexchange](http://gis.stackexchange.com/questions/ask?tags=esri-oss).
+
+### Versioning
+
+For transparency into the release cycle and in striving to maintain backward compatibility, @esri/arcgis-rest-js is maintained under Semantic Versioning guidelines and will adhere to these rules whenever possible.
+
+For more information on SemVer, please visit <http://semver.org/>.
+
+### Contributing
+
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](CONTRIBUTING.md).
+
+### License
+
+Copyright 2018 Esri
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+> http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A copy of the license is available in the repository's [LICENSE](./LICENSE) file.

--- a/packages/arcgis-rest-users/package.json
+++ b/packages/arcgis-rest-users/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@esri/arcgis-rest-users",
+  "version": "1.1.1",
+  "description": "Portal user helpers for @esri/arcgis-rest-request",
+  "main": "dist/node/index.js",
+  "browser": "dist/umd/arcgis-rest-users.umd.js",
+  "module": "dist/esm/index.js",
+  "js:next": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "license": "Apache-2.0",
+  "files": [
+    "dist/**"
+  ],
+  "dependencies": {
+    "tslib": "^1.7.1"
+  },
+  "peerDependencies": {
+    "@esri/arcgis-rest-auth": "^1.1.1",
+    "@esri/arcgis-rest-common-types": "^1.1.1",
+    "@esri/arcgis-rest-request": "^1.1.1"
+  },
+  "devDependencies": {
+    "@esri/arcgis-rest-auth": "^1.1.1",
+    "@esri/arcgis-rest-common-types": "^1.1.1",
+    "@esri/arcgis-rest-request": "^1.1.1"
+  },
+  "scripts": {
+    "prepare": "npm run build",
+    "build": "npm run build:node && npm run build:umd && npm run build:esm",
+    "build:esm": "tsc -p ./tsconfig.json --module es2015 --outDir ./dist/esm --declaration",
+    "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
+    "build:node": "tsc -p ./tsconfig.json --module commonjs --outDir ./dist/node"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Esri/arcgis-rest-js.git"
+  },
+  "contributors": [
+    {
+      "name": "John Gravois",
+      "email": "john@esri.com"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/Esri/arcgis-rest-js/issues"
+  },
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+}

--- a/packages/arcgis-rest-users/src/index.ts
+++ b/packages/arcgis-rest-users/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./users";

--- a/packages/arcgis-rest-users/src/users.ts
+++ b/packages/arcgis-rest-users/src/users.ts
@@ -10,7 +10,14 @@ import {
 import { IUser } from "@esri/arcgis-rest-common-types";
 import { UserSession, IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
-export interface IGetUserRequestOptions extends IUserRequestOptions {
+export interface IGetUserRequestOptions extends IRequestOptions {
+  /**
+   * A session representing a logged in user.
+   */
+  authentication?: UserSession;
+  /**
+   * Supply a username if you'd like to fetch information about a different user than is being used to authenticate the request.
+   */
   username?: string;
 }
 
@@ -20,10 +27,20 @@ export interface IGetUserRequestOptions extends IUserRequestOptions {
  * ```js
  * import { getUser } from '@esri/arcgis-rest-users';
  *
- * getUser("johnqpublic")
+ * getUser("jsmith")
  *   .then(
- *     results => console.log(response); // IUser
- *   )
+ *     results => {
+ *      // {
+ *      //   firstName: "John",
+ *      //   lastName: "Smith",
+ *      //   description: "Senior GIS Analyst for the city of Redlands.",
+ *      //   tags: ["GIS Analyst", "City of Redlands"],
+ *      //   thumbnail: "myProfile.jpg",
+ *      //   created: 1258501046000,
+ *      //   modified: 1290625562000,
+ *      //   etc.
+ *      // };
+ *   })
  * ```
  *
  * @param requestOptions - options to pass through in the request

--- a/packages/arcgis-rest-users/src/users.ts
+++ b/packages/arcgis-rest-users/src/users.ts
@@ -1,0 +1,56 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import {
+  request,
+  IRequestOptions,
+  getPortalUrl
+} from "@esri/arcgis-rest-request";
+
+import { IUser } from "@esri/arcgis-rest-common-types";
+import { UserSession, IUserRequestOptions } from "@esri/arcgis-rest-auth";
+
+export interface IGetUserRequestOptions extends IUserRequestOptions {
+  username?: string;
+}
+
+/**
+ * Get information about a user
+ *
+ * ```js
+ * import { getUser } from '@esri/arcgis-rest-users';
+ *
+ * getUser("johnqpublic")
+ *   .then(
+ *     results => console.log(response); // IUser
+ *   )
+ * ```
+ *
+ * @param requestOptions - options to pass through in the request
+ * @returns A Promise that will resolve with metdata about the user
+ */
+export function getUser(
+  requestOptions?: string | IGetUserRequestOptions
+): Promise<IUser> {
+  let url;
+  let options = { httpMethod: "GET" } as IGetUserRequestOptions;
+
+  // if a username is passed, assume ArcGIS Online
+  if (typeof requestOptions === "string") {
+    url = `http://www.arcgis.com/sharing/rest/community/users/${requestOptions}`;
+  } else {
+    // if an authenticated session is passed, default to that user/portal unless another username is provided manually
+    const username =
+      requestOptions.username || requestOptions.authentication.username;
+    url = `${getPortalUrl(requestOptions)}/community/users/${encodeURIComponent(
+      username
+    )}`;
+    options = {
+      ...requestOptions,
+      ...options
+    };
+  }
+
+  // send the request
+  return request(url, options);
+}

--- a/packages/arcgis-rest-users/test/mocks/responses.ts
+++ b/packages/arcgis-rest-users/test/mocks/responses.ts
@@ -1,0 +1,71 @@
+import { IUser } from "@esri/arcgis-rest-common-types";
+
+export const AnonUserResponse: IUser = {
+  username: "jsmith",
+  fullName: "John Smith",
+  firstName: "John",
+  lastName: "Smith",
+  description: "Senior GIS Analyst for the city of Redlands.",
+  tags: ["GIS Analyst", "City of Redlands"],
+  culture: "en",
+  region: "US",
+  units: "metric",
+  thumbnail: "myProfile.jpg",
+  created: 1258501046000,
+  modified: 1290625562000,
+  provider: "arcgis"
+};
+
+export const UserResponse = {
+  ...AnonUserResponse,
+  availableCredits: 479.50998,
+  assignedCredits: 500.0,
+  preferredView: "Web",
+  email: "jsmith33@esri.com",
+  idpUsername: "null",
+  favGroupId: "829e32cca4dd475a8bb63bb56b16fe3e",
+  lastLogin: 1385766284000,
+  mfaEnabled: false,
+  access: "public",
+  storageUsage: 583650,
+  storageQuota: 2147483648,
+  orgId: "qWAReEOCnD7eTxOe",
+  role: "org_admin",
+  privileges: [
+    "portal:admin:deleteItems",
+    "portal:admin:reassignItems",
+    "portal:admin:updateItems",
+    "portal:admin:viewItems",
+    "portal:admin:viewUsers",
+    "portal:user:createGroup",
+    "portal:user:createItem",
+    "portal:user:joinGroup",
+    "portal:user:shareToGroup",
+    "portal:user:shareToOrg"
+  ],
+  roleId: "RDnHQBSBbsJuIkUp",
+  level: "2",
+  disabled: false,
+  groups: [
+    {
+      id: "0657d48d0c0841d793ea6ada2e6955f3",
+      title: "Street Maps",
+      isInvitationOnly: false,
+      owner: "jsmith",
+      description:
+        "The street map group provides street maps for the city of Redlands.",
+      snippet: "City of Redlands maps",
+      tags: ["Redlands", "street", "maps"],
+      phone: "http://www.esri.com",
+      thumbnail: "streets.jpg",
+      created: 1258501221000,
+      modified: 1272309404000,
+      access: "org",
+      userMembership: {
+        username: "jsmith",
+        memberType: "owner",
+        applications: 0
+      }
+    }
+  ]
+};

--- a/packages/arcgis-rest-users/test/users.test.ts
+++ b/packages/arcgis-rest-users/test/users.test.ts
@@ -1,0 +1,93 @@
+import { getUser } from "../src/index";
+
+import { AnonUserResponse, UserResponse } from "./mocks/responses";
+
+import { encodeParam } from "@esri/arcgis-rest-request";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import * as fetchMock from "fetch-mock";
+
+const TOMORROW = (function() {
+  const now = new Date();
+  now.setDate(now.getDate() + 1);
+  return now;
+})();
+
+describe("users", () => {
+  afterEach(fetchMock.restore);
+
+  describe("getUser", () => {
+    const session = new UserSession({
+      username: "c@sey",
+      password: "123456",
+      portal: "https://myorg.maps.arcgis.com/sharing/rest"
+    });
+
+    fetchMock.postOnce(
+      "https://myorg.maps.arcgis.com/sharing/rest/generateToken",
+      {
+        token: "token",
+        expires: TOMORROW.getTime(),
+        username: " c@sey"
+      }
+    );
+
+    session.refreshSession();
+
+    it("should make a simple, unauthenticated request for information about a user", done => {
+      fetchMock.once("*", AnonUserResponse);
+
+      getUser("jsmith")
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "http://www.arcgis.com/sharing/rest/community/users/jsmith?f=json"
+          );
+          expect(options.method).toBe("GET");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should make an authenticated request for information about a user", done => {
+      fetchMock.once("*", UserResponse);
+
+      getUser({ authentication: session })
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey?f=json&token=token"
+          );
+          expect(options.method).toBe("GET");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should make an authenticated request for information about a different user", done => {
+      fetchMock.once("*", UserResponse);
+
+      getUser({
+        username: "jsmith",
+        authentication: session
+      })
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=token"
+          );
+          expect(options.method).toBe("GET");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+  });
+});

--- a/packages/arcgis-rest-users/tsconfig.json
+++ b/packages/arcgis-rest-users/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+      "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
* didnt implement `getSelf()` because it'd cause a global namespace collision, but the following three signatures are supported

```js
getUser("johnqpublic")
// returns info available to anonymous requests

getUser({ authentication: session })
// returns information about the currently logged in user

getUser({
  authentication: session,
  username: "otheruser"
})
// returns information about an explicitly defined user (based on level of permission of the authenticated session)
```

AFFECTS PACKAGES:
@esri/arcgis-rest-common-types
@esri/arcgis-rest-users

ISSUES CLOSED: #159