### PR TITLE
fix(users): users defaults to https://www.arcgis.com instead of http://

### DIFF
--- a/packages/arcgis-rest-users/src/users.ts
+++ b/packages/arcgis-rest-users/src/users.ts
@@ -51,7 +51,7 @@ export function getUser(
 
   // if a username is passed, assume ArcGIS Online
   if (typeof requestOptions === "string") {
-    url = `http://www.arcgis.com/sharing/rest/community/users/${requestOptions}`;
+    url = `https://www.arcgis.com/sharing/rest/community/users/${requestOptions}`;
   } else {
     // if an authenticated session is passed, default to that user/portal unless another username is provided manually
     const username =

--- a/packages/arcgis-rest-users/test/users.test.ts
+++ b/packages/arcgis-rest-users/test/users.test.ts
@@ -45,7 +45,7 @@ describe("users", () => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(
-            "http://www.arcgis.com/sharing/rest/community/users/jsmith?f=json"
+            "https://www.arcgis.com/sharing/rest/community/users/jsmith?f=json"
           );
           expect(options.method).toBe("GET");
           done();


### PR DESCRIPTION
always use HTTPS

AFFECTS PACKAGES:
@esri/arcgis-rest-users