### PR TITLE
fix(query features): add count and extent to IQueryFeaturesResponse

### DIFF
--- a/demos/attachments/package-lock.json
+++ b/demos/attachments/package-lock.json
@@ -2,22 +2,6 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "@esri/arcgis-rest-feature-service": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-1.5.1.tgz",
-      "integrity": "sha1-UHcRzNbH12qWAiGrt1NftGZqlEE=",
-      "requires": {
-        "tslib": "^1.7.1"
-      }
-    },
-    "@esri/arcgis-rest-request": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.5.1.tgz",
-      "integrity": "sha1-FkpHBgWJL9D03rQihJMj/pNId4w=",
-      "requires": {
-        "tslib": "^1.7.1"
-      }
-    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -175,11 +159,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-    },
-    "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "union": {
       "version": "0.4.6",

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -88,8 +88,14 @@ export interface IQueryFeaturesRequestOptions
 
 export interface IQueryFeaturesResponse extends IFeatureSet {
   exceededTransferLimit?: boolean;
-  count?: number;
-  extent?: IExtent;
+}
+
+export interface IQueryCountResponse {
+  count: number;
+}
+
+export interface IQueryExtentResponse {
+  extent: IExtent;
 }
 
 /**
@@ -147,7 +153,9 @@ export function getFeature(
  */
 export function queryFeatures(
   requestOptions: IQueryFeaturesRequestOptions
-): Promise<IQueryFeaturesResponse> {
+): Promise<
+  IQueryFeaturesResponse | IQueryCountResponse | IQueryExtentResponse
+> {
   // default to a GET request
   const options: IQueryFeaturesRequestOptions = {
     params: {},

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -5,7 +5,8 @@ import {
   ISpatialReference,
   IFeatureSet,
   IFeature,
-  esriUnits
+  esriUnits,
+  IExtent
 } from "@esri/arcgis-rest-common-types";
 import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 
@@ -87,6 +88,8 @@ export interface IQueryFeaturesRequestOptions
 
 export interface IQueryFeaturesResponse extends IFeatureSet {
   exceededTransferLimit?: boolean;
+  count?: number;
+  extent?: IExtent;
 }
 
 /**

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -90,12 +90,11 @@ export interface IQueryFeaturesResponse extends IFeatureSet {
   exceededTransferLimit?: boolean;
 }
 
-export interface IQueryCountResponse {
-  count: number;
-}
-
-export interface IQueryExtentResponse {
-  extent: IExtent;
+export interface IQueryResponse {
+  count?: number;
+  extent?: IExtent;
+  objectIdFieldName?: string;
+  objectIds?: number[];
 }
 
 /**
@@ -153,9 +152,7 @@ export function getFeature(
  */
 export function queryFeatures(
   requestOptions: IQueryFeaturesRequestOptions
-): Promise<
-  IQueryFeaturesResponse | IQueryCountResponse | IQueryExtentResponse
-> {
+): Promise<IQueryFeaturesResponse | IQueryResponse> {
   // default to a GET request
   const options: IQueryFeaturesRequestOptions = {
     params: {},


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-feature-service

`count` and `extent` properties can be returned depending on input params. See examples here https://developers.arcgis.com/rest/services-reference/query-feature-service-layer-.htm

I didn't include this in this PR, but technically `features` should also be optional in the response type. I didn't want to edit `IFeatureSet` since it makes sense that `features` would be required there, so I just left it.