### PR TITLE
make sure methods w/ union types pass through *all* requestOptions

### DIFF
--- a/packages/arcgis-rest-geocoder/src/geocoder.ts
+++ b/packages/arcgis-rest-geocoder/src/geocoder.ts
@@ -191,9 +191,8 @@ export interface IGetGeocodeServiceResponse {
  */
 export function geocode(
   address: string | IGeocodeRequestOptions
-  // requestOptions?: IGeocodeRequestOptions
 ): Promise<IGeocodeResponse> {
-  const options: IGeocodeRequestOptions = {
+  let options: IGeocodeRequestOptions = {
     endpoint: worldGeocoder,
     params: {}
   };
@@ -201,8 +200,11 @@ export function geocode(
   if (typeof address === "string") {
     options.params.singleLine = address;
   } else {
-    options.params = { ...address.params };
     options.endpoint = address.endpoint || worldGeocoder;
+    options = {
+      ...options,
+      ...address
+    };
   }
 
   // add spatialReference property to individual matches

--- a/packages/arcgis-rest-geocoder/src/geocoder.ts
+++ b/packages/arcgis-rest-geocoder/src/geocoder.ts
@@ -250,7 +250,7 @@ export function suggest(
 
   // is this the most concise way to mixin these optional parameters?
   if (requestOptions && requestOptions.params) {
-    options.params = { ...requestOptions.params };
+    options.params = requestOptions.params;
   }
 
   if (requestOptions && requestOptions.magicKey) {

--- a/packages/arcgis-rest-geocoder/test/geocoder.test.ts
+++ b/packages/arcgis-rest-geocoder/test/geocoder.test.ts
@@ -112,6 +112,34 @@ describe("geocode", () => {
       });
   });
 
+  it("should pass through all requestOptions when making a geocoding request", done => {
+    fetchMock.once("*", FindAddressCandidates);
+
+    geocode({
+      endpoint: customGeocoderUrl,
+      params: {
+        outSr: 3857,
+        address: "380 New York St",
+        postal: 92373
+      },
+      httpMethod: "GET"
+    })
+      .then(response => {
+        expect(fetchMock.called()).toEqual(true);
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/findAddressCandidates?f=json&outSr=3857&address=380%20New%20York%20St&postal=92373"
+        );
+        expect(options.method).toBe("GET");
+        // the only property this lib tacks on
+        expect(response.spatialReference.wkid).toEqual(4326);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
   it("should make a reverse geocoding request", done => {
     fetchMock.once("*", ReverseGeocode);
 

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -102,18 +102,20 @@ export interface ISearchResult {
 export function searchItems(
   search: string | ISearchRequestOptions
 ): Promise<ISearchResult> {
-  const options: ISearchRequestOptions = {
+  let options: ISearchRequestOptions = {
     httpMethod: "GET",
     params: {}
   };
 
   if (typeof search === "string") {
-    options.params = { q: search };
+    options.params.q = search;
   } else {
     options.params = search.searchForm;
-    if (search.authentication) {
-      options.authentication = search.authentication;
-    }
+    // mixin, giving user supplied requestOptions precedence
+    options = {
+      ...options,
+      ...search
+    };
   }
 
   // construct the search url

--- a/packages/arcgis-rest-items/test/items.test.ts
+++ b/packages/arcgis-rest-items/test/items.test.ts
@@ -82,6 +82,34 @@ describe("search", () => {
       });
   });
 
+  it("should pass through other requestOptions at the same time", done => {
+    fetchMock.once("*", SearchResponse);
+
+    searchItems({
+      searchForm: {
+        q: "DC AND typekeywords:hubSiteApplication",
+        num: 12,
+        start: 22,
+        sortField: "title",
+        sortDir: "desc"
+      },
+      httpMethod: "POST"
+    })
+      .then(response => {
+        expect(fetchMock.called()).toEqual(true);
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual("https://www.arcgis.com/sharing/rest/search");
+        expect(options.body).toContain(
+          "q=DC%20AND%20typekeywords%3AhubSiteApplication&num=12&start=22&sortField=title&sortDir=desc"
+        );
+        expect(options.method).toBe("POST");
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
   it("should return an item by id", done => {
     fetchMock.once("*", ItemResponse);
 


### PR DESCRIPTION
@noahmulfinger noticed `searchItems()` in #183. `geocode()` had the same problem.