### PR TITLE
constrain what constitutes a valid Item for crud operations, and require auth

### DIFF
--- a/packages/arcgis-rest-common-types/src/group.ts
+++ b/packages/arcgis-rest-common-types/src/group.ts
@@ -1,0 +1,51 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+/**
+ * A [Group](https://developers.arcgis.com/rest/users-groups-and-items/common-parameters.htm) that has not been created yet.
+ */
+export interface IGroupAdd {
+  title: string;
+  owner?: string;
+  tags?: string[];
+  description?: string;
+  access?: "private" | "org" | "public";
+  phone?: string;
+  sortField?:
+    | "title"
+    | "owner"
+    | "avgrating"
+    | "numviews"
+    | "created"
+    | "modified";
+  sortOrder?: "asc" | "desc";
+  isViewOnly?: boolean;
+  isInvitationOnly?: boolean;
+  thumbnail?: string;
+  autoJoin?: boolean;
+  snippet?: string;
+  [key: string]: any;
+}
+
+/**
+ * Existing Portal [Group](https://developers.arcgis.com/rest/users-groups-and-items/group.htm).
+ */
+export interface IGroup extends IGroupAdd {
+  id: string;
+  owner: string;
+  tags: string[];
+  created: number;
+  modified: number;
+  protected: boolean;
+  isInvitationOnly: boolean;
+  isViewOnly: boolean;
+  isOpenData: boolean;
+  isFav: boolean;
+  autoJoin: boolean;
+  userMembership?: {
+    username?: string;
+    memberType?: string;
+    applications?: number;
+  };
+  hasCategorySchema?: boolean;
+}

--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -1,7 +1,11 @@
-/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { IGroup } from "./group";
+
 export * from "./webmap";
+export * from "./item";
+export * from "./group";
 
 /**
  * an arc can be represented as a JSON curve object
@@ -178,28 +182,6 @@ export interface IFont {
   style?: "italic" | "normal" | "oblique";
   weight?: "bold" | "bolder" | "lighter" | "normal";
   decoration?: "line-through" | "underline" | "none";
-}
-
-/**
- * Portal Item
- */
-export interface IItem {
-  id?: string;
-  owner?: string;
-  title?: string;
-  type?: string;
-  tags?: string[];
-  typeKeywords?: string[];
-  description?: string;
-  snippet?: string;
-  documentation?: string;
-  extent?: number[][];
-  categories?: string[];
-  spatialReference?: any;
-  culture?: string;
-  properties?: any;
-  url?: string;
-  [key: string]: any;
 }
 
 /**
@@ -474,31 +456,6 @@ export interface IUser {
   modified?: number;
   groups?: IGroup[];
   provider?: "arcgis" | "enterprise" | "facebook" | "google";
-}
-
-export interface IGroup extends IItem {
-  isInvitationOnly?: boolean;
-  phone?: string;
-  sortField?:
-    | "title"
-    | "owner"
-    | "avgrating"
-    | "numviews"
-    | "created"
-    | "modified";
-  isViewOnly?: boolean;
-  isFav?: boolean;
-  access?: "private" | "org" | "public";
-  userMembership?: {
-    username?: string;
-    memberType?: string;
-    applications?: number;
-  };
-  protected?: boolean;
-  autoJoin?: boolean;
-  hasCategorySchema?: boolean;
-  isOpenData?: boolean;
-  [key: string]: any;
 }
 
 export type esriUnits =

--- a/packages/arcgis-rest-common-types/src/item.ts
+++ b/packages/arcgis-rest-common-types/src/item.ts
@@ -1,0 +1,45 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { ISpatialReference } from "./index";
+
+/**
+ * A Portal [Item](https://developers.arcgis.com/rest/users-groups-and-items/common-parameters.htm) that has not been created yet.
+ */
+export interface IItemAdd {
+  title: string;
+  type: string;
+  owner?: string;
+  typeKeywords?: string[];
+  description?: string;
+  snippet?: string;
+  documentation?: string;
+  extent?: number[][];
+  categories?: string[];
+  spatialReference?: ISpatialReference;
+  culture?: string;
+  properties?: any;
+  url?: string;
+  tags?: string[];
+  [key: string]: any;
+}
+
+/**
+ * A Portal [Item](https://developers.arcgis.com/rest/users-groups-and-items/common-parameters.htm) to be updated.
+ */
+export interface IItemUpdate {
+  id: string;
+  [key: string]: any;
+}
+
+/**
+ * Existing Portal [Item](https://developers.arcgis.com/rest/users-groups-and-items/item.htm).
+ */
+export interface IItem extends IItemAdd {
+  id: string;
+  owner: string;
+  tags: string[];
+  created: number;
+  modified: number;
+  protected: boolean;
+}

