### PR TITLE
Add support for uploading blob item's data

### DIFF
--- a/packages/arcgis-rest-feature-service/test/attachments.test.ts
+++ b/packages/arcgis-rest-feature-service/test/attachments.test.ts
@@ -19,7 +19,7 @@ import {
   genericInvalidResponse
 } from "./mocks/feature";
 
-function attachmentFile() {
+export function attachmentFile() {
   if (typeof File !== "undefined" && File) {
     return new File(["foo"], "foo.txt", { type: "text/plain" });
   } else {

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -30,9 +30,9 @@ export interface IItemIdRequestOptions extends IUserRequestOptions {
   owner?: string;
 }
 
-export interface IItemJsonDataRequestOptions extends IItemIdRequestOptions {
+export interface IItemJsonRequestOptions extends IItemIdRequestOptions {
   /**
-   * JSON object to store
+   * Object to store
    */
   data: any;
 }
@@ -198,7 +198,7 @@ export function createItem(
  * @param requestOptions - Options for the request
  */
 export function addItemJsonData(
-  requestOptions: IItemJsonDataRequestOptions
+  requestOptions: IItemJsonRequestOptions
 ): Promise<any> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
@@ -211,6 +211,28 @@ export function addItemJsonData(
   requestOptions.params = {
     ...requestOptions.params,
     text: JSON.stringify(requestOptions.data)
+  };
+
+  return request(url, requestOptions);
+}
+/**
+ * Send blob to an item to be stored as the `/data` resource
+ *
+ * @param requestOptions - Options for the request
+ */
+export function addItemBinaryData(
+  requestOptions: IItemJsonRequestOptions
+): Promise<any> {
+  const owner = requestOptions.owner || requestOptions.authentication.username;
+
+  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
+    requestOptions.id
+  }/update`;
+
+  // Portal API requires that the 'data' be POSTed in a `file` form field.
+  requestOptions.params = {
+    ...requestOptions.params,
+    file: requestOptions.data
   };
 
   return request(url, requestOptions);

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -30,7 +30,7 @@ export interface IItemIdRequestOptions extends IUserRequestOptions {
   owner?: string;
 }
 
-export interface IItemJsonRequestOptions extends IItemIdRequestOptions {
+export interface IItemDataAddRequestOptions extends IItemIdRequestOptions {
   /**
    * Object to store
    */
@@ -97,6 +97,15 @@ export interface ISearchResult {
   results: IItem[];
 }
 
+export interface IItemUpdateResponse {
+  success: boolean;
+  id: string;
+}
+
+export interface IItemAddResponse extends IItemUpdateResponse {
+  folder: string;
+}
+
 /**
  * Search for items via the portal api
  *
@@ -145,7 +154,7 @@ export function searchItems(
  */
 export function createItemInFolder(
   requestOptions: IItemAddRequestOptions
-): Promise<any> {
+): Promise<IItemAddResponse> {
   const owner = determineOwner(requestOptions);
 
   const baseUrl = `${getPortalUrl(requestOptions)}/content/users/${owner}`;
@@ -183,7 +192,7 @@ export function createItemInFolder(
  */
 export function createItem(
   requestOptions: IItemAddRequestOptions
-): Promise<any> {
+): Promise<IItemAddResponse> {
   // delegate to createItemInFolder placing in the root of the filestore
   const options = {
     folder: null,
@@ -196,10 +205,12 @@ export function createItem(
  * Send json to an item to be stored as the `/data` resource
  *
  * @param requestOptions - Options for the request
+ * @returns A Promise that will resolve with an object reporting
+ *        success/failure and echoing the item id.
  */
 export function addItemJsonData(
-  requestOptions: IItemJsonRequestOptions
-): Promise<any> {
+  requestOptions: IItemDataAddRequestOptions
+): Promise<IItemUpdateResponse> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.id
@@ -209,21 +220,23 @@ export function addItemJsonData(
   // a `text` form field. It can also be sent with the `.create` call by sending
   // a `.data` property.
   requestOptions.params = {
-    ...requestOptions.params,
-    text: JSON.stringify(requestOptions.data)
+    text: JSON.stringify(requestOptions.data),
+    ...requestOptions.params
   };
 
   return request(url, requestOptions);
 }
 /**
- * Send blob to an item to be stored as the `/data` resource
+ * Send a file or blob to an item to be stored as the `/data` resource
  *
  * @param requestOptions - Options for the request
+ * @returns A Promise that will resolve with an object reporting
+ *        success/failure and echoing the item id.
  */
-export function addItemBinaryData(
-  requestOptions: IItemJsonRequestOptions
-): Promise<any> {
-  const owner = requestOptions.owner || requestOptions.authentication.username;
+export function addItemData(
+  requestOptions: IItemDataAddRequestOptions
+): Promise<IItemUpdateResponse> {
+  const owner = determineOwner(requestOptions);
 
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.id
@@ -231,8 +244,8 @@ export function addItemBinaryData(
 
   // Portal API requires that the 'data' be POSTed in a `file` form field.
   requestOptions.params = {
-    ...requestOptions.params,
-    file: requestOptions.data
+    file: requestOptions.data,
+    ...requestOptions.params
   };
 
   return request(url, requestOptions);
@@ -448,7 +461,7 @@ export function removeItemResource(
  * Serialize an item into a json format accepted by the Portal API
  * for create and update operations
  *
- * @param item IItem to be serialized
+ * @param item Item to be serialized
  * @returns a formatted json object to be sent to Portal
  */
 function serializeItem(item: IItemAdd | IItemUpdate | IItem): any {

--- a/packages/arcgis-rest-items/test/items.test.ts
+++ b/packages/arcgis-rest-items/test/items.test.ts
@@ -1,5 +1,7 @@
 import * as fetchMock from "fetch-mock";
 
+import { attachmentFile } from "../../arcgis-rest-feature-service/test/attachments.test";
+
 import {
   searchItems,
   getItem,
@@ -9,6 +11,7 @@ import {
   createItemInFolder,
   updateItem,
   addItemJsonData,
+  addItemData,
   protectItem,
   unprotectItem,
   getItemResources,
@@ -657,6 +660,37 @@ describe("search", () => {
             encodeParam("text", JSON.stringify(fakeData))
           );
 
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should add binary item data by id", done => {
+      fetchMock.once("*", {
+        success: true
+      });
+
+      addItemData({
+        id: "3ef",
+        // File() is only available in the browser
+        data: attachmentFile(),
+        ...MOCK_USER_REQOPTS
+      })
+        .then(() => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/update"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body instanceof FormData).toBeTruthy();
+          const params = options.body as FormData;
+          // need to figure out how to introspect FormData from Node.js
+          // expect(params.get("token")).toEqual("fake-token");
+          // expect(params.get("f")).toEqual("json");
+          // expect(params.get("filename")).toEqual("foo.txt");
           done();
         })
         .catch(e => {

--- a/packages/arcgis-rest-request/src/utils/encode-form-data.ts
+++ b/packages/arcgis-rest-request/src/utils/encode-form-data.ts
@@ -15,7 +15,12 @@ export function encodeFormData(params: any): FormData | string {
   if (useFormData) {
     const formData = new FormData();
     Object.keys(newParams).forEach((key: any) => {
-      formData.append(key, newParams[key]);
+      if (key === "file" && newParams[key].name) {
+        // Pass on the file's name if provided to override defaults such as "blob"
+        formData.append(key, newParams[key], newParams[key].name);
+      } else {
+        formData.append(key, newParams[key]);
+      }
     });
     return formData;
   } else {

--- a/packages/arcgis-rest-request/src/utils/process-params.ts
+++ b/packages/arcgis-rest-request/src/utils/process-params.ts
@@ -47,7 +47,12 @@ export function processParams(params: any): any {
 
   Object.keys(params).forEach(key => {
     const param = params[key];
-    if (!param && param !== 0 && typeof param !== "boolean") {
+    if (
+      !param &&
+      param !== 0 &&
+      typeof param !== "boolean" &&
+      typeof param !== "string"
+    ) {
       return;
     }
     const type = param.constructor.name;
@@ -56,10 +61,15 @@ export function processParams(params: any): any {
 
     // properly encodes objects, arrays and dates for arcgis.com and other services.
     // ported from https://github.com/Esri/esri-leaflet/blob/master/src/Request.js#L22-L30
-    // also see https://github.com/Esri/arcgis-rest-js/issues/18
+    // also see https://github.com/Esri/arcgis-rest-js/issues/18:
+    // null, undefined, function are excluded. If you want to send an empty key you need to send an empty string "".
     switch (type) {
       case "Array":
+        // Based on the first element of the array, classify array as an array of objects to be stringified
+        // or an array of non-objects to be comma-separated
         value =
+          param[0] &&
+          param[0].constructor &&
           param[0].constructor.name === "Object"
             ? JSON.stringify(param)
             : param.join(",");
@@ -80,7 +90,7 @@ export function processParams(params: any): any {
         value = param;
         break;
     }
-    if (value || value === 0) {
+    if (value || value === 0 || typeof value === "string") {
       newParams[key] = value;
     }
   });

--- a/packages/arcgis-rest-request/test/utils/encode-form-data.test.ts
+++ b/packages/arcgis-rest-request/test/utils/encode-form-data.test.ts
@@ -1,4 +1,9 @@
 import { encodeFormData } from "../../src/utils/encode-form-data";
+import {
+  requiresFormData,
+  processParams
+} from "../../src/utils/process-params";
+import { attachmentFile } from "../../../arcgis-rest-feature-service/test/attachments.test";
 
 describe("encodeFormData", () => {
   it("should encode in form data for multipart requests", () => {
@@ -12,5 +17,96 @@ describe("encodeFormData", () => {
     const formData = encodeFormData({ binary: binaryObj });
 
     expect(formData instanceof FormData).toBeTruthy();
+  });
+
+  it("should encode as query string for basic types", () => {
+    const dateValue = 1471417200000;
+
+    // null, undefined, function are excluded. If you want to send an empty key you need to send an empty string "".
+    // See https://github.com/Esri/arcgis-rest-js/issues/18
+    const params = {
+      myArray1: new Array(8),
+      myArray2: [1, 2, 4, 16],
+      myArray3: [{ a: 1, b: 2 }, { c: "abc" }],
+      myDate: new Date(dateValue),
+      myFunction: () => {
+        return 3.1415;
+      },
+      myBoolean: true,
+      myString: "Hello, world!",
+      myEmptyString: "",
+      myNumber: 380
+    };
+
+    expect(requiresFormData(params)).toBeFalsy();
+
+    const formData = processParams(params);
+    expect(typeof formData).toBe("object");
+    expect(formData.myArray1).toBe(",,,,,,,");
+    expect(formData.myArray2).toBe("1,2,4,16");
+    expect(formData.myArray3).toBe('[{"a":1,"b":2},{"c":"abc"}]');
+    expect(formData.myDate).toBe(dateValue);
+    expect(formData.myBoolean).toBeTruthy();
+    expect(formData.myString).toBe("Hello, world!");
+    expect(formData.myEmptyString).toBe("");
+    expect(formData.myNumber).toBe(380);
+
+    const encodedFormData = encodeFormData(params);
+    expect(typeof encodedFormData).toBe("string");
+    expect(encodedFormData).toBe(
+      "myArray1=%2C%2C%2C%2C%2C%2C%2C&" +
+        "myArray2=1%2C2%2C4%2C16&" +
+        "myArray3=%5B%7B%22a%22%3A1%2C%22b%22%3A2%7D%2C%7B%22c%22%3A%22abc%22%7D%5D&" +
+        "myDate=1471417200000&" +
+        "myBoolean=true&" +
+        "myString=Hello%2C%20world!&" +
+        "myEmptyString=&" +
+        "myNumber=380"
+    );
+  });
+
+  it("should switch to form data if any item is not a basic type", () => {
+    const dateValue = 1471417200000;
+    const file = attachmentFile();
+    if (!file.name) {
+      // The file's name is used for adding files to a form, so supply a name when we're in a testing
+      // environment that doesn't support File (attachmentFile creates a File with the name "foo.txt"
+      // if File is supported and a file stream otherwise)
+      file.name = "foo.txt";
+    }
+
+    // null, undefined, function are excluded. If you want to send an empty key you need to send an empty string "".
+    // See https://github.com/Esri/arcgis-rest-js/issues/18
+    const params = {
+      myArray1: new Array(8),
+      myArray2: [1, 2, 4, 16],
+      myArray3: [{ a: 1, b: 2 }, { c: "abc" }],
+      myDate: new Date(dateValue),
+      myFunction: () => {
+        return 3.1415;
+      },
+      myBoolean: true,
+      myString: "Hello, world!",
+      myEmptyString: "",
+      myNumber: 380,
+      file
+    };
+
+    expect(requiresFormData(params)).toBeTruthy();
+
+    const formData = processParams(params);
+    expect(typeof formData).toBe("object");
+    expect(formData.myArray1).toBe(",,,,,,,");
+    expect(formData.myArray2).toBe("1,2,4,16");
+    expect(formData.myArray3).toBe('[{"a":1,"b":2},{"c":"abc"}]');
+    expect(formData.myDate).toBe(dateValue);
+    expect(formData.myBoolean).toBeTruthy();
+    expect(formData.myString).toBe("Hello, world!");
+    expect(formData.myEmptyString).toBe("");
+    expect(formData.myNumber).toBe(380);
+    expect(typeof formData.file).toBe("object");
+
+    const encodedFormData = encodeFormData(params);
+    expect(encodedFormData instanceof FormData).toBeTruthy();
   });
 });


### PR DESCRIPTION
For reasonable browsers, a Blob can be converted into a File and sent up with its filename. For IE 11 & Edge, the File constructor is not available, and even if one adds the missing File properties to the Blob, it's sent up to AGOL as "blob" by these two browsers. Changing encode-form-data to use the filename in the FormData.append call gets past this behavior.

I changed the name of IItemJsonDataRequestOptions from a documentation perspective since it can be used by both the JSON and binary functions.

Working on test code.