### PR TITLE
fix(fetch): set credentials: 'same-origin' in fetch options 

### DIFF
--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -154,7 +154,9 @@ export function request(
   };
 
   const fetchOptions: RequestInit = {
-    method: httpMethod
+    method: httpMethod,
+    // ensures behavior mimics XMLHttpRequest. needed to support sending IWA cookies
+    credentials: "same-origin"
   };
 
   return (authentication ? authentication.getToken(url) : Promise.resolve(""))


### PR DESCRIPTION
to support Integrated Windows Authentication.

ref: https://github.com/Esri/torii-provider-arcgis/pull/43

AFFECTS PACKAGES:
@esri/arcgis-rest-request