### PR TITLE
have travis test on Node 8/10 (instead of 6/8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 notifications:
   email: false
 node_js:
-  - "6"
   - "8"
+  - "10"
 cache:
   directories: # Cache dependencies
     - node_modules


### PR DESCRIPTION
6.x moved into [maintenance mode](https://medium.com/the-node-js-collection/april-2018-release-updates-from-the-node-js-project-71687e1f7742) on 4/30/2018
