### PR TITLE
fix(getPortalUrl): make getPortalUrl use portal in request options if passed in

### DIFF
--- a/packages/arcgis-rest-request/src/utils/get-portal-url.ts
+++ b/packages/arcgis-rest-request/src/utils/get-portal-url.ts
@@ -5,17 +5,21 @@ import { IRequestOptions } from "../request";
 /**
  * Helper that returns the portalUrl - either defaulting to www.arcgis.com or using
  * the passed in auth manager's .portal property
- * 
+ *
  * @param requestOptions - Request options that may have authentication manager
  * @returns Portal url to be used in API requests
  */
-export function getPortalUrl(requestOptions?: IRequestOptions): string {
-  // default to arcgis.com
-  let portalUrl = "https://www.arcgis.com/sharing/rest";
-  // but if the auth was passed, use that portal...
-  if (requestOptions && requestOptions.authentication) {
-    portalUrl = requestOptions.authentication.portal;
+export function getPortalUrl(requestOptions: IRequestOptions = {}): string {
+  // use portal in options if specified
+  if (requestOptions.portal) {
+    return requestOptions.portal;
   }
 
-  return portalUrl;
+  // if the auth was passed, use that portal
+  if (requestOptions.authentication) {
+    return requestOptions.authentication.portal;
+  }
+
+  // default to arcgis.com
+  return "https://www.arcgis.com/sharing/rest";
 }

--- a/packages/arcgis-rest-request/test/utils/get-portal-url.test.ts
+++ b/packages/arcgis-rest-request/test/utils/get-portal-url.test.ts
@@ -17,4 +17,18 @@ describe("getPortalUrl", () => {
     const url = getPortalUrl(requestOptions);
     expect(url).toEqual("https://foo.com/arcgis/sharing/rest");
   });
+
+  it("should use the portal in the requestOptions if passed", () => {
+    const requestOptions = {
+      authentication: {
+        portal: "https://foo.com/arcgis/sharing/rest",
+        getToken() {
+          return Promise.resolve("fake");
+        }
+      },
+      portal: "https://bar.com/arcgis/sharing/rest"
+    };
+    const url = getPortalUrl(requestOptions);
+    expect(url).toEqual("https://bar.com/arcgis/sharing/rest");
+  });
 });


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-request

ISSUES CLOSED: #180