### PR TITLE
fix(GET): switch to POST for requests > 2048 characters by default

### DIFF
--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -100,7 +100,7 @@ export interface IQueryFeaturesResponse extends IFeatureSet {
  * getFeature({
  *   url,
  *   id: 42
- * };)
+ * })
  *   .then(feature => {
  *     console.log(feature.attributes.FID); // 42
  *   });
@@ -133,9 +133,9 @@ export function getFeature(
  * queryFeatures({
  *   url,
  *   where: "STATE_NAME = 'Alaska"
- * };)
+ * })
  *   .then(feature => {
- *     console.log(feature.attributes.FID); // 42
+ *     console.log(response.features.length); // 1
  *   });
  * ```
  *

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -110,6 +110,7 @@ export function request(
 ): Promise<any> {
   const options: IRequestOptions = {
     httpMethod: "POST",
+    maxUrlLength: 2048,
     fetch,
     ...requestOptions
   };


### PR DESCRIPTION
use the maximum value supported by IE as the default maximum length of a GET request.

i think it makes sense to do this in `request`. another option would be to set the value in methods that are specifically likely to overrun the limit (like `queryFeatures`).

AFFECTS PACKAGES:
@esri/arcgis-rest-feature-service
@esri/arcgis-rest-request