### PR TITLE
fix: ensure getGeocodeService() is exported

### DIFF
--- a/demos/geocoder-browser/index.html
+++ b/demos/geocoder-browser/index.html
@@ -101,7 +101,7 @@ reverseBtn.addEventListener('click', function (e) {
 var metadataBtn = document.getElementById('metadata');
 
 metadataBtn.addEventListener('click', function (e) {
-    arcgisRest.serviceInfo()
+    arcgisRest.getGeocodeService()
     .then((response) => {
         console.log("metadata", response);
     });

--- a/demos/geocoder-browser/post-sign-in.html
+++ b/demos/geocoder-browser/post-sign-in.html
@@ -6,8 +6,8 @@
 <body>
 
 <script src="config.js"></script>
-<script src="node_modules/@esri/arcgis-rest-request/dist/umd/arcgis-rest-request.umd.js"></script>
-<script src="node_modules/@esri/arcgis-rest-auth/dist/umd/arcgis-rest-auth.umd.js"></script>
+<script src="node_modules/@esri/arcgis-rest-request/dist/umd/request.umd.js"></script>
+<script src="node_modules/@esri/arcgis-rest-auth/dist/umd/auth.umd.js"></script>
 
 <script>
 try {

--- a/packages/arcgis-rest-geocoder/src/index.ts
+++ b/packages/arcgis-rest-geocoder/src/index.ts
@@ -2,3 +2,4 @@ export * from "./geocode";
 export * from "./suggest";
 export * from "./reverse";
 export * from "./bulk";
+export * from "./helpers";


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-geocoder
@esri/arcgis-rest-geocoder-vanilla

ISSUES CLOSED: #267