### PR TITLE
more concise .umd filenames

### DIFF
--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "description": "Authentication helpers for @esri/arcgis-rest-*.",
   "main": "dist/node/index.js",
-  "browser": "dist/umd/arcgis-rest-auth.umd.js",
+  "browser": "dist/umd/auth.umd.js",
   "module": "dist/esm/index.js",
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/arcgis-rest-common-types/package.json
+++ b/packages/arcgis-rest-common-types/package.json
@@ -26,6 +26,10 @@
       "name": "Patrick Arlt",
       "email": "parlt@esri.com",
       "url": "http://patrickarlt.com/"
+    },
+    {
+      "name": "Jeff Jacobson",
+      "url": "http://github.com/jeffjacobson"
     }
   ],
   "bugs": {

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "description": "Feature service helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
-  "browser": "dist/umd/arcgis-rest-feature-service.umd.js",
+  "browser": "dist/umd/feature-service.umd.js",
   "module": "dist/esm/index.js",
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/arcgis-rest-geocoder/package.json
+++ b/packages/arcgis-rest-geocoder/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "description": "Geocoding helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
-  "browser": "dist/umd/arcgis-rest-geocoder.umd.js",
+  "browser": "dist/umd/geocoder.umd.js",
   "module": "dist/esm/index.js",
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/arcgis-rest-groups/package.json
+++ b/packages/arcgis-rest-groups/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "description": "Portal Group helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
-  "browser": "dist/umd/arcgis-rest-groups.umd.js",
+  "browser": "dist/umd/groups.umd.js",
   "module": "dist/esm/index.js",
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/arcgis-rest-items/package.json
+++ b/packages/arcgis-rest-items/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "description": "Portal Item helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
-  "browser": "dist/umd/arcgis-rest-items.umd.js",
+  "browser": "dist/umd/items.umd.js",
   "module": "dist/esm/index.js",
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "description": "Common methods and utilities for @esri/arcgis-rest-* packages.",
   "main": "dist/node/index.js",
-  "browser": "dist/umd/arcgis-rest-request.umd.js",
+  "browser": "dist/umd/request.umd.js",
   "module": "dist/esm/index.js",
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/arcgis-rest-users/package.json
+++ b/packages/arcgis-rest-users/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "description": "Portal user helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
-  "browser": "dist/umd/arcgis-rest-users.umd.js",
+  "browser": "dist/umd/users.umd.js",
   "module": "dist/esm/index.js",
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/umd-base-profile.js
+++ b/umd-base-profile.js
@@ -63,8 +63,8 @@ const globals = packageNames.reduce((globals, p) => {
 export default {
   input: "./src/index.ts",
   output: {
-    file: `./dist/umd/${name.replace("@esri/", "")}.umd.js`,
-    sourcemap: `./dist/umd/${name.replace("@esri/", "")}.umd.js.map`,
+    file: `./dist/umd/${name.replace("@esri/arcgis-rest-", "")}.umd.js`,
+    sourcemap: true,
     banner: copyright,
     format: "umd",
     name: moduleName,

--- a/umd-production-profile.js
+++ b/umd-production-profile.js
@@ -4,7 +4,6 @@ import filesize from "rollup-plugin-filesize";
 
 // use umd.min.js
 config.output.file = config.output.file.replace(".umd.", ".umd.min.");
-config.output.sourcemap = config.output.sourcemap.replace(".umd.", ".umd.min.");
 
 config.plugins.push(filesize())
 config.plugins.push(uglify({


### PR DESCRIPTION
remove `arcgis-rest-` from built .umds

old: https://unpkg.com/@esri/arcgis-rest-request/dist/umd/arcgis-rest-request.umd.js

new: https://unpkg.com/@esri/arcgis-rest-request/dist/umd/request.umd.js