### PR TITLE
Add attachment notes for api docs

### DIFF
--- a/packages/arcgis-rest-feature-service/src/addAttachment.ts
+++ b/packages/arcgis-rest-feature-service/src/addAttachment.ts
@@ -8,9 +8,6 @@ import { IEditFeatureResult } from "./helpers";
 /**
  * Request options for adding a related attachment to a feature by id. See [Add Attachment](https://developers.arcgis.com/rest/services-reference/add-attachment.htm) for more information.
  *
- * @param url - Feature service url.
- * @param featureId - Unique identifier of feature to add related attachment.
- * @param attachment - File to be attached.
  */
 export interface IAddAttachmentOptions extends IRequestOptions {
   /**

--- a/packages/arcgis-rest-feature-service/src/addAttachment.ts
+++ b/packages/arcgis-rest-feature-service/src/addAttachment.ts
@@ -13,8 +13,17 @@ import { IEditFeatureResult } from "./helpers";
  * @param attachment - File to be attached.
  */
 export interface IAddAttachmentOptions extends IRequestOptions {
+  /**
+   * Feature service url.
+   */
   url: string;
+  /**
+   * Unique identifier of feature to add related attachment.
+   */
   featureId: number;
+  /**
+   * File to be attached.
+   */
   attachment: File;
 }
 

--- a/packages/arcgis-rest-feature-service/src/deleteAttachments.ts
+++ b/packages/arcgis-rest-feature-service/src/deleteAttachments.ts
@@ -13,8 +13,17 @@ import { IEditFeatureResult } from "./helpers";
  * @param attachmentIds - Array of unique identifiers of attachments to delete.
  */
 export interface IDeleteAttachmentsOptions extends IRequestOptions {
+  /**
+   * Feature service url.
+   */
   url: string;
+  /**
+   * Unique identifier of feature to delete related attachment(s).
+   */
   featureId: number;
+  /**
+   * Array of unique identifiers of attachments to delete.
+   */
   attachmentIds: number[];
 }
 

--- a/packages/arcgis-rest-feature-service/src/deleteAttachments.ts
+++ b/packages/arcgis-rest-feature-service/src/deleteAttachments.ts
@@ -8,9 +8,6 @@ import { IEditFeatureResult } from "./helpers";
 /**
  * Request options to for deleting related attachments of a feature by id. See [Delete Attachments](https://developers.arcgis.com/rest/services-reference/delete-attachments.htm) for more information.
  *
- * @param url - Feature service url.
- * @param featureId - Unique identifier of feature to delete related attachment(s).
- * @param attachmentIds - Array of unique identifiers of attachments to delete.
  */
 export interface IDeleteAttachmentsOptions extends IRequestOptions {
   /**

--- a/packages/arcgis-rest-feature-service/src/getAttachments.ts
+++ b/packages/arcgis-rest-feature-service/src/getAttachments.ts
@@ -6,8 +6,6 @@ import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 /**
  * Request options to fetch `attachmentInfos` of a feature by id. See [Attachment Infos](https://developers.arcgis.com/rest/services-reference/attachment-infos-feature-service-.htm) for more information.
  *
- * @param url - Feature service url.
- * @param featureId - Unique identifier of feature to request related `attachmentInfos`.
  */
 export interface IGetAttachmentsOptions extends IRequestOptions {
   /**

--- a/packages/arcgis-rest-feature-service/src/getAttachments.ts
+++ b/packages/arcgis-rest-feature-service/src/getAttachments.ts
@@ -10,7 +10,13 @@ import { request, IRequestOptions } from "@esri/arcgis-rest-request";
  * @param featureId - Unique identifier of feature to request related `attachmentInfos`.
  */
 export interface IGetAttachmentsOptions extends IRequestOptions {
+  /**
+   * Feature service url.
+   */
   url: string;
+  /**
+   * Unique identifier of feature to request related `attachmentInfos`.
+   */
   featureId: number;
 }
 

--- a/packages/arcgis-rest-feature-service/src/updateAttachment.ts
+++ b/packages/arcgis-rest-feature-service/src/updateAttachment.ts
@@ -8,10 +8,6 @@ import { IEditFeatureResult, appendCustomParams } from "./helpers";
 /**
  * Request options to for updating a related attachment to a feature by id. See [Update Attachment](https://developers.arcgis.com/rest/services-reference/update-attachment.htm) for more information.
  *
- * @param url - Feature service url.
- * @param featureId - Unique identifier of feature to update related attachment.
- * @param attachment - File to be updated.
- * @param attachmentId - Unique identifier of the attachment.
  */
 export interface IUpdateAttachmentOptions extends IRequestOptions {
   /**

--- a/packages/arcgis-rest-feature-service/src/updateAttachment.ts
+++ b/packages/arcgis-rest-feature-service/src/updateAttachment.ts
@@ -14,9 +14,21 @@ import { IEditFeatureResult, appendCustomParams } from "./helpers";
  * @param attachmentId - Unique identifier of the attachment.
  */
 export interface IUpdateAttachmentOptions extends IRequestOptions {
+  /**
+   * Feature service url.
+   */
   url: string;
+  /**
+   * Unique identifier of feature to update related attachment.
+   */
   featureId: number;
+  /**
+   * File to be updated.
+   */
   attachment: File;
+  /**
+   * Unique identifier of the attachment.
+   */
   attachmentId: number;
 }
 


### PR DESCRIPTION
@jgravois I noticed the the Notes in the API docs come from the comments in the interfaces themselves and not from `@param`. Here they be.