### PR TITLE
fix(umd): strip outdated umd files from npm packages

### DIFF
--- a/docs/acetate.config.js
+++ b/docs/acetate.config.js
@@ -199,7 +199,7 @@ module.exports = function(acetate) {
   acetate.helper("cdnUrl", function(context, package) {
     return `https://unpkg.com/${
       package.name
-    }@${package.version}/dist/umd/${package.name.split("/")[1]}.umd.js`;
+    }@${package.version}/dist/umd/${package.name.replace("arcgis-rest-", "")}.umd.js`;
   });
 
   acetate.helper("npmInstallCmd", function(context, package) {


### PR DESCRIPTION
no code is necessary to resolve the problem reported in #198. we just need to push something into `master` to convince lerna to help us publish a `v1.2.1` release.

ISSUES CLOSED: #198 

AFFECTS PACKAGES:
@esri/arcgis-rest-request
@esri/arcgis-rest-feature-service
@esri/arcgis-rest-geocoder
@esri/arcgis-rest-groups
@esri/arcgis-rest-items