### PR TITLE
chore(:lock:): bump devDependencies to resolve security vulnerability

### DIFF
--- a/demos/batch-geocoder-node/README.md
+++ b/demos/batch-geocoder-node/README.md
@@ -9,6 +9,6 @@
    3. `"csv"`: csv path
    4. `"output"`: output csv path
    5. `"fieldmap"`: `object` that maps CSV fields to [address fields](https://esri.github.io/arcgis-rest-js/api/geocoder/IAddressBulk/) __or__ `string` that points to a CSV field with single-line addresses
-3. `node batch-geocode.js`
+3. `npm start`
 
 Sample Restaurant Inspections adapted from a DOHMH dataset available [online](https://data.cityofnewyork.us/Health/DOHMH-New-York-City-Restaurant-Inspection-Results/xx67-kt59/data)

--- a/demos/batch-geocoder-node/config-template.js
+++ b/demos/batch-geocoder-node/config-template.js
@@ -2,7 +2,7 @@ module.exports = {
   "un": "<USERNAME>",
   "pw": "<PASSWORD>",
   "csv": "NYC_Restaurant_Inspection_Results.csv",
-  "output": "NYC_Inspections_Geocoded.csv",
+  "output": "NYC_Restaurant_Inspection_Results_Geocoded.csv",
   "fieldmap": {
     "address": "ADDRESS",
     // "address2": "<csv field>",

--- a/demos/batch-geocoder-node/package-lock.json
+++ b/demos/batch-geocoder-node/package-lock.json
@@ -1,21 +1,16 @@
 {
-  "name": "batch-geocoder",
-  "version": "1.6.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
-    "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "requires": {
-        "lodash": "^4.14.0"
-      }
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -34,13 +29,13 @@
       }
     },
     "form-data": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "async": "^2.0.1",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.11"
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "iconv-lite": {
@@ -77,41 +72,35 @@
       }
     },
     "isomorphic-form-data": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-1.0.0.tgz",
-      "integrity": "sha1-BEe+fg9rht7z05MDbPdmSpiRkQA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz",
+      "integrity": "sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==",
       "requires": {
-        "form-data": "^1.0.0-rc3"
+        "form-data": "^2.3.2"
       }
     },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "requires": {
-        "mime-db": "~1.30.0"
+        "mime-db": "~1.35.0"
       }
     },
     "node-fetch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
-      "dev": true
+      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
     },
     "papaparse": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.3.6.tgz",
-      "integrity": "sha1-lWbtoOyrE6/LdApiOBxpn0hssUU="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.6.0.tgz",
+      "integrity": "sha512-ylm8pmgyz9rkS3Ng/ru5tHUF3JxWwKYP0aZZWZ8eCGdSxoqgYiDUXLNQei73mUJOjHw8QNu5ZNCsLoDpkMA6sg=="
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/demos/batch-geocoder-node/package.json
+++ b/demos/batch-geocoder-node/package.json
@@ -4,7 +4,8 @@
   "description": "arcgis-rest-js batch geocode sample",
   "main": "batch-geocode.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node batch-geocode.js"
   },
   "repository": {
     "type": "git",
@@ -31,10 +32,8 @@
     "@esri/arcgis-rest-geocoder": "^1.7.0",
     "@esri/arcgis-rest-request": "^1.7.0",
     "isomorphic-fetch": "^2.2.1",
-    "isomorphic-form-data": "^1.0.0",
-    "papaparse": "^4.3.6"
-  },
-  "devDependencies": {
-    "node-fetch": "^2.2.0"
+    "isomorphic-form-data": "^2.0.0",
+    "node-fetch": "^2.2.0",
+    "papaparse": "^4.6.0"
   }
 }

--- a/demos/express/package-lock.json
+++ b/demos/express/package-lock.json
@@ -16,18 +16,15 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
-    "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "requires": {
-        "lodash": "^4.14.0"
-      }
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -153,13 +150,13 @@
       }
     },
     "form-data": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "async": "^2.0.1",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.11"
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -213,17 +210,12 @@
       }
     },
     "isomorphic-form-data": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-1.0.0.tgz",
-      "integrity": "sha1-BEe+fg9rht7z05MDbPdmSpiRkQA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz",
+      "integrity": "sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==",
       "requires": {
-        "form-data": "^1.0.0-rc3"
+        "form-data": "^2.3.2"
       }
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/demos/express/package.json
+++ b/demos/express/package.json
@@ -10,7 +10,7 @@
     "@esri/arcgis-rest-request": "^1.7.0",
     "express": "^4.15.4",
     "isomorphic-fetch": "^2.2.1",
-    "isomorphic-form-data": "^1.0.0"
+    "isomorphic-form-data": "^2.0.0"
   },
   "scripts": {
     "start": "node server.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4432,7 +4432,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -9965,7 +9965,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "resolved": "https://r.cnpmjs.org/cross-spawn/download/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
@@ -10728,7 +10728,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-3721

AFFECTS PACKAGES:
batch-geocoder
@esri/arcgis-rest-demo-express