### PR TITLE
throw NOT_FEDERATED error when no 'owningSystemUrl' is found

### DIFF
--- a/docs/src/api/_package.html
+++ b/docs/src/api/_package.html
@@ -4,7 +4,7 @@
 <h2 class="font-size--1 trailer-half">npm install:</h2>
 <pre><code>{% npmInstallCmd pkg %}</code></pre>
 <h2 class="font-size--1 trailer-half">CDN url:</h2>
-<pre><code>{% cdnUrl pkg %}</code></pre>
+<pre><code>{% cdnUrl pkg %}.js</code></pre>
 <hr class="leader-half trailer-half">
 <ul class="list-plain package-contents">
 {% for declaration in declarations %}

--- a/docs/src/api/index.html
+++ b/docs/src/api/index.html
@@ -11,7 +11,7 @@ layout: "api/_layout:content"
   <h3 class="font-size--1 trailer-half">npm install:</h2>
   <pre><code>{% npmInstallCmd package.pkg %}</code></pre>
   <h3 class="font-size--1 trailer-half">CDN url:</h2>
-  <pre><code>{% cdnUrl package.pkg %}</code></pre>
+  <pre><code>{% cdnUrl package.pkg %}.js</code></pre>
   <hr class="leader-half trailer-half">
   <ul class="list-plain package-contents">
   {% for declaration in package.declarations %}

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -662,17 +662,19 @@ export class UserSession implements IAuthenticationManager {
 
     this._pendingTokenRequests[root] = request(`${root}/rest/info`)
       .then((response: any) => {
-        // a stand-alone instance of ArcGIS Server won't advertise federation at all
-        return response.owningSystemUrl
-          ? response.owningSystemUrl
-          : "https://foo.bar";
+        return response.owningSystemUrl;
       })
       .then(owningSystemUrl => {
         /**
-         * if this server is not owned by this portal bail out with an error
-         * since we know we wont be able to generate a token
+         * if this server is not owned by this portal or the stand-alone
+         * instance of ArcGIS Server doesn't advertise federation,
+         * bail out with an error since we know we wont
+         * be able to generate a token
          */
-        if (!new RegExp(owningSystemUrl).test(this.portal)) {
+        if (
+          !owningSystemUrl ||
+          !new RegExp(owningSystemUrl).test(this.portal)
+        ) {
           throw new ArcGISAuthError(
             `${url} is not federated with ${this.portal}.`,
             "NOT_FEDERATED"

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -662,7 +662,10 @@ export class UserSession implements IAuthenticationManager {
 
     this._pendingTokenRequests[root] = request(`${root}/rest/info`)
       .then((response: any) => {
-        return response.owningSystemUrl;
+        // a stand-alone instance of ArcGIS Server won't advertise federation at all
+        return response.owningSystemUrl
+          ? response.owningSystemUrl
+          : "https://foo.bar";
       })
       .then(owningSystemUrl => {
         /**

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -263,6 +263,37 @@ describe("UserSession", () => {
           done();
         });
     });
+
+    it("should throw an ArcGISAuthError when no owning system is advertised", done => {
+      const session = new UserSession({
+        clientId: "id",
+        token: "token",
+        refreshToken: "refresh",
+        tokenExpires: YESTERDAY
+      });
+
+      fetchMock.post("https://gisservices.city.gov/public/rest/info", {
+        currentVersion: 10.51,
+        fullVersion: "10.5.1.120",
+        authInfo: {
+          isTokenBasedSecurity: true,
+          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken"
+        }
+      });
+
+      session
+        .getToken(
+          "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query"
+        )
+        .catch(e => {
+          expect(e.name).toEqual(ErrorTypes.ArcGISAuthError);
+          expect(e.code).toEqual("NOT_FEDERATED");
+          expect(e.message).toEqual(
+            "NOT_FEDERATED: https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query is not federated with https://www.arcgis.com/sharing/rest."
+          );
+          done();
+        });
+    });
   });
 
   describe(".refreshSession()", () => {


### PR DESCRIPTION
fix to ensure we throw an error when a developer attempts to fetch a token for a standalone instance of ArcGIS Server that doesn't advertise an `owningSystemUrl` (like [this one](http://sampleserver6.arcgisonline.com/arcgis/rest/info?f=json)).

STR:
```js
const session = new arcgisRest.UserSession({
  username: "johnq",
  password: "public"
});

session.getToken("http://sampleserver6.arcgisonline.com/arcgis/rest/services/")
  .catch(err => {
    err.code // "NOT_FEDERATED"
  })
```