### PR TITLE
fix title in geocoder readme

### DIFF
--- a/packages/arcgis-rest-geocoder/README.md
+++ b/packages/arcgis-rest-geocoder/README.md
@@ -7,7 +7,7 @@
 [travis-img]: https://img.shields.io/travis/Esri/arcgis-rest-js/master.svg?style=flat-square
 [travis-url]: https://travis-ci.org/Esri/arcgis-rest-js
 
-# @esri/arcgis-rest-groups
+# @esri/arcgis-rest-geocoder
 
 > Geocoding helpers for [`@esri/arcgis-rest-request`](https://github.com/Esri/arcgis-rest-js).
 


### PR DESCRIPTION
![broken badge](https://img.shields.io/npm/v/%40esri%2Farcgis-rest-request.svg)

for the problem above, see https://github.com/badges/shields/issues/1732