### PR TITLE
refactor: use JSON object literal to construct Headers

### DIFF
--- a/demos/batch-geocoder-node/batch-geocode.js
+++ b/demos/batch-geocoder-node/batch-geocode.js
@@ -1,4 +1,6 @@
 require('isomorphic-fetch');
+// const customFetch = require('node-fetch');
+
 require('isomorphic-form-data');
 const fs = require('fs');
 const Papa = require('papaparse');
@@ -90,7 +92,11 @@ parseCsv(config.csv)
 
     // Geocode
     const promises = chunks.map(chunk => 
-      bulkGeocode({addresses: chunk, authentication: session})
+      bulkGeocode({
+        addresses: chunk,
+        authentication: session //,
+        // fetch: customFetch
+      })
     );
 
     // Resolve results and combine with CSV data

--- a/demos/batch-geocoder-node/package-lock.json
+++ b/demos/batch-geocoder-node/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "batch-geocoder",
+  "version": "1.6.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "async": {
       "version": "2.6.0",
@@ -42,9 +44,12 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -58,6 +63,17 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isomorphic-form-data": {
@@ -87,18 +103,20 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
+      "dev": true
     },
     "papaparse": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.3.6.tgz",
       "integrity": "sha1-lWbtoOyrE6/LdApiOBxpn0hssUU="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "whatwg-fetch": {
       "version": "2.0.3",

--- a/demos/batch-geocoder-node/package.json
+++ b/demos/batch-geocoder-node/package.json
@@ -33,5 +33,8 @@
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-form-data": "^1.0.0",
     "papaparse": "^4.3.6"
+  },
+  "devDependencies": {
+    "node-fetch": "^2.2.0"
   }
 }

