### PR TITLE
fix(enterprise): ensure a brand new token can be generated for servers federated with ArcGIS Enterprise

### DIFF
--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -19,7 +19,7 @@
     "@esri/arcgis-rest-request": "^1.2.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.4.1",
+    "@esri/arcgis-rest-common-types": "^1.4.2",
     "@esri/arcgis-rest-request": "^1.4.2"
   },
   "scripts": {

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -19,7 +19,7 @@
     "@esri/arcgis-rest-request": "^1.2.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.4.1",
+    "@esri/arcgis-rest-common-types": "^1.4.2",
     "@esri/arcgis-rest-request": "^1.4.2"
   },
   "scripts": {

--- a/packages/arcgis-rest-geocoder/package.json
+++ b/packages/arcgis-rest-geocoder/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.4.2",
-    "@esri/arcgis-rest-common-types": "^1.4.1",
+    "@esri/arcgis-rest-common-types": "^1.4.2",
     "@esri/arcgis-rest-request": "^1.4.2"
   },
   "scripts": {

--- a/packages/arcgis-rest-groups/package.json
+++ b/packages/arcgis-rest-groups/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.4.2",
-    "@esri/arcgis-rest-common-types": "^1.4.1",
+    "@esri/arcgis-rest-common-types": "^1.4.2",
     "@esri/arcgis-rest-request": "^1.4.2"
   },
   "scripts": {

--- a/packages/arcgis-rest-items/package.json
+++ b/packages/arcgis-rest-items/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.4.2",
-    "@esri/arcgis-rest-common-types": "^1.4.1",
+    "@esri/arcgis-rest-common-types": "^1.4.2",
     "@esri/arcgis-rest-request": "^1.4.2"
   },
   "scripts": {

--- a/packages/arcgis-rest-sharing/package.json
+++ b/packages/arcgis-rest-sharing/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.4.2",
-    "@esri/arcgis-rest-common-types": "^1.4.1",
+    "@esri/arcgis-rest-common-types": "^1.4.2",
     "@esri/arcgis-rest-request": "^1.4.2"
   },
   "files": [

--- a/packages/arcgis-rest-users/package.json
+++ b/packages/arcgis-rest-users/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.4.2",
-    "@esri/arcgis-rest-common-types": "^1.4.1",
+    "@esri/arcgis-rest-common-types": "^1.4.2",
     "@esri/arcgis-rest-request": "^1.4.2"
   },
   "scripts": {


### PR DESCRIPTION
> this PR description has been edited _heavily_. previous drafts are available from the <kbd>edited &#9660;</kbd> dropdown 

proposed fix to enable the generation of tokens for ArcGIS Data Store content associated with ArcGIS Enterprise.

the tweak i'm proposing ~~generalizes the comparison of the two relevant urls and gives a ✅ as long as the portal and service url share the same `sub.domain.com`.~~ introspects the current session to see whether a token is already available. if not, and both username/password are present (indicating that the session was _not_ instantiated for an OAuth flow), then a request to fetch one manually is fired.

STR:
```js
// real portal instance, fake username and password
const session = new UserSession({
  username: "c@sey",
  password: "jones",
  portal: "https://portalhostds.ags.esri.com/gis/sharing/rest"
});

session.getToken("https://serverhostds.ags.esri.com/gis/rest/services/Hosted/restjs/FeatureServer")
  .then(token => {
    console.log(token);
  })
```

AFFECTS PACKAGES:
@esri/arcgis-rest-auth

ISSUES CLOSED: #161

paging @slibby in the hopes that he can provide a sanity check.