### PR TITLE
fix(amd): add output.amd.id to rollup.config

### DIFF
--- a/docs/src/guides/amd-requirejs-dojo.md
+++ b/docs/src/guides/amd-requirejs-dojo.md
@@ -7,3 +7,33 @@ group: 1-get-started
 ---
 
 # Get Started with ArcGIS REST JS and AMD
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>ArcGIS REST JS</title>
+</head>
+<body>
+  Open your console to see the demo.
+</body>
+  <!-- require polyfills for fetch and Promise from https://polyfill.io -->
+  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=es5,Promise,fetch"></script>
+
+  <!-- The ArcGIS API for JavaScript includes its own AMD loader -->
+  <script src="https://js.arcgis.com/4.7/"></script>
+
+  <!-- require ArcGIS REST JS from https://unpkg.com -->
+  <script src="{% cdnUrl data.typedoc | findPackage('@esri/arcgis-rest-request') %}"></script>
+
+  <script>
+    require(["@esri/arcgis-rest-request"], function(arcgisRequest) {
+      arcgisRequest.request("https://www.arcgis.com/sharing/rest/info").then(response => {
+        console.log(response);
+      });
+    });
+  </script>
+</html>
+```

--- a/umd-base-profile.js
+++ b/umd-base-profile.js
@@ -69,7 +69,10 @@ export default {
     format: "umd",
     name: moduleName,
     globals,
-    extend: true // causes this module to extend the global specified by `moduleName`
+    extend: true, // causes this module to extend the global specified by `moduleName`
+    amd: {
+      id: `${name}`
+    }
   },
   context: "window",
   external: packageNames,


### PR DESCRIPTION
yesterday i was scratching my head for quite awhile trying to reference this lib in a dead simple application alongside the ArcGIS API for JavaScript.

my research indicated that UMD's register themselves automatically as _anonymous_ AMD modules when a loader is detected, but if that was indeed happening, i sure couldn't figure out how to reference to them.

declaring an explicit [`amd.id`](https://rollupjs.org/guide/en#big-list-of-options) in the rollup build makes the following possible.

```js
require(["@esri/arcgis-rest-request"/*, etc. */], function(arcgis/*, etc. */) {
  arcgis.request(url).then(response => {
      console.log(response);
  });
});
```