--- a/packages/arcgis-rest-auth/src/fetch-token.ts
+++ b/packages/arcgis-rest-auth/src/fetch-token.ts
@@ -1,22 +1,12 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, IParams } from "@esri/arcgis-rest-request";
-
-export type GrantTypes =
-  | "authorization_code"
-  | "refresh_token"
-  | "client_credentials"
-  | "exchange_refresh_token";
-
-export interface IFetchTokenParams extends IParams {
-  client_id: string;
-  client_secret?: string;
-  grant_type: GrantTypes;
-  redirect_uri?: string;
-  refresh_token?: string;
-  code?: string;
-}
+import {
+  request,
+  IRequestOptions,
+  IFetchTokenParams,
+  ITokenRequestOptions
+} from "@esri/arcgis-rest-request";
 
 interface IFetchTokenRawResponse {
   access_token: string;
@@ -34,11 +24,15 @@ export interface IFetchTokenResponse {
 
 export function fetchToken(
   url: string,
-  options: IFetchTokenParams
+  requestOptions: IFetchTokenParams | ITokenRequestOptions
 ): Promise<IFetchTokenResponse> {
-  return request(url, {
-    params: options
-  }).then((response: IFetchTokenRawResponse) => {
+  // TODO: remove union type and type guard next breaking change and just expect IGenerateTokenRequestOptions
+  const options: IRequestOptions = (requestOptions as ITokenRequestOptions)
+    .params
+    ? (requestOptions as IRequestOptions)
+    : { params: requestOptions };
+
+  return request(url, options).then((response: IFetchTokenRawResponse) => {
     const r: IFetchTokenResponse = {
       token: response.access_token,
       username: response.username,

--- a/packages/arcgis-rest-auth/src/generate-token.ts
+++ b/packages/arcgis-rest-auth/src/generate-token.ts
@@ -1,15 +1,12 @@
-/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, IParams } from "@esri/arcgis-rest-request";
-
-export interface IGenerateTokenParams extends IParams {
-  username?: string;
-  password?: string;
-  expiration?: number;
-  token?: string;
-  serverUrl?: string;
-}
+import {
+  request,
+  IRequestOptions,
+  IGenerateTokenParams,
+  ITokenRequestOptions
+} from "@esri/arcgis-rest-request";
 
 export interface IGenerateTokenResponse {
   token: string;
@@ -19,18 +16,24 @@ export interface IGenerateTokenResponse {
 
 export function generateToken(
   url: string,
-  params: IGenerateTokenParams
+  requestOptions: IGenerateTokenParams | ITokenRequestOptions
 ): Promise<IGenerateTokenResponse> {
+  // TODO: remove union type and type guard next breaking change and just expect IGenerateTokenRequestOptions
+  const options: IRequestOptions = (requestOptions as ITokenRequestOptions)
+    .params
+    ? (requestOptions as IRequestOptions)
+    : { params: requestOptions };
+
   /* istanbul ignore else */
   if (
     typeof window !== "undefined" &&
     window.location &&
     window.location.host
   ) {
-    params.referer = window.location.host;
+    options.params.referer = window.location.host;
   } else {
-    params.referer = "@esri.arcgis-rest-auth";
+    options.params.referer = "@esri.arcgis-rest-auth";
   }
 
-  return request(url, { params });
+  return request(url, options);
 }

--- a/packages/arcgis-rest-auth/test/fetchToken.test.ts
+++ b/packages/arcgis-rest-auth/test/fetchToken.test.ts
@@ -13,9 +13,11 @@ describe("fetchToken()", () => {
     });
 
     fetchToken(TOKEN_URL, {
-      client_id: "clientId",
-      client_secret: "clientSecret",
-      grant_type: "client_credentials"
+      params: {
+        client_id: "clientId",
+        client_secret: "clientSecret",
+        grant_type: "client_credentials"
+      }
     })
       .then(response => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
@@ -44,10 +46,12 @@ describe("fetchToken()", () => {
     });
 
     fetchToken(TOKEN_URL, {
-      client_id: "clientId",
-      redirect_uri: "https://example-app.com/redirect-uri",
-      code: "authorizationCode",
-      grant_type: "authorization_code"
+      params: {
+        client_id: "clientId",
+        redirect_uri: "https://example-app.com/redirect-uri",
+        code: "authorizationCode",
+        grant_type: "authorization_code"
+      }
     })
       .then(response => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(

--- a/packages/arcgis-rest-auth/test/generateToken.test.ts
+++ b/packages/arcgis-rest-auth/test/generateToken.test.ts
@@ -7,6 +7,7 @@ const TOKEN_URL = "https://www.arcgis.com/sharing/rest/generateToken";
 describe("generateToken()", () => {
   afterEach(fetchMock.restore);
 
+  // to do: remove next time we have a breaking change
   it("should generate a token for a username and password", done => {
     fetchMock.postOnce(TOKEN_URL, {
       token: "token",
@@ -27,6 +28,96 @@ describe("generateToken()", () => {
         expect(options.body).toContain("password=Jones");
         expect(response.token).toEqual("token");
         expect(response.expires).toEqual(TOMORROW.getTime());
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
+  it("should generate a token for a username and password as params", done => {
+    fetchMock.postOnce(TOKEN_URL, {
+      token: "token",
+      expires: TOMORROW.getTime()
+    });
+
+    generateToken(TOKEN_URL, {
+      params: {
+        username: "Casey",
+        password: "Jones"
+      }
+    })
+      .then(response => {
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          TOKEN_URL
+        );
+        expect(url).toEqual(TOKEN_URL);
+        expect(options.body).toContain("f=json");
+        expect(options.body).toContain("username=Casey");
+        expect(options.body).toContain("password=Jones");
+        expect(response.token).toEqual("token");
+        expect(response.expires).toEqual(TOMORROW.getTime());
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+});
+
+describe("generateToken() with custom fetch", () => {
+  const oldPromise = Promise;
+  const oldFetch = fetch;
+  const oldFormData = FormData;
+
+  beforeEach(() => {
+    Promise = undefined;
+    FormData = undefined;
+    Function("return this")().fetch = undefined;
+  });
+
+  afterEach(() => {
+    Promise = oldPromise;
+    FormData = oldFormData;
+    Function("return this")().fetch = oldFetch;
+  });
+
+  it("should generate a token for a username and password with custom fetch", done => {
+    Promise = oldPromise;
+    FormData = oldFormData;
+
+    const tokenResponse = {
+      token: "token",
+      expires: TOMORROW.getTime()
+    };
+
+    const MockFetchResponse = {
+      ok: true,
+      json() {
+        return Promise.resolve(tokenResponse);
+      },
+      blob() {
+        return Promise.resolve(new Blob([JSON.stringify(tokenResponse)]));
+      },
+      text() {
+        return Promise.resolve(JSON.stringify(tokenResponse));
+      }
+    };
+
+    const MockFetch = function() {
+      return Promise.resolve(MockFetchResponse);
+    };
+
+    generateToken(TOKEN_URL, {
+      params: {
+        username: "Casey",
+        password: "Jones"
+      },
+      fetch: MockFetch as any
+    })
+      .then(response => {
+        expect(response.token).toEqual(tokenResponse.token);
+        expect(response.expires).toEqual(tokenResponse.expires);
         done();
       })
       .catch(e => {

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -207,11 +207,9 @@ export function request(
 
       /* istanbul ignore else blob responses are difficult to make cross platform we will just have to trust the isomorphic fetch will do its job */
       if (!requiresFormData(params)) {
-        fetchOptions.headers = new Headers();
-        fetchOptions.headers.append(
-          "Content-Type",
-          "application/x-www-form-urlencoded"
-        );
+        fetchOptions.headers = {};
+        fetchOptions.headers["Content-Type"] =
+          "application/x-www-form-urlencoded";
       }
 
       return options.fetch(url, fetchOptions);

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
 import { checkForErrors } from "./utils/check-for-errors";
@@ -6,6 +6,35 @@ import { encodeFormData } from "./utils/encode-form-data";
 import { encodeQueryString } from "./utils/encode-query-string";
 import { requiresFormData } from "./utils/process-params";
 import { ArcGISRequestError } from "./utils/ArcGISRequestError";
+
+export type GrantTypes =
+  | "authorization_code"
+  | "refresh_token"
+  | "client_credentials"
+  | "exchange_refresh_token";
+
+export interface IGenerateTokenParams extends IParams {
+  username?: string;
+  password?: string;
+  expiration?: number;
+  token?: string;
+  serverUrl?: string;
+}
+
+export interface IFetchTokenParams extends IParams {
+  client_id: string;
+  client_secret?: string;
+  grant_type: GrantTypes;
+  redirect_uri?: string;
+  refresh_token?: string;
+  code?: string;
+}
+
+export interface ITokenRequestOptions {
+  params?: IGenerateTokenParams | IFetchTokenParams;
+  httpMethod?: HTTPMethods;
+  fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+}
 
 /**
  * Authentication can be supplied to `request` via [`UserSession`](../../auth/UserSession/) or [`ApplicationSession`](../../auth/ApplicationSession/). Both classes extend `IAuthenticationManager`.
@@ -25,7 +54,7 @@ export interface IAuthenticationManager {
    * Defaults to 'https://www.arcgis.com/sharing/rest'.
    */
   portal: string;
-  getToken(url: string): Promise<string>;
+  getToken(url: string, requestOptions?: ITokenRequestOptions): Promise<string>;
 }
 
 /**
@@ -126,14 +155,16 @@ export function request(
 ): Promise<any> {
   const options: IRequestOptions = {
     httpMethod: "POST",
-    fetch,
     ...requestOptions
   };
 
   const missingGlobals: string[] = [];
   const recommendedPackages: string[] = [];
 
-  if (!options.fetch) {
+  // don't check for a global fetch if a custom implementation was passed through
+  if (!options.fetch && typeof fetch !== "undefined") {
+    options.fetch = fetch.bind(Function("return this")());
+  } else {
     missingGlobals.push("`fetch`");
     recommendedPackages.push("`isomorphic-fetch`");
   }
@@ -158,10 +189,6 @@ export function request(
     );
   }
 
-  if (options.fetch === fetch) {
-    options.fetch = fetch.bind(Function("return this")());
-  }
-
   const { httpMethod, authentication } = options;
 
   const params: IParams = {
@@ -175,7 +202,12 @@ export function request(
     credentials: "same-origin"
   };
 
-  return (authentication ? authentication.getToken(url) : Promise.resolve(""))
+  return (authentication
+    ? authentication.getToken(url, {
+        fetch: options.fetch
+      })
+    : Promise.resolve("")
+  )
     .then(token => {
       if (token.length) {
         params.token = token;


### PR DESCRIPTION
i have no idea _why_, but `ember-fetch` ignores the real [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) we currently pass through. this approach is also necessary to support the use case described in #203.

i can't see any downside to the proposed change, but i'm happy to be proven wrong.

AFFECTS PACKAGES:
@esri/arcgis-rest-request