### PR TITLE
feat(shareItem): add a function to share an item as the item owner

### DIFF
--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -60,6 +60,25 @@ export interface IItemCrudRequestOptions extends IUserRequestOptions {
   folder?: string;
 }
 
+export interface IItemShareRequestOptions extends IItemIdRequestOptions {
+  /**
+   * A comma-separated list of group IDs with which the item will be shared.
+   */
+  groups?: string;
+  /**
+   * If `true`, this item will be shared with everyone, for example, it will be publicly accessible. If explicitly set to false, the item will not be shared with the public.
+   */
+  everyone?: boolean;
+  /**
+   * If `true`, this item will be shared with the organization. If set to false, the item will not be shared with the organization.
+   */
+  org?: boolean;
+  /**
+   * Set to `true` when the item will be shared with groups with item update capability so that any member of such groups can update the item that is shared with them.
+   */
+  confirmItemControl?: boolean;
+}
+
 // this interface still needs to be docced
 export interface ISearchRequest extends IPagingParams {
   q: string;
@@ -374,6 +393,25 @@ export function removeItemResource(
 }
 
 /**
+ * Share an item as the item owner
+ * @param requestOptions - Options for the request
+ * @return A Promise to share an item
+ */
+export function shareItem(
+  requestOptions: IItemShareRequestOptions
+): Promise<any> {
+  const owner = requestOptions.owner || requestOptions.authentication.username;
+  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
+    requestOptions.id
+  }/share`;
+
+  // this is a POST only API
+  requestOptions.httpMethod = "POST";
+
+  return request(url, requestOptions);
+}
+
+/**
  * Serialize an item into a json format accepted by the Portal API
  * for create and update operations
  *
@@ -384,7 +422,7 @@ function serializeItem(item: IItem): any {
   // create a clone so we're not messing with the original
   const clone = JSON.parse(JSON.stringify(item));
   // join keywords and tags...
-  const { typeKeywords=[], tags=[] } = item;
+  const { typeKeywords = [], tags = [] } = item;
   clone.typeKeywords = typeKeywords.join(", ");
   clone.tags = tags.join(", ");
   // convert .data to .text

--- a/packages/arcgis-rest-items/test/items.test.ts
+++ b/packages/arcgis-rest-items/test/items.test.ts
@@ -1097,6 +1097,7 @@ describe("search", () => {
       shareItem({
         id: "3ef",
         owner: "haoliang",
+        everyone: true,
         ...MOCK_USER_REQOPTS
       })
         .then(response => {
@@ -1106,6 +1107,7 @@ describe("search", () => {
           );
           expect(options.method).toBe("POST");
           expect(options.body).toContain(encodeParam("f", "json"));
+          expect(options.body).toContain(encodeParam("everyone", "true"));
           expect(options.body).toContain(encodeParam("token", "fake-token"));
           done();
         })
@@ -1118,6 +1120,7 @@ describe("search", () => {
       fetchMock.once("*", ItemSuccessResponse);
       shareItem({
         id: "3ef",
+        confirmItemControl: false,
         ...MOCK_USER_REQOPTS
       })
         .then(response => {
@@ -1127,6 +1130,9 @@ describe("search", () => {
           );
           expect(options.method).toBe("POST");
           expect(options.body).toContain(encodeParam("f", "json"));
+          expect(options.body).toContain(
+            encodeParam("confirmItemControl", "false")
+          );
           expect(options.body).toContain(encodeParam("token", "fake-token"));
           done();
         })

--- a/packages/arcgis-rest-items/test/items.test.ts
+++ b/packages/arcgis-rest-items/test/items.test.ts
@@ -12,6 +12,7 @@ import {
   getItemResources,
   updateItemResource,
   removeItemResource,
+  shareItem,
   ISearchRequestOptions
 } from "../src/index";
 
@@ -206,6 +207,7 @@ describe("search", () => {
           fail(e);
         });
     });
+
     it("should return an item data by id using a token", done => {
       fetchMock.once("*", ItemDataResponse);
 
@@ -531,6 +533,7 @@ describe("search", () => {
           fail(e);
         });
     });
+
     it("should add data to an item", done => {
       fetchMock.once("*", ItemSuccessResponse);
       const fakeData = {
@@ -1081,6 +1084,49 @@ describe("search", () => {
           expect(options.body).toContain(
             encodeParam("resource", "image/banner.png")
           );
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should share an item", done => {
+      fetchMock.once("*", ItemSuccessResponse);
+      shareItem({
+        id: "3ef",
+        owner: "haoliang",
+        ...MOCK_USER_REQOPTS
+      })
+        .then(response => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/haoliang/items/3ef/share"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain(encodeParam("f", "json"));
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should share an item, no owner passed", done => {
+      fetchMock.once("*", ItemSuccessResponse);
+      shareItem({
+        id: "3ef",
+        ...MOCK_USER_REQOPTS
+      })
+        .then(response => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/share"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain(encodeParam("f", "json"));
           expect(options.body).toContain(encodeParam("token", "fake-token"));
           done();
         })


### PR DESCRIPTION
This function covers the API
https://developers.arcgis.com/rest/users-groups-and-items/share-item-as-item-owner-.htm

AFFECTS PACKAGES:
@esri/arcgis-rest-items