### PR TITLE
Fix peer dependency name

### DIFF
--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -15,7 +15,7 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-common-types": "^1.2.1",
+    "@esri/arcgis-rest-common-types": "^1.2.1",
     "@esri/arcgis-rest-request": "^1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The wrong package name makes it impossible to install since that dep cannot be installed.