### PR TITLE
fix: ensure deleteFeatures doesnt pass the extraneous parameter 'deletes'

### DIFF
--- a/packages/arcgis-rest-feature-service/src/add.ts
+++ b/packages/arcgis-rest-feature-service/src/add.ts
@@ -76,6 +76,7 @@ export function addFeatures(
 
   // mixin, don't overwrite
   options.params.features = requestOptions.adds;
+  delete options.params.adds;
 
   return request(url, options);
 }

--- a/packages/arcgis-rest-feature-service/src/delete.ts
+++ b/packages/arcgis-rest-feature-service/src/delete.ts
@@ -79,6 +79,7 @@ export function deleteFeatures(
 
   // mixin, don't overwrite
   options.params.objectIds = requestOptions.deletes;
+  delete options.params.deletes;
 
   return request(url, options);
 }

--- a/packages/arcgis-rest-feature-service/src/update.ts
+++ b/packages/arcgis-rest-feature-service/src/update.ts
@@ -75,6 +75,7 @@ export function updateFeatures(
 
   // mixin, don't overwrite
   options.params.features = requestOptions.updates;
+  delete options.params.updates;
 
   return request(url, options);
 }

--- a/packages/arcgis-rest-feature-service/test/features.test.ts
+++ b/packages/arcgis-rest-feature-service/test/features.test.ts
@@ -111,9 +111,8 @@ describe("feature", () => {
           )
       );
       expect(options.method).toBe("POST");
-      expect(addFeaturesResponse.addResults[0].objectId).toEqual(1001);
-      expect(addFeaturesResponse.addResults[0].success).toEqual(true);
-      expect(options.method).toBe("POST");
+      expect(response.addResults[0].objectId).toEqual(1001);
+      expect(response.addResults[0].success).toEqual(true);
       done();
     });
   });
@@ -146,7 +145,7 @@ describe("feature", () => {
           )
       );
       expect(options.body).toContain("rollbackOnFailure=false");
-      expect(updateFeaturesResponse.updateResults[0].success).toEqual(true);
+      expect(response.updateResults[0].success).toEqual(true);
       done();
     });
   });
@@ -166,10 +165,10 @@ describe("feature", () => {
       expect(options.body).toContain("objectIds=1001");
       expect(options.body).toContain("where=1%3D1");
       expect(options.method).toBe("POST");
-      expect(deleteFeaturesResponse.deleteResults[0].objectId).toEqual(
+      expect(response.deleteResults[0].objectId).toEqual(
         requestOptions.deletes[0]
       );
-      expect(deleteFeaturesResponse.deleteResults[0].success).toEqual(true);
+      expect(response.deleteResults[0].success).toEqual(true);
       done();
     });
   });


### PR DESCRIPTION
working on https://github.com/Esri/hub.js/pull/35 i noticed that we're currently unnecessarily passing a few unrecognized parameters (`adds=`, `updates=`, `deletes=`) in requests.

```js
deleteFeatures({
  url,
  deletes: [123]
})
```
![screenshot 2018-07-05 10 13 42](https://user-images.githubusercontent.com/3011734/42337590-1f527c02-803c-11e8-8672-872bd4d7a7cd.png)

its a harmless bug, but its one i introduced.

while i was at it, i also fixed the corresponding tests to introspect the objects returned by each promise instead of the canned responses we feed to the mock server.

AFFECTS PACKAGES:
@esri/arcgis-rest-feature-service