### PR TITLE
fix bad link in the guides

### DIFF
--- a/docs/src/guides/babel-and-rollup.md
+++ b/docs/src/guides/babel-and-rollup.md
@@ -8,7 +8,7 @@ group: 1-get-started
 
 # Get Started with Babel and Rollup
 
-ArcGIS REST JS is ready-to-use with popular module bundlers like [webpack](https://webpack.js.org/) and [rollup](https://rollupjs.org/). Make sure you also install the polyfills for [`fetch`](https://github.com/matthew-andrews/isomorphic-fetch) and [`Promise`](https://github.com/stefanpenner/es6-promise). You can find `npm install` commands for all packages in the [API reference](../api).
+ArcGIS REST JS is ready-to-use with popular module bundlers like [webpack](https://webpack.js.org/) and [rollup](https://rollupjs.org/). Make sure you also install the polyfills for [`fetch`](https://github.com/matthew-andrews/isomorphic-fetch) and [`Promise`](https://github.com/stefanpenner/es6-promise). You can find `npm install` commands for all packages in the [API reference](../../api).
 
 ```bash
 npm install @esri/arcgis-rest-request isomorphic-fetch es6-promise

--- a/docs/src/guides/babel-and-webpack.md
+++ b/docs/src/guides/babel-and-webpack.md
@@ -8,7 +8,7 @@ group: 1-get-started
 
 # Get Started with Babel and Webpack
 
-ArcGIS REST JS is ready-to-use with popular module bundlers like [webpack](https://webpack.js.org/) and [rollup](https://rollupjs.org/). Make sure you also install the polyfills for [`fetch`](https://github.com/matthew-andrews/isomorphic-fetch) and [`Promise`](https://github.com/stefanpenner/es6-promise). You can find `npm install` commands for all packages in the [API reference](../api).
+ArcGIS REST JS is ready-to-use with popular module bundlers like [webpack](https://webpack.js.org/) and [rollup](https://rollupjs.org/). Make sure you also install the polyfills for [`fetch`](https://github.com/matthew-andrews/isomorphic-fetch) and [`Promise`](https://github.com/stefanpenner/es6-promise). You can find `npm install` commands for all packages in the [API reference](../../api).
 
 ```bash
 npm install @esri/arcgis-rest-request isomorphic-fetch es6-promise

--- a/docs/src/guides/from-a-cdn.md
+++ b/docs/src/guides/from-a-cdn.md
@@ -8,7 +8,7 @@ group: 1-get-started
 
 # Get Started using a CDN
 
-ArcGIS REST JS is hosted on [unpkg](https://unpkg.com/). You can find URLs for individual packages in the [API reference](../api).
+ArcGIS REST JS is hosted on [unpkg](https://unpkg.com/). You can find URLs for individual packages in the [API reference](../../api).
 
 ```html
 <!DOCTYPE html>

--- a/docs/src/guides/node.md
+++ b/docs/src/guides/node.md
@@ -8,7 +8,7 @@ group: 1-get-started
 
 # Get Started with Node.js
 
-Make sure you have polyfills for [`fetch`](https://github.com/matthew-andrews/isomorphic-fetch) and [`FormData`](https://github.com/form-data/isomorphic-form-data) installed before using any ArcGIS REST JS library. You can find `npm install` commands for all packages in the [API reference](../api).
+Make sure you have polyfills for [`fetch`](https://github.com/matthew-andrews/isomorphic-fetch) and [`FormData`](https://github.com/form-data/isomorphic-form-data) installed before using any ArcGIS REST JS library. You can find `npm install` commands for all packages in the [API reference](../../api).
 
 ```bash
 npm install @esri/arcgis-rest-request isomorphic-fetch isomorphic-form-data


### PR DESCRIPTION
found a few `404`s ripping off this doc site for [`@esri/hub.js`](https://github.com/Esri/hub.js/pull/12)