### PR TITLE
IGroup cleanup

### DIFF
--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-auth",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Authentication helpers for @esri/arcgis-rest-*.",
   "main": "dist/node/index.js",
   "browser": "dist/umd/auth.umd.js",
@@ -15,12 +15,12 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.2.1",
-    "@esri/arcgis-rest-request": "^1.2.1"
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.4.2",
-    "@esri/arcgis-rest-request": "^1.4.2"
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-common-types/package.json
+++ b/packages/arcgis-rest-common-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-common-types",
-  "version": "1.4.2",
+  "version": "1.5.1",
   "description": "Common TypeScript types for @esri/arcgis-rest-* packages.",
   "types": "dist/types/index.d.ts",
   "author": "",

--- a/packages/arcgis-rest-common-types/src/index.js
+++ b/packages/arcgis-rest-common-types/src/index.js
@@ -1,2 +1,0 @@
-/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
- * Apache-2.0 */

--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -476,24 +476,28 @@ export interface IUser {
   provider?: "arcgis" | "enterprise" | "facebook" | "google";
 }
 
-export interface IGroup {
-  id?: string;
-  title?: string;
+export interface IGroup extends IItem {
   isInvitationOnly?: boolean;
-  owner?: string;
-  description?: string;
-  snippet?: string;
-  tags?: string[];
   phone?: string;
-  thumbnail?: string;
-  created?: number; // utc date
-  modified?: number;
+  sortField?:
+    | "title"
+    | "owner"
+    | "avgrating"
+    | "numviews"
+    | "created"
+    | "modified";
+  isViewOnly?: boolean;
+  isFav?: boolean;
   access?: "private" | "org" | "public";
   userMembership?: {
     username?: string;
     memberType?: string;
     applications?: number;
   };
+  protected?: boolean;
+  autoJoin?: boolean;
+  hasCategorySchema?: boolean;
+  isOpenData?: boolean;
   [key: string]: any;
 }
 

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-feature-service",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Feature service helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/umd/feature-service.umd.js",
@@ -15,12 +15,12 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.2.1",
-    "@esri/arcgis-rest-request": "^1.2.1"
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.4.2",
-    "@esri/arcgis-rest-request": "^1.4.2"
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-geocoder/package.json
+++ b/packages/arcgis-rest-geocoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-geocoder",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Geocoding helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/umd/geocoder.umd.js",
@@ -15,14 +15,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.5.0",
-    "@esri/arcgis-rest-common-types": "^1.2.1",
-    "@esri/arcgis-rest-request": "^1.2.1"
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.5.0",
-    "@esri/arcgis-rest-common-types": "^1.4.2",
-    "@esri/arcgis-rest-request": "^1.4.2"
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-groups/package.json
+++ b/packages/arcgis-rest-groups/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-groups",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Portal Group helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/umd/groups.umd.js",
@@ -15,14 +15,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.5.0",
-    "@esri/arcgis-rest-common-types": "^1.2.1",
-    "@esri/arcgis-rest-request": "^1.2.1"
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.5.0",
-    "@esri/arcgis-rest-common-types": "^1.4.2",
-    "@esri/arcgis-rest-request": "^1.4.2"
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-groups/src/groups.ts
+++ b/packages/arcgis-rest-groups/src/groups.ts
@@ -7,7 +7,7 @@ import {
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 
-import { IPagingParams, IItem } from "@esri/arcgis-rest-common-types";
+import { IPagingParams, IItem, IGroup } from "@esri/arcgis-rest-common-types";
 
 export interface IPagingParamsRequestOptions extends IRequestOptions {
   paging: IPagingParams;
@@ -17,19 +17,8 @@ export interface IGroupIdRequestOptions extends IRequestOptions {
   id: string;
 }
 
-export interface IGroup {
-  id?: string;
-  owner: string;
-  title: string;
-  tags: string[];
-  description?: string;
-  categories?: string[];
-  culture?: string;
-  [key: string]: any;
-}
-
 export interface IGroupRequestOptions extends IRequestOptions {
-  group: IGroup;
+  group: IItem;
 }
 
 export interface IGroupSearchRequest extends IPagingParams {
@@ -192,9 +181,7 @@ export function createGroup(
   requestOptions: IGroupRequestOptions
 ): Promise<any> {
   const url = `${getPortalUrl(requestOptions)}/community/createGroup`;
-  // default to a POST request
   const options: IGroupRequestOptions = {
-    ...{ httpMethod: "POST" },
     ...requestOptions
   };
   // serialize the group into something Portal will accept
@@ -213,9 +200,8 @@ export function updateGroup(
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.group.id
   }/update`;
-  // default to a POST request
+
   const options: IGroupRequestOptions = {
-    ...{ httpMethod: "POST" },
     ...requestOptions
   };
   // serialize the group into something Portal will accept
@@ -234,9 +220,7 @@ export function removeGroup(
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
   }/delete`;
-  // default to a POST request
   const options: IGroupIdRequestOptions = {
-    ...{ httpMethod: "POST" },
     ...requestOptions
   };
   return request(url, options);
@@ -253,9 +237,7 @@ export function protectGroup(
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
   }/protect`;
-  // default to a POST request
   const options: IGroupIdRequestOptions = {
-    ...{ httpMethod: "POST" },
     ...requestOptions
   };
   return request(url, options);
@@ -272,9 +254,7 @@ export function unprotectGroup(
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
   }/unprotect`;
-  // default to a POST request
   const options: IGroupIdRequestOptions = {
-    ...{ httpMethod: "POST" },
     ...requestOptions
   };
   return request(url, options);

--- a/packages/arcgis-rest-groups/src/groups.ts
+++ b/packages/arcgis-rest-groups/src/groups.ts
@@ -18,7 +18,7 @@ export interface IGroupIdRequestOptions extends IRequestOptions {
 }
 
 export interface IGroupRequestOptions extends IRequestOptions {
-  group: IItem;
+  group: IGroup;
 }
 
 export interface IGroupSearchRequest extends IPagingParams {

--- a/packages/arcgis-rest-groups/test/mocks/responses.ts
+++ b/packages/arcgis-rest-groups/test/mocks/responses.ts
@@ -1,9 +1,10 @@
 import {
-  IGroup,
   IGroupSearchResult,
   IGroupContentResult,
   IGroupUsersResult
 } from "../../src/groups";
+
+import { IGroup } from "@esri/arcgis-rest-common-types";
 
 export const GroupSearchResponse: IGroupSearchResult = {
   query: "* AND owner:dcadmin",

--- a/packages/arcgis-rest-items/package.json
+++ b/packages/arcgis-rest-items/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-items",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Portal Item helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/umd/items.umd.js",
@@ -15,14 +15,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.5.0",
-    "@esri/arcgis-rest-common-types": "^1.2.1",
-    "@esri/arcgis-rest-request": "^1.2.1"
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.5.0",
-    "@esri/arcgis-rest-common-types": "^1.4.2",
-    "@esri/arcgis-rest-request": "^1.4.2"
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-request",
-  "version": "1.4.2",
+  "version": "1.5.1",
   "description": "Common methods and utilities for @esri/arcgis-rest-* packages.",
   "main": "dist/node/index.js",
   "browser": "dist/umd/request.umd.js",

--- a/packages/arcgis-rest-sharing/package.json
+++ b/packages/arcgis-rest-sharing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-sharing",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Helper utilities for managing access to ArcGIS content in Node.js and modern browsers.",
   "main": "dist/node/index.js",
   "browser": "dist/umd/sharing.umd.js",
@@ -12,14 +12,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.5.0",
-    "@esri/arcgis-rest-common-types": "^1.3.0",
-    "@esri/arcgis-rest-request": "^1.3.0"
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.5.0",
-    "@esri/arcgis-rest-common-types": "^1.4.2",
-    "@esri/arcgis-rest-request": "^1.4.2"
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "files": [
     "dist/**"

--- a/packages/arcgis-rest-users/package.json
+++ b/packages/arcgis-rest-users/package.json
@@ -15,14 +15,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.5.0",
-    "@esri/arcgis-rest-common-types": "^1.2.1",
-    "@esri/arcgis-rest-request": "^1.2.1"
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.5.0",
-    "@esri/arcgis-rest-common-types": "^1.4.2",
-    "@esri/arcgis-rest-request": "^1.4.2"
+    "@esri/arcgis-rest-auth": "^1.5.1",
+    "@esri/arcgis-rest-common-types": "^1.5.1",
+    "@esri/arcgis-rest-request": "^1.5.1"
   },
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION
this PR:

* removes the `IGroup` interface from 'arcgis-rest-groups' (in favor of the one in 'arcgis-rest-common-types').
* updates the canonical interface to extend `IItem` (instead of duplicating props)
* updates the canonical interface with the new props @alukach mentioned

sorry for the noise in the diff, when @tomwayson published `v1.5.1` for some reason the script didn't update all the relevant package.json files.