### PR TITLE
refactor: allow passing a custom fetch through for ApplicationSession too

### DIFF
--- a/packages/arcgis-rest-auth/src/fetch-token.ts
+++ b/packages/arcgis-rest-auth/src/fetch-token.ts
@@ -1,22 +1,12 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, IParams } from "@esri/arcgis-rest-request";
-
-export type GrantTypes =
-  | "authorization_code"
-  | "refresh_token"
-  | "client_credentials"
-  | "exchange_refresh_token";
-
-export interface IFetchTokenParams extends IParams {
-  client_id: string;
-  client_secret?: string;
-  grant_type: GrantTypes;
-  redirect_uri?: string;
-  refresh_token?: string;
-  code?: string;
-}
+import {
+  request,
+  IRequestOptions,
+  IFetchTokenParams,
+  ITokenRequestOptions
+} from "@esri/arcgis-rest-request";
 
 interface IFetchTokenRawResponse {
   access_token: string;
@@ -34,11 +24,15 @@ export interface IFetchTokenResponse {
 
 export function fetchToken(
   url: string,
-  options: IFetchTokenParams
+  requestOptions: IFetchTokenParams | ITokenRequestOptions
 ): Promise<IFetchTokenResponse> {
-  return request(url, {
-    params: options
-  }).then((response: IFetchTokenRawResponse) => {
+  // TODO: remove union type and type guard next breaking change and just expect IGenerateTokenRequestOptions
+  const options: IRequestOptions = (requestOptions as ITokenRequestOptions)
+    .params
+    ? (requestOptions as IRequestOptions)
+    : { params: requestOptions };
+
+  return request(url, options).then((response: IFetchTokenRawResponse) => {
     const r: IFetchTokenResponse = {
       token: response.access_token,
       username: response.username,

--- a/packages/arcgis-rest-auth/src/generate-token.ts
+++ b/packages/arcgis-rest-auth/src/generate-token.ts
@@ -5,7 +5,7 @@ import {
   request,
   IRequestOptions,
   IGenerateTokenParams,
-  IGenerateTokenRequestOptions
+  ITokenRequestOptions
 } from "@esri/arcgis-rest-request";
 
 export interface IGenerateTokenResponse {
@@ -16,13 +16,13 @@ export interface IGenerateTokenResponse {
 
 export function generateToken(
   url: string,
-  requestOptionsOrParams: IGenerateTokenParams | IGenerateTokenRequestOptions
+  requestOptions: IGenerateTokenParams | ITokenRequestOptions
 ): Promise<IGenerateTokenResponse> {
   // TODO: remove union type and type guard next breaking change and just expect IGenerateTokenRequestOptions
-  const options: IRequestOptions = (requestOptionsOrParams as IGenerateTokenRequestOptions)
+  const options: IRequestOptions = (requestOptions as ITokenRequestOptions)
     .params
-    ? (requestOptionsOrParams as IRequestOptions)
-    : { params: requestOptionsOrParams };
+    ? (requestOptions as IRequestOptions)
+    : { params: requestOptions };
 
   /* istanbul ignore else */
   if (

--- a/packages/arcgis-rest-auth/test/fetchToken.test.ts
+++ b/packages/arcgis-rest-auth/test/fetchToken.test.ts
@@ -13,9 +13,11 @@ describe("fetchToken()", () => {
     });
 
     fetchToken(TOKEN_URL, {
-      client_id: "clientId",
-      client_secret: "clientSecret",
-      grant_type: "client_credentials"
+      params: {
+        client_id: "clientId",
+        client_secret: "clientSecret",
+        grant_type: "client_credentials"
+      }
     })
       .then(response => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
@@ -44,10 +46,12 @@ describe("fetchToken()", () => {
     });
 
     fetchToken(TOKEN_URL, {
-      client_id: "clientId",
-      redirect_uri: "https://example-app.com/redirect-uri",
-      code: "authorizationCode",
-      grant_type: "authorization_code"
+      params: {
+        client_id: "clientId",
+        redirect_uri: "https://example-app.com/redirect-uri",
+        code: "authorizationCode",
+        grant_type: "authorization_code"
+      }
     })
       .then(response => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -7,6 +7,12 @@ import { encodeQueryString } from "./utils/encode-query-string";
 import { requiresFormData } from "./utils/process-params";
 import { ArcGISRequestError } from "./utils/ArcGISRequestError";
 
+export type GrantTypes =
+  | "authorization_code"
+  | "refresh_token"
+  | "client_credentials"
+  | "exchange_refresh_token";
+
 export interface IGenerateTokenParams extends IParams {
   username?: string;
   password?: string;
@@ -15,8 +21,17 @@ export interface IGenerateTokenParams extends IParams {
   serverUrl?: string;
 }
 
-export interface IGenerateTokenRequestOptions {
-  params?: IGenerateTokenParams;
+export interface IFetchTokenParams extends IParams {
+  client_id: string;
+  client_secret?: string;
+  grant_type: GrantTypes;
+  redirect_uri?: string;
+  refresh_token?: string;
+  code?: string;
+}
+
+export interface ITokenRequestOptions {
+  params?: IGenerateTokenParams | IFetchTokenParams;
   httpMethod?: HTTPMethods;
   fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 }
@@ -39,10 +54,7 @@ export interface IAuthenticationManager {
    * Defaults to 'https://www.arcgis.com/sharing/rest'.
    */
   portal: string;
-  getToken(
-    url: string,
-    requestOptions?: IGenerateTokenRequestOptions
-  ): Promise<string>;
+  getToken(url: string, requestOptions?: ITokenRequestOptions): Promise<string>;
 }
 
 /**


### PR DESCRIPTION
caught a few internal UserSession methods while i was at it.

AFFECTS PACKAGES:
@esri/arcgis-rest-auth
@esri/arcgis-rest-request