### PR TITLE
fix(IItem): make id and owner the only required properties of IItem

### DIFF
--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -152,11 +152,11 @@ export interface IFont {
  */
 export interface IItem {
   id?: string;
-  owner: string;
-  title: string;
-  type: string;
-  tags: string[];
-  typeKeywords: string[];
+  owner?: string;
+  title?: string;
+  type?: string;
+  tags?: string[];
+  typeKeywords?: string[];
   description?: string;
   snippet?: string;
   documentation?: string;

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -24,7 +24,7 @@ export interface IItemIdRequestOptions extends IUserRequestOptions {
    */
   id: string;
   /**
-   * Item owner username (by default authentication session will be used).
+   * Item owner username. If not present, `authentication.username` is utilized.
    */
   owner?: string;
 }
@@ -34,10 +34,6 @@ export interface IItemJsonDataRequestOptions extends IItemIdRequestOptions {
    * JSON object to store
    */
   data: any;
-  /**
-   * Item owner username (by default authentication session will be used).
-   */
-  owner?: string;
 }
 
 export interface IItemResourceRequestOptions extends IItemIdRequestOptions {
@@ -55,11 +51,11 @@ export interface IItemResourceRequestOptions extends IItemIdRequestOptions {
 export interface IItemCrudRequestOptions extends IUserRequestOptions {
   item: IItem;
   /**
-   * Item owner username (by default authentication session will be used).
+   * The owner of the item. If this property is not present, `item.owner` will be passed, or lastly `authentication.username`.
    */
   owner?: string;
   /**
-   * Optional folder to house the item
+   * Folder to house the item.
    */
   folder?: string;
 }
@@ -135,7 +131,10 @@ export function searchItems(
 export function createItemInFolder(
   requestOptions: IItemCrudRequestOptions
 ): Promise<any> {
-  const owner = requestOptions.owner || requestOptions.authentication.username;
+  const owner =
+    requestOptions.owner ||
+    requestOptions.item.owner ||
+    requestOptions.authentication.username;
   const baseUrl = `${getPortalUrl(requestOptions)}/content/users/${owner}`;
   let url = `${baseUrl}/addItem`;
 

--- a/packages/arcgis-rest-items/test/items.test.ts
+++ b/packages/arcgis-rest-items/test/items.test.ts
@@ -215,7 +215,6 @@ describe("search", () => {
           }
         }
       };
-      // why not just use item.owner??
       createItem({
         item: fakeItem,
         owner: "dbouwman",
@@ -231,6 +230,98 @@ describe("search", () => {
           expect(options.body).toContain("f=json");
           expect(options.body).toContain(encodeParam("token", "fake-token"));
           expect(options.body).toContain("owner=dbouwman");
+          // ensure the array props are serialized into strings
+          expect(options.body).toContain(
+            encodeParam("typeKeywords", "fake, kwds")
+          );
+          expect(options.body).toContain(
+            encodeParam("tags", "fakey, mcfakepants")
+          );
+          expect(options.body).toContain(
+            encodeParam("properties", JSON.stringify(fakeItem.properties))
+          );
+
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should create an item without an explicit owner", done => {
+      fetchMock.once("*", ItemSuccessResponse);
+      const fakeItem = {
+        title: "my fake item",
+        owner: "dbouwman",
+        description: "yep its fake",
+        snipped: "so very fake",
+        type: "Web Mapping Application",
+        typeKeywords: ["fake", "kwds"],
+        tags: ["fakey", "mcfakepants"],
+        properties: {
+          key: "somevalue"
+        }
+      };
+      createItem({
+        item: fakeItem,
+        ...MOCK_USER_REQOPTS
+      })
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/addItem"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain("f=json");
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          expect(options.body).toContain("owner=dbouwman");
+          // ensure the array props are serialized into strings
+          expect(options.body).toContain(
+            encodeParam("typeKeywords", "fake, kwds")
+          );
+          expect(options.body).toContain(
+            encodeParam("tags", "fakey, mcfakepants")
+          );
+          expect(options.body).toContain(
+            encodeParam("properties", JSON.stringify(fakeItem.properties))
+          );
+
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should create an item with only a username from auth", done => {
+      fetchMock.once("*", ItemSuccessResponse);
+      const fakeItem = {
+        title: "my fake item",
+        description: "yep its fake",
+        snipped: "so very fake",
+        type: "Web Mapping Application",
+        typeKeywords: ["fake", "kwds"],
+        tags: ["fakey", "mcfakepants"],
+        properties: {
+          key: "somevalue"
+        }
+      };
+      // why not just use item.owner??
+      createItem({
+        item: fakeItem,
+        ...MOCK_USER_REQOPTS
+      })
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/addItem"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain("f=json");
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          // expect(options.body).toContain("owner=casey");
           // ensure the array props are serialized into strings
           expect(options.body).toContain(
             encodeParam("typeKeywords", "fake, kwds")

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -53,17 +53,17 @@ export interface IRequestOptions {
   authentication?: IAuthenticationManager;
 
   /**
-   * Base url for the portal you want to make the request to. Defaults to 'https://www.arcgis.com/sharing/rest'
+   * Base url for the portal you want to make the request to. Defaults to 'https://www.arcgis.com/sharing/rest'.
    */
   portal?: string;
 
   /**
-   * The implementation of `fetch` to use. Defaults to a global `fetch`
+   * The implementation of `fetch` to use. Defaults to a global `fetch`.
    */
   fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 
   /**
-   * If the length of a GET request's URL exceeds `maxUrlLength` the request will use POST instead
+   * If the length of a GET request's URL exceeds `maxUrlLength` the request will use POST instead.
    */
   maxUrlLength?: number;
 }


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-common-types

ISSUES CLOSED: #171