--- a/packages/arcgis-rest-groups/src/groups.ts
+++ b/packages/arcgis-rest-groups/src/groups.ts
@@ -1,5 +1,6 @@
-/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
+
 import {
   request,
   IRequestOptions,
@@ -7,7 +8,13 @@ import {
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 
-import { IPagingParams, IItem, IGroup } from "@esri/arcgis-rest-common-types";
+import {
+  IPagingParams,
+  IItem,
+  IItemUpdate,
+  IGroupAdd,
+  IGroup
+} from "@esri/arcgis-rest-common-types";
 
 export interface IPagingParamsRequestOptions extends IRequestOptions {
   paging: IPagingParams;
@@ -17,8 +24,12 @@ export interface IGroupIdRequestOptions extends IRequestOptions {
   id: string;
 }
 
-export interface IGroupRequestOptions extends IRequestOptions {
-  group: IGroup;
+export interface IGroupAddRequestOptions extends IRequestOptions {
+  group: IGroupAdd;
+}
+
+export interface IGroupUpdateRequestOptions extends IRequestOptions {
+  group: IItemUpdate;
 }
 
 export interface IGroupSearchRequest extends IPagingParams {
@@ -157,31 +168,16 @@ export function getGroupUsers(
 }
 
 /**
- * Serialize a group into a json format accepted by the Portal API
- * for create and update operations
- *
- * @param group IGroup to be serialized
- * @returns a formatted JSON object to be sent to Portal
- */
-function serializeGroup(group: IGroup): any {
-  // create a clone so we're not messing with the original
-  const clone = JSON.parse(JSON.stringify(group));
-  // join and tags...
-  clone.tags = clone.tags.join(", ");
-  return clone;
-}
-
-/**
  * Create a new Group.
  * Note: The group name must be unique within the user's organization.
  * @param requestOptions  - Options for the request, including a group object
  * @returns A Promise that will resolve with the success/failure status of the request
  */
 export function createGroup(
-  requestOptions: IGroupRequestOptions
+  requestOptions: IGroupAddRequestOptions
 ): Promise<any> {
   const url = `${getPortalUrl(requestOptions)}/community/createGroup`;
-  const options: IGroupRequestOptions = {
+  const options: IGroupAddRequestOptions = {
     ...requestOptions
   };
   // serialize the group into something Portal will accept
@@ -195,13 +191,13 @@ export function createGroup(
  * @returns A Promise that will resolve with the success/failure status of the request
  */
 export function updateGroup(
-  requestOptions: IGroupRequestOptions
+  requestOptions: IGroupUpdateRequestOptions
 ): Promise<any> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.group.id
   }/update`;
 
-  const options: IGroupRequestOptions = {
+  const options: IGroupUpdateRequestOptions = {
     ...requestOptions
   };
   // serialize the group into something Portal will accept
@@ -258,4 +254,19 @@ export function unprotectGroup(
     ...requestOptions
   };
   return request(url, options);
+}
+
+/**
+ * Serialize a group into a json format accepted by the Portal API
+ * for create and update operations
+ *
+ * @param group IGroup to be serialized
+ * @returns a formatted JSON object to be sent to Portal
+ */
+function serializeGroup(group: IGroupAdd | IItemUpdate | IGroup): any {
+  // create a clone so we're not messing with the original
+  const clone = JSON.parse(JSON.stringify(group));
+  // join and tags...
+  clone.tags = clone.tags.join(", ");
+  return clone;
 }

--- a/packages/arcgis-rest-groups/test/mocks/responses.ts
+++ b/packages/arcgis-rest-groups/test/mocks/responses.ts
@@ -130,7 +130,8 @@ export const GroupContentResponse: IGroupContentResult = {
       avgRating: 0,
       numViews: 1301,
       groupCategories: [],
-      scoreCompleteness: 50
+      scoreCompleteness: 50,
+      protected: false
     }
   ]
 };

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -7,21 +7,13 @@ import {
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 
-import { IItem, IPagingParams } from "@esri/arcgis-rest-common-types";
+import {
+  IItemAdd,
+  IItemUpdate,
+  IItem,
+  IPagingParams
+} from "@esri/arcgis-rest-common-types";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
-
-export interface IItemAdd extends IItem {
-  title: string;
-  type: string;
-}
-
-export interface IItemUpdate extends IItem {
-  id: string;
-}
-
-export interface IItemRequestOptions extends IRequestOptions {
-  item: IItem;
-}
 
 export interface IItemIdRequestOptions extends IUserRequestOptions {
   /**
@@ -424,7 +416,7 @@ export function removeItemResource(
  * @param item IItem to be serialized
  * @returns a formatted json object to be sent to Portal
  */
-function serializeItem(item: IItem): any {
+function serializeItem(item: IItemAdd | IItemUpdate | IItem): any {
   // create a clone so we're not messing with the original
   const clone = JSON.parse(JSON.stringify(item));
   // join keywords and tags...

--- a/packages/arcgis-rest-items/test/mocks/item.ts
+++ b/packages/arcgis-rest-items/test/mocks/item.ts
@@ -16,7 +16,10 @@ export const ItemResponse: IItem = {
   typeKeywords: ["Javascript", "hubSiteApplication"],
   properties: {
     parentId: "3eb"
-  }
+  },
+  created: 123,
+  modified: 456,
+  protected: false
 };
 
 export const ItemDataResponse: any = {

--- a/packages/arcgis-rest-items/test/mocks/search.ts
+++ b/packages/arcgis-rest-items/test/mocks/search.ts
@@ -53,7 +53,8 @@ export const SearchResponse: ISearchResult = {
       numComments: 0,
       numRatings: 0,
       avgRating: 0,
-      numViews: 4
+      numViews: 4,
+      protected: false
     }
   ]
 };

--- a/packages/arcgis-rest-users/test/mocks/responses.ts
+++ b/packages/arcgis-rest-users/test/mocks/responses.ts
@@ -65,7 +65,12 @@ export const GroupMemberUserResponse: IUser = {
         username: "jsmith",
         memberType: "user",
         applications: 0
-      }
+      },
+      protected: false,
+      isViewOnly: false,
+      isFav: false,
+      isOpenData: true,
+      autoJoin: false
     }
   ]
 };
@@ -91,7 +96,12 @@ export const GroupNonMemberUserResponse: IUser = {
         username: "jsmith",
         memberType: "user",
         applications: 0
-      }
+      },
+      protected: false,
+      isViewOnly: false,
+      isFav: false,
+      isOpenData: true,
+      autoJoin: false
     }
   ]
 };
@@ -117,7 +127,12 @@ export const GroupAdminUserResponse = {
         username: "jsmith",
         memberType: "admin",
         applications: 0
-      }
+      },
+      protected: false,
+      isViewOnly: false,
+      isFav: false,
+      isOpenData: true,
+      autoJoin: false
     }
   ]
 };
@@ -144,7 +159,12 @@ export const OrgAdminUserResponse = {
         username: "jsmith",
         memberType: "owner",
         applications: 0
-      }
+      },
+      protected: false,
+      isViewOnly: false,
+      isFav: false,
+      isOpenData: true,
+      autoJoin: false
     }
   ]
 };


### PR DESCRIPTION
resolves #246:
* adds a couple code snippets
* ~~stops using the (unnecessary) interface `IUserRequestOptions`~~
* `createItem()` now requires an Item with 'title' and 'type'
* `updateItem()` now requires an Item with an 'id'
* ~~the methods above, and `removeItem()`, now _all_ require authentication~~

no one loves interface soup more than @dbouwman. hopefully he can find time to review soon as @tomwayson is out until late next week.