### PR TITLE
Handle missing tags and typeKeywords properties

### DIFF
--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -384,8 +384,9 @@ function serializeItem(item: IItem): any {
   // create a clone so we're not messing with the original
   const clone = JSON.parse(JSON.stringify(item));
   // join keywords and tags...
-  clone.typeKeywords = item.typeKeywords.join(", ");
-  clone.tags = item.tags.join(", ");
+  const { typeKeywords=[], tags=[] } = item;
+  clone.typeKeywords = typeKeywords.join(", ");
+  clone.tags = tags.join(", ");
   // convert .data to .text
   if (clone.data) {
     clone.text = JSON.stringify(clone.data);

--- a/packages/arcgis-rest-items/test/items.test.ts
+++ b/packages/arcgis-rest-items/test/items.test.ts
@@ -368,6 +368,45 @@ describe("search", () => {
         });
     });
 
+    it("should create an item with no tags or typeKeywords", done => {
+      fetchMock.once("*", ItemSuccessResponse);
+      const fakeItem = {
+        title: "my fake item",
+        description: "yep its fake",
+        snipped: "so very fake",
+        type: "Web Mapping Application",
+        properties: {
+          key: "somevalue"
+        }
+      };
+      createItem({
+        item: fakeItem,
+        ...MOCK_USER_REQOPTS
+      })
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/addItem"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain("f=json");
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          expect(options.body).toContain(
+            encodeParam("type", "Web Mapping Application")
+          );
+          // ensure the array props are serialized into strings
+          expect(options.body).toContain(
+            encodeParam("properties", JSON.stringify(fakeItem.properties))
+          );
+
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
     it("should create an item in a folder", done => {
       fetchMock.once("*", ItemSuccessResponse);
       const fakeItem = {


### PR DESCRIPTION
Hi all. I'm just getting started using `arcgis-rest-js` to automate some tooling (let CI upload new WAB Widgets to our Portal upon successful PR merge) and got snagged on a small issue: [The documentation](https://esri.github.io/arcgis-rest-js/api/common-types/IItem/) shows the `typeKeywords` and `tags` properties of an `IItem` to be optional, however the serializer method expects them to be an array. If they are omitted from an `item` object a `Cannot read property 'join' of undefined` error will be thrown ([ex](https://stackblitz.com/edit/js-pmfwlq?embed=1&file=index.js&hideExplorer=1&hideNavigation=1)).  I think this fix would resolve the issue. I can generate a test if need-be.

Is there any particular reason we have `strictNullChecks: false` in the `tsconfig.json`? I believe this would avoid such issues (although I admit to being very green to TypeScript, so I may be missing something).

Btw, digging the library so far! 💯 