### PR TITLE
Query related records

### DIFF
--- a/packages/arcgis-rest-feature-service/src/helpers.ts
+++ b/packages/arcgis-rest-feature-service/src/helpers.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 import {
   esriGeometryType,
@@ -6,13 +6,13 @@ import {
   IGeometry,
   ISpatialReference
 } from "@esri/arcgis-rest-common-types";
-import { request, IRequestOptions, IParams } from "@esri/arcgis-rest-request";
+import { IRequestOptions } from "@esri/arcgis-rest-request";
 
 import { IQueryFeaturesRequestOptions } from "./query";
 import { IAddFeaturesRequestOptions } from "./add";
 import { IUpdateFeaturesRequestOptions } from "./update";
 import { IDeleteFeaturesRequestOptions } from "./delete";
-import { IQueryRelatedRecordsRequestOptions } from "./queryRelated";
+import { IQueryRelatedRequestOptions } from "./queryRelated";
 
 export interface ISharedQueryParams {
   where?: string;
@@ -59,7 +59,7 @@ export function appendCustomParams(
     | IAddFeaturesRequestOptions
     | IUpdateFeaturesRequestOptions
     | IDeleteFeaturesRequestOptions
-    | IQueryRelatedRecordsRequestOptions,
+    | IQueryRelatedRequestOptions,
   newOptions: IRequestOptions
 ) {
   // only pass query parameters through in the request, not generic IRequestOptions props

--- a/packages/arcgis-rest-feature-service/src/helpers.ts
+++ b/packages/arcgis-rest-feature-service/src/helpers.ts
@@ -12,6 +12,7 @@ import { IQueryFeaturesRequestOptions } from "./query";
 import { IAddFeaturesRequestOptions } from "./add";
 import { IUpdateFeaturesRequestOptions } from "./update";
 import { IDeleteFeaturesRequestOptions } from "./delete";
+import { IQueryRelatedRecordsRequestOptions } from "./queryRelated";
 
 export interface ISharedQueryParams {
   where?: string;
@@ -57,7 +58,8 @@ export function appendCustomParams(
     | IQueryFeaturesRequestOptions
     | IAddFeaturesRequestOptions
     | IUpdateFeaturesRequestOptions
-    | IDeleteFeaturesRequestOptions,
+    | IDeleteFeaturesRequestOptions
+    | IQueryRelatedRecordsRequestOptions,
   newOptions: IRequestOptions
 ) {
   // only pass query parameters through in the request, not generic IRequestOptions props

--- a/packages/arcgis-rest-feature-service/src/index.ts
+++ b/packages/arcgis-rest-feature-service/src/index.ts
@@ -6,3 +6,4 @@ export * from "./getAttachments";
 export * from "./addAttachment";
 export * from "./updateAttachment";
 export * from "./deleteAttachments";
+export * from "./queryRelated";

--- a/packages/arcgis-rest-feature-service/src/queryRelated.ts
+++ b/packages/arcgis-rest-feature-service/src/queryRelated.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
 import {
@@ -12,27 +12,14 @@ import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 import { appendCustomParams } from "./helpers";
 
 /**
- * Query related records request options. See [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-records-feature-service-.htm) for more information.
+ * Related record query request options. Additional arguments can be passed via the [params](/api/feature-service/IQueryRelatedRecordsRequestOptions/#params) property. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-records-feature-service-.htm) for more information and a full list of parameters.
  */
 export interface IQueryRelatedRecordsRequestOptions extends IRequestOptions {
   url: string;
-  relationshipId: number;
+  relationshipId?: number;
   objectIds?: number[];
   outFields?: "*" | string[];
   definitionExpression?: string;
-  returnGeometry?: boolean;
-  maxAllowableOffset?: number;
-  geometryPrecision?: number;
-  resultOffset?: number;
-  resultRecordCount?: number;
-  outSR?: string | ISpatialReference;
-  gdbVersion?: string;
-  historicMoment?: number;
-  returnZ?: boolean;
-  returnM?: boolean;
-  returnTrueCurves?: boolean;
-  orderByFields?: string;
-  returnCountOnly?: boolean;
 }
 
 /**
@@ -49,14 +36,14 @@ export interface IRelatedRecordGroup {
  * Related record response structure
  */
 
-export interface IQueryRelatedRecordResponse extends IHasZM {
+export interface IQueryRelatedRecordsResponse extends IHasZM {
   geometryType?: esriGeometryType;
   spatialReference?: ISpatialReference;
   fields?: IField[];
   relatedRecordGroups: IRelatedRecordGroup[];
 }
 /**
- * Query the related records for a feature service. See [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-records-feature-service-.htm) for more information.
+ * Query the related records for a feature service. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-records-feature-service-.htm) for more information.
  *
  * ```js
  * import { queryRelatedRecords } from '@esri/arcgis-rest-feature-service'
@@ -65,8 +52,9 @@ export interface IQueryRelatedRecordResponse extends IHasZM {
  *
  * queryRelatedRecords({
  *  url: url,
- *  relationshipId: 1
- * };)
+ *  relationshipId: 1,
+ *  params: { returnCountOnly: true }
+ * })
  *  .then(response => {
  *    console.log(response.relatedRecords)
  *  })
@@ -77,7 +65,7 @@ export interface IQueryRelatedRecordResponse extends IHasZM {
  */
 export function queryRelatedRecords(
   requestOptions: IQueryRelatedRecordsRequestOptions
-): Promise<IQueryRelatedRecordResponse> {
+): Promise<IQueryRelatedRecordsResponse> {
   const options: IQueryRelatedRecordsRequestOptions = {
     params: {},
     httpMethod: "GET",
@@ -93,6 +81,10 @@ export function queryRelatedRecords(
 
   if (!options.params.outFields) {
     options.params.outFields = "*";
+  }
+
+  if (!options.params.relationshipId) {
+    options.params.relationshipId = 0;
   }
 
   return request(`${options.url}/queryRelatedRecords`, options);

--- a/packages/arcgis-rest-feature-service/src/queryRelated.ts
+++ b/packages/arcgis-rest-feature-service/src/queryRelated.ts
@@ -39,7 +39,7 @@ export interface IQueryRelatedRecordsRequestOptions extends IRequestOptions {
  * Related record data structure
  */
 
-export interface IRelatedRecordGroups {
+export interface IRelatedRecordGroup {
   objectId: number;
   relatedRecords?: IFeature[];
   count?: number;
@@ -53,7 +53,7 @@ export interface IQueryRelatedRecordResponse extends IHasZM {
   geometryType?: esriGeometryType;
   spatialReference?: ISpatialReference;
   fields?: IField[];
-  relatedRecordGroups: IRelatedRecordGroups;
+  relatedRecordGroups: IRelatedRecordGroup[];
 }
 /**
  * Query the related records for a feature service. See [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-records-feature-service-.htm) for more information.

--- a/packages/arcgis-rest-feature-service/src/queryRelated.ts
+++ b/packages/arcgis-rest-feature-service/src/queryRelated.ts
@@ -12,9 +12,9 @@ import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 import { appendCustomParams } from "./helpers";
 
 /**
- * Related record query request options. Additional arguments can be passed via the [params](/api/feature-service/IQueryRelatedRecordsRequestOptions/#params) property. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-records-feature-service-.htm) for more information and a full list of parameters.
+ * Related record query request options. Additional arguments can be passed via the [params](/arcgis-rest-js/api/feature-service/IQueryRelatedRequestOptions/#params) property. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-feature-service-.htm) for more information and a full list of parameters.
  */
-export interface IQueryRelatedRecordsRequestOptions extends IRequestOptions {
+export interface IQueryRelatedRequestOptions extends IRequestOptions {
   url: string;
   relationshipId?: number;
   objectIds?: number[];
@@ -36,7 +36,7 @@ export interface IRelatedRecordGroup {
  * Related record response structure
  */
 
-export interface IQueryRelatedRecordsResponse extends IHasZM {
+export interface IQueryRelatedResponse extends IHasZM {
   geometryType?: esriGeometryType;
   spatialReference?: ISpatialReference;
   fields?: IField[];
@@ -46,11 +46,11 @@ export interface IQueryRelatedRecordsResponse extends IHasZM {
  * Query the related records for a feature service. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-records-feature-service-.htm) for more information.
  *
  * ```js
- * import { queryRelatedRecords } from '@esri/arcgis-rest-feature-service'
+ * import { queryRelated } from '@esri/arcgis-rest-feature-service'
  *
  * const url = "http://services.myserver/OrgID/ArcGIS/rest/services/Petroleum/KSPetro/FeatureServer/0"
  *
- * queryRelatedRecords({
+ * queryRelated({
  *  url: url,
  *  relationshipId: 1,
  *  params: { returnCountOnly: true }
@@ -63,10 +63,10 @@ export interface IQueryRelatedRecordsResponse extends IHasZM {
  * @param requestOptions
  * @returns A Promise that will resolve with the query response
  */
-export function queryRelatedRecords(
-  requestOptions: IQueryRelatedRecordsRequestOptions
-): Promise<IQueryRelatedRecordsResponse> {
-  const options: IQueryRelatedRecordsRequestOptions = {
+export function queryRelated(
+  requestOptions: IQueryRelatedRequestOptions
+): Promise<IQueryRelatedResponse> {
+  const options: IQueryRelatedRequestOptions = {
     params: {},
     httpMethod: "GET",
     url: requestOptions.url,

--- a/packages/arcgis-rest-feature-service/src/queryRelated.ts
+++ b/packages/arcgis-rest-feature-service/src/queryRelated.ts
@@ -1,0 +1,99 @@
+/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import {
+  ISpatialReference,
+  IFeature,
+  IHasZM,
+  esriGeometryType,
+  IField
+} from "@esri/arcgis-rest-common-types";
+import { request, IRequestOptions } from "@esri/arcgis-rest-request";
+import { appendCustomParams } from "./helpers";
+
+/**
+ * Query related records request options. See [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-records-feature-service-.htm) for more information.
+ */
+export interface IQueryRelatedRecordsRequestOptions extends IRequestOptions {
+  url: string;
+  relationshipId: number;
+  objectIds?: number[];
+  outFields?: "*" | string[];
+  definitionExpression?: string;
+  returnGeometry?: boolean;
+  maxAllowableOffset?: number;
+  geometryPrecision?: number;
+  resultOffset?: number;
+  resultRecordCount?: number;
+  outSR?: string | ISpatialReference;
+  gdbVersion?: string;
+  historicMoment?: number;
+  returnZ?: boolean;
+  returnM?: boolean;
+  returnTrueCurves?: boolean;
+  orderByFields?: string;
+  returnCountOnly?: boolean;
+}
+
+/**
+ * Related record data structure
+ */
+
+export interface IRelatedRecordGroups {
+  objectId: number;
+  relatedRecords?: IFeature[];
+  count?: number;
+}
+
+/**
+ * Related record response structure
+ */
+
+export interface IQueryRelatedRecordResponse extends IHasZM {
+  geometryType?: esriGeometryType;
+  spatialReference?: ISpatialReference;
+  fields?: IField[];
+  relatedRecordGroups: IRelatedRecordGroups;
+}
+/**
+ * Query the related records for a feature service. See [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-records-feature-service-.htm) for more information.
+ *
+ * ```js
+ * import { queryRelatedRecords } from '@esri/arcgis-rest-feature-service'
+ *
+ * const url = "http://services.myserver/OrgID/ArcGIS/rest/services/Petroleum/KSPetro/FeatureServer/0"
+ *
+ * queryRelatedRecords({
+ *  url: url,
+ *  relationshipId: 1
+ * };)
+ *  .then(response => {
+ *    console.log(response.relatedRecords)
+ *  })
+ * ```
+ *
+ * @param requestOptions
+ * @returns A Promise that will resolve with the query response
+ */
+export function queryRelatedRecords(
+  requestOptions: IQueryRelatedRecordsRequestOptions
+): Promise<IQueryRelatedRecordResponse> {
+  const options: IQueryRelatedRecordsRequestOptions = {
+    params: {},
+    httpMethod: "GET",
+    url: requestOptions.url,
+    ...requestOptions
+  };
+
+  appendCustomParams(requestOptions, options);
+
+  if (!options.params.definitionExpression) {
+    options.params.definitionExpression = "1=1";
+  }
+
+  if (!options.params.outFields) {
+    options.params.outFields = "*";
+  }
+
+  return request(`${options.url}/queryRelatedRecords`, options);
+}

--- a/packages/arcgis-rest-feature-service/test/features.test.ts
+++ b/packages/arcgis-rest-feature-service/test/features.test.ts
@@ -172,10 +172,9 @@ describe("feature", () => {
     });
   });
 
-  it("should supply default query parameters (query related)", done => {
+  it("should supply default query related parameters", done => {
     const requestOptions = {
-      url: serviceUrl,
-      relationshipId: 1
+      url: serviceUrl
     };
     fetchMock.once("*", queryRelatedResponse);
     queryRelatedRecords(requestOptions).then(response => {
@@ -184,14 +183,14 @@ describe("feature", () => {
       expect(url).toEqual(
         `${
           requestOptions.url
-        }/queryRelatedRecords?f=json&relationshipId=1&definitionExpression=1%3D1&outFields=*`
+        }/queryRelatedRecords?f=json&definitionExpression=1%3D1&outFields=*&relationshipId=0`
       );
       expect(options.method).toBe("GET");
       done();
     });
   });
 
-  it("should use passed in query parameters (query related)", done => {
+  it("should use passed in query related parameters", done => {
     const requestOptions = {
       url: serviceUrl,
       relationshipId: 1,

--- a/packages/arcgis-rest-feature-service/test/features.test.ts
+++ b/packages/arcgis-rest-feature-service/test/features.test.ts
@@ -4,6 +4,7 @@ import {
   addFeatures,
   updateFeatures,
   deleteFeatures,
+  queryRelatedRecords,
   IDeleteFeaturesRequestOptions,
   IUpdateFeaturesRequestOptions
 } from "../src/index";
@@ -15,7 +16,8 @@ import {
   queryResponse,
   addFeaturesResponse,
   updateFeaturesResponse,
-  deleteFeaturesResponse
+  deleteFeaturesResponse,
+  queryRelatedResponse
 } from "./mocks/feature";
 
 const serviceUrl =
@@ -166,6 +168,45 @@ describe("feature", () => {
         requestOptions.deletes[0]
       );
       expect(response.deleteResults[0].success).toEqual(true);
+      done();
+    });
+  });
+
+  it("should supply default query parameters (query related)", done => {
+    const requestOptions = {
+      url: serviceUrl,
+      relationshipId: 1
+    };
+    fetchMock.once("*", queryRelatedResponse);
+    queryRelatedRecords(requestOptions).then(response => {
+      expect(fetchMock.called()).toBeTruthy();
+      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+      expect(url).toEqual(
+        `${
+          requestOptions.url
+        }/queryRelatedRecords?f=json&relationshipId=1&definitionExpression=1%3D1&outFields=*`
+      );
+      expect(options.method).toBe("GET");
+      done();
+    });
+  });
+
+  it("should use passed in query parameters (query related)", done => {
+    const requestOptions = {
+      url: serviceUrl,
+      relationshipId: 1,
+      definitionExpression: "APPROXACRE<10000",
+      outFields: ["APPROXACRE", "FIELD_NAME"]
+    };
+    fetchMock.once("*", queryRelatedResponse);
+    queryRelatedRecords(requestOptions).then(response => {
+      expect(fetchMock.called()).toBeTruthy();
+      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+      expect(url).toEqual(
+        `${
+          requestOptions.url
+        }/queryRelatedRecords?f=json&relationshipId=1&definitionExpression=APPROXACRE%3C10000&outFields=APPROXACRE%2CFIELD_NAME`
+      );
       done();
     });
   });

--- a/packages/arcgis-rest-feature-service/test/features.test.ts
+++ b/packages/arcgis-rest-feature-service/test/features.test.ts
@@ -4,9 +4,10 @@ import {
   addFeatures,
   updateFeatures,
   deleteFeatures,
-  queryRelatedRecords,
+  queryRelated,
   IDeleteFeaturesRequestOptions,
-  IUpdateFeaturesRequestOptions
+  IUpdateFeaturesRequestOptions,
+  IQueryRelatedRequestOptions
 } from "../src/index";
 
 import * as fetchMock from "fetch-mock";
@@ -177,7 +178,7 @@ describe("feature", () => {
       url: serviceUrl
     };
     fetchMock.once("*", queryRelatedResponse);
-    queryRelatedRecords(requestOptions).then(response => {
+    queryRelated(requestOptions).then(() => {
       expect(fetchMock.called()).toBeTruthy();
       const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
       expect(url).toEqual(
@@ -195,17 +196,19 @@ describe("feature", () => {
       url: serviceUrl,
       relationshipId: 1,
       definitionExpression: "APPROXACRE<10000",
-      outFields: ["APPROXACRE", "FIELD_NAME"]
-    };
+      outFields: ["APPROXACRE", "FIELD_NAME"],
+      httpMethod: "POST"
+    } as IQueryRelatedRequestOptions;
     fetchMock.once("*", queryRelatedResponse);
-    queryRelatedRecords(requestOptions).then(response => {
+    queryRelated(requestOptions).then(() => {
       expect(fetchMock.called()).toBeTruthy();
       const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(
-        `${
-          requestOptions.url
-        }/queryRelatedRecords?f=json&relationshipId=1&definitionExpression=APPROXACRE%3C10000&outFields=APPROXACRE%2CFIELD_NAME`
-      );
+      expect(url).toEqual(`${requestOptions.url}/queryRelatedRecords`);
+      expect(options.method).toBe("POST");
+      expect(options.body).toContain("f=json");
+      expect(options.body).toContain("relationshipId=1");
+      expect(options.body).toContain("definitionExpression=APPROXACRE%3C10000");
+      expect(options.body).toContain("outFields=APPROXACRE%2CFIELD_NAME");
       done();
     });
   });

--- a/packages/arcgis-rest-feature-service/test/mocks/feature.ts
+++ b/packages/arcgis-rest-feature-service/test/mocks/feature.ts
@@ -218,3 +218,61 @@ export const genericInvalidResponse = {
     message: "Invalid or missing input parameters."
   }
 };
+
+export const queryRelatedResponse = {
+  geometryType: "esriGeometryPolygon",
+  spatialReference: {
+    wkid: 4267
+  },
+  fields: [
+    {
+      name: "OBJECTID",
+      type: "esriFieldTypeOID",
+      alias: "OBJECTID"
+    },
+    {
+      name: "FIELD_KID",
+      type: "esriFieldTypeString",
+      alias: "FIELD_KID",
+      length: 25
+    },
+    {
+      name: "APPROXACRE",
+      type: "esriFieldTypeDouble",
+      alias: "APPROXACRE"
+    },
+    {
+      name: "FIELD_NAME",
+      type: "esriFieldTypeString",
+      alias: "FIELD_NAME",
+      length: 150
+    }
+  ],
+  relatedRecordGroups: [
+    {
+      objectId: 3,
+      relatedRecords: [
+        {
+          attributes: {
+            OBJECTID: 5540,
+            FIELD_KID: "1000147595",
+            APPROXACRE: 95929,
+            FIELD_NAME: "LOST SPRINGS"
+          },
+          geometry: {
+            rings: [
+              [
+                [-96.929599633999942, 38.52426809800005],
+                [-96.929602437999961, 38.522448437000037],
+                [-96.92959118999994, 38.529723252000053],
+                [-96.929594022999936, 38.527905578000059],
+                [-96.929596839999988, 38.526087119000067],
+                [-96.929599633999942, 38.52426809800005]
+              ]
+            ]
+          }
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
Hey arcgis-rest-js team!

`queryRelatedRecords` came up in a project so I thought I'd try TS and write a wrapper--please let me know if you have feedback/suggested changes

Also, how do I compile and test the function? I wrote a couple mock [unit tests](https://github.com/mpayson/arcgis-rest-js/blob/mp-queryrelates/packages/arcgis-rest-feature-service/test/features.test.ts#L175) following the `queryFeatures` [pattern](https://github.com/mpayson/arcgis-rest-js/blob/mp-queryrelates/packages/arcgis-rest-feature-service/test/features.test.ts#L45), but I'm not sure how to access this function to test on a live feature service

thanks!

cc @jgravois 