### PR TITLE
convert JSAPI credentials to a _valid_ UserSession 

### DIFF
--- a/demos/jsapi-integration/index.html
+++ b/demos/jsapi-integration/index.html
@@ -22,10 +22,10 @@
   <script src="node_modules/@esri/arcgis-rest-auth/dist/umd/auth.umd.js"></script>
   <script src="node_modules/@esri/arcgis-rest-items/dist/umd/items.umd.js"></script>
 
-  <!-- 
+  <!--
     NOTE: rather than include the ArcGIS API for JavaScript via a <script> tag
     typically you would using something like https://github.com/Esri/esri-loader
-    to lazy-load the API _after_ you had used the light-weight arcgis-rest-js 
+    to lazy-load the API _after_ you had used the light-weight arcgis-rest-js
     libraries above to log in and fetch some data (see NOTE below)
   -->
   <script src="https://js.arcgis.com/4.7/"></script>
@@ -58,7 +58,7 @@
           esriId, MapView, WebMap
         ) {
             // pass the authenticated session over to the JSAPI Identity Manager
-            esriId.registerToken(session.getCredential());
+            esriId.registerToken(session.toCredential());
 
             // dig the webmap id out of the response
             var webmap = new WebMap({

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -534,7 +534,7 @@ export class UserSession implements IAuthenticationManager {
    */
   static fromCredential(credential: ICredential) {
     return new UserSession({
-      portal: credential.server,
+      portal: credential.server + `/sharing/rest`,
       token: credential.token,
       username: credential.userId,
       tokenExpires: new Date(credential.expires)

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -707,7 +707,7 @@ describe("UserSession", () => {
   describe("to/fromCredential()", () => {
     const MOCK_CREDENTIAL: ICredential = {
       expires: TOMORROW.getTime(),
-      server: "https://www.arcgis.com/sharing/rest",
+      server: "https://www.arcgis.com",
       ssl: true,
       token: "token",
       userId: "jsmith"
@@ -727,7 +727,11 @@ describe("UserSession", () => {
       });
 
       const creds = session.toCredential();
-      expect(creds).toEqual(MOCK_CREDENTIAL);
+      expect(creds.userId).toEqual("jsmith");
+      expect(creds.server).toEqual("https://www.arcgis.com/sharing/rest");
+      expect(creds.ssl).toEqual(true);
+      expect(creds.token).toEqual("token");
+      expect(creds.expires).toEqual(TOMORROW.getTime());
     });
 
     it("should create a UserSession from a credential", () => {


### PR DESCRIPTION
resolves #208 once and for all (i hope)

tested against www.arcgis.com _and_ ArcGIS Enterprise.