### PR TITLE
fix(auth): use www.arcgis.com consistently

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -308,7 +308,7 @@ export class UserSession implements IAuthenticationManager {
       locale
     }: IOauth2Options = {
       ...{
-        portal: "https://arcgis.com/sharing/rest",
+        portal: "https://www.arcgis.com/sharing/rest",
         duration: 20160,
         popup: true,
         state: options.clientId,
@@ -371,7 +371,7 @@ export class UserSession implements IAuthenticationManager {
   /* istanbul ignore next */
   static completeOAuth2(options: IOauth2Options, win: any = window) {
     const { portal, clientId }: IOauth2Options = {
-      ...{ portal: "https://arcgis.com/sharing/rest" },
+      ...{ portal: "https://www.arcgis.com/sharing/rest" },
       ...options
     };
 

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -425,7 +425,7 @@ describe("UserSession", () => {
         });
 
       expect(MockWindow.open).toHaveBeenCalledWith(
-        "https://arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId123&response_type=token&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=abc123&locale=",
+        "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId123&response_type=token&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=abc123&locale=",
         "oauth-window",
         "height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes"
       );
@@ -457,7 +457,7 @@ describe("UserSession", () => {
       });
 
       expect(MockWindow.open).toHaveBeenCalledWith(
-        "https://arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId123&response_type=token&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=clientId123&locale=fr",
+        "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId123&response_type=token&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=clientId123&locale=fr",
         "oauth-window",
         "height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes"
       );
@@ -488,7 +488,7 @@ describe("UserSession", () => {
       );
 
       expect(MockWindow.location.href).toBe(
-        "https://arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId123&response_type=token&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=clientId123&locale="
+        "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId123&response_type=token&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=clientId123&locale="
       );
     });
   });


### PR DESCRIPTION
`www` _4 lyfe_.

AFFECTS PACKAGES:
@esri/arcgis-rest-auth

ISSUES CLOSED: #223