### PR TITLE
differentiate IGroup and IGroupResponse

### DIFF
--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -477,8 +477,8 @@ export interface IUser {
 }
 
 export interface IGroup extends IItem {
-  isInvitationOnly?: boolean;
   phone?: string;
+  access?: "private" | "org" | "public";
   sortField?:
     | "title"
     | "owner"
@@ -486,19 +486,11 @@ export interface IGroup extends IItem {
     | "numviews"
     | "created"
     | "modified";
+  sortOrder?: "asc" | "desc";
   isViewOnly?: boolean;
-  isFav?: boolean;
-  access?: "private" | "org" | "public";
-  userMembership?: {
-    username?: string;
-    memberType?: string;
-    applications?: number;
-  };
-  protected?: boolean;
+  isInvitationOnly?: boolean;
+  thumbnail?: "string";
   autoJoin?: boolean;
-  hasCategorySchema?: boolean;
-  isOpenData?: boolean;
-  [key: string]: any;
 }
 
 export type esriUnits =

--- a/packages/arcgis-rest-groups/src/groups.ts
+++ b/packages/arcgis-rest-groups/src/groups.ts
@@ -1,9 +1,9 @@
-/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
+
 import {
   request,
   IRequestOptions,
-  // IParams,
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 
@@ -28,6 +28,18 @@ export interface IGroupSearchRequest extends IPagingParams {
   [key: string]: any;
 }
 
+export interface IGroupResponse extends IGroup {
+  isFav?: boolean;
+  userMembership?: {
+    username?: string;
+    memberType?: string;
+    applications?: number;
+  };
+  protected?: boolean;
+  hasCategorySchema?: boolean;
+  isOpenData?: boolean;
+}
+
 export interface IGroupSearchResult {
   /**
    * Matches the REST APIs form param
@@ -37,7 +49,7 @@ export interface IGroupSearchResult {
   start: number;
   num: number;
   nextStart: number;
-  results: IGroup[];
+  results: IGroupResponse[];
 }
 
 export interface IGroupContentResult {
@@ -98,7 +110,7 @@ export function searchGroups(
 export function getGroup(
   id: string,
   requestOptions?: IRequestOptions
-): Promise<IGroup> {
+): Promise<IGroupResponse> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${id}`;
   // default to a GET request
   const options: IRequestOptions = {
@@ -118,7 +130,7 @@ export function getGroup(
 export function getGroupContent(
   id: string,
   requestOptions?: IPagingParamsRequestOptions
-): Promise<IGroup> {
+): Promise<IGroupContentResult> {
   const url = `${getPortalUrl(requestOptions)}/content/groups/${id}`;
 
   // default to a GET request

--- a/packages/arcgis-rest-groups/test/groups.test.ts
+++ b/packages/arcgis-rest-groups/test/groups.test.ts
@@ -17,6 +17,7 @@ import {
   GroupContentResponse,
   GroupUsersResponse
 } from "./mocks/responses";
+
 import { encodeParam } from "@esri/arcgis-rest-request";
 import * as fetchMock from "fetch-mock";
 
@@ -118,7 +119,7 @@ describe("groups", () => {
     });
   });
 
-  describe("authenticted methods", () => {
+  describe("authenticated methods", () => {
     const MOCK_AUTH = {
       getToken() {
         return Promise.resolve("fake-token");
@@ -154,6 +155,7 @@ describe("groups", () => {
         tags: ["foo", "bar"],
         description: "my fake group"
       };
+
       createGroup({ group: fakeGroup, ...MOCK_REQOPTS })
         .then(response => {
           expect(fetchMock.called()).toEqual(true);


### PR DESCRIPTION
what do you think of this @alukach?

something like `readonly isOpenData: boolean;` would have been less complicated, but that only prohibits a property from being altered _after_ the object has been instantiated.
 
AFFECTS PACKAGES:
@esri/arcgis-rest-common-types
@esri/arcgis-rest-groups

~~ISSUES CLOSED: #241~~