### PR TITLE
docs: clarify that createItemInFolder expects an id, not a name.

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -188,7 +188,7 @@ export interface IUserSessionOptions {
  * ```
  * Used to manage the authentication of ArcGIS Online and ArcGIS Enterprise users
  * in `request`. This class also includes several
- * helper methods for authenticating users with OAuth 2.0 in both browser and
+ * helper methods for authenticating users with [OAuth 2.0](https://developers.arcgis.com/documentation/core-concepts/security-and-authentication/browser-based-user-logins/) in both browser and
  * server applications.
  *
  */

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -51,7 +51,7 @@ export interface IItemCrudRequestOptions extends IUserRequestOptions {
    */
   owner?: string;
   /**
-   * Folder to house the item.
+   * Id of the folder to house the item.
    */
   folder?: string;
 }

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -7,7 +7,23 @@ import { encodeQueryString } from "./utils/encode-query-string";
 import { requiresFormData } from "./utils/process-params";
 import { ArcGISRequestError } from "./utils/ArcGISRequestError";
 
+/**
+ * Authentication can be supplied to `request` via [`UserSession`](../../auth/UserSession/) or [`ApplicationSession`](../../auth/ApplicationSession/). Both classes extend `IAuthenticationManager`.
+ * ```js
+ * const session = new UserSession({
+ *   username: "jsmith",
+ *   password: "123456",
+ *   // optional
+ *   portal: "https://[yourserver]/arcgis/sharing/rest"
+ * })
+ *
+ * request(url, { authentication: session })
+ * ```
+ */
 export interface IAuthenticationManager {
+  /**
+   * Defaults to 'https://www.arcgis.com/sharing/rest'.
+   */
   portal: string;
   getToken(url: string): Promise<string>;
 }


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-items

ISSUES CLOSED: #236