### PR TITLE
docs(LICENSE): fix license links in package READMEs

### DIFF
--- a/packages/arcgis-rest-auth/README.md
+++ b/packages/arcgis-rest-auth/README.md
@@ -61,4 +61,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](../../LICENSE) file.

--- a/packages/arcgis-rest-common-types/README.md
+++ b/packages/arcgis-rest-common-types/README.md
@@ -58,4 +58,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](../../LICENSE) file.

--- a/packages/arcgis-rest-feature-service/README.md
+++ b/packages/arcgis-rest-feature-service/README.md
@@ -67,4 +67,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](../../LICENSE) file.

--- a/packages/arcgis-rest-geocoder/README.md
+++ b/packages/arcgis-rest-geocoder/README.md
@@ -61,4 +61,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](../../LICENSE) file.

--- a/packages/arcgis-rest-groups/README.md
+++ b/packages/arcgis-rest-groups/README.md
@@ -61,4 +61,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](../../LICENSE) file.

--- a/packages/arcgis-rest-items/README.md
+++ b/packages/arcgis-rest-items/README.md
@@ -63,4 +63,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](../../LICENSE) file.

--- a/packages/arcgis-rest-request/README.md
+++ b/packages/arcgis-rest-request/README.md
@@ -62,4 +62,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](../../LICENSE) file.

--- a/packages/arcgis-rest-users/README.md
+++ b/packages/arcgis-rest-users/README.md
@@ -68,4 +68,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](../../LICENSE) file.


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-auth
@esri/arcgis-rest-common-types
@esri/arcgis-rest-feature-service
@esri/arcgis-rest-geocoder
@esri/arcgis-rest-groups
@esri/arcgis-rest-items
@esri/arcgis-rest-request
@esri/arcgis-rest-users