### PR TITLE
fix(encodeFormData): append file name based on object type instead of…

### DIFF
--- a/packages/arcgis-rest-items/test/items.test.ts
+++ b/packages/arcgis-rest-items/test/items.test.ts
@@ -672,10 +672,12 @@ describe("search", () => {
         success: true
       });
 
+      const file = attachmentFile();
+
       addItemData({
         id: "3ef",
         // File() is only available in the browser
-        data: attachmentFile(),
+        data: file,
         ...MOCK_USER_REQOPTS
       })
         .then(() => {
@@ -687,10 +689,12 @@ describe("search", () => {
           expect(options.method).toBe("POST");
           expect(options.body instanceof FormData).toBeTruthy();
           const params = options.body as FormData;
-          // need to figure out how to introspect FormData from Node.js
-          // expect(params.get("token")).toEqual("fake-token");
-          // expect(params.get("f")).toEqual("json");
-          // expect(params.get("filename")).toEqual("foo.txt");
+          if (params.get) {
+            expect(params.get("token")).toEqual("fake-token");
+            expect(params.get("f")).toEqual("json");
+            expect(params.get("file")).toEqual(file);
+          }
+
           done();
         })
         .catch(e => {

--- a/packages/arcgis-rest-request/src/utils/encode-form-data.ts
+++ b/packages/arcgis-rest-request/src/utils/encode-form-data.ts
@@ -15,9 +15,9 @@ export function encodeFormData(params: any): FormData | string {
   if (useFormData) {
     const formData = new FormData();
     Object.keys(newParams).forEach((key: any) => {
-      if (key === "file" && newParams[key].name) {
-        // Pass on the file's name if provided to override defaults such as "blob"
-        formData.append(key, newParams[key], newParams[key].name);
+      if (typeof Blob !== "undefined" && newParams[key] instanceof Blob) {
+        // Pass on the explicit file name to override default name such as "blob"
+        formData.append(key, newParams[key], newParams[key].name || key);
       } else {
         formData.append(key, newParams[key]);
       }

--- a/packages/arcgis-rest-request/test/utils/encode-form-data.test.ts
+++ b/packages/arcgis-rest-request/test/utils/encode-form-data.test.ts
@@ -6,17 +6,35 @@ import {
 import { attachmentFile } from "../../../arcgis-rest-feature-service/test/attachments.test";
 
 describe("encodeFormData", () => {
-  it("should encode in form data for multipart requests", () => {
-    const binaryObj =
-      typeof File !== "undefined"
-        ? new File(["foo"], "foo.txt", {
-            type: "text/plain"
-          })
-        : new Buffer("");
+  it("should encode in form data for multipart file requests", () => {
+    const binaryObj = attachmentFile();
 
     const formData = encodeFormData({ binary: binaryObj });
-
     expect(formData instanceof FormData).toBeTruthy();
+
+    const data = formData as FormData;
+    if (data.get) {
+      expect(data.get("binary") instanceof File).toBeTruthy();
+      expect((data.get("binary") as File).name).toBe("foo.txt");
+    }
+  });
+
+  it("should encode in form data for multipart blob requests", () => {
+    const binaryObj =
+      typeof Blob !== "undefined"
+        ? new Blob([], {
+            type: "text/plain"
+          })
+        : Buffer.from("");
+
+    const formData = encodeFormData({ binary: binaryObj });
+    expect(formData instanceof FormData).toBeTruthy();
+
+    const data = formData as FormData;
+    if (data.get) {
+      expect(data.get("binary") instanceof File).toBeTruthy();
+      expect((data.get("binary") as File).name).toBe("binary");
+    }
   });
 
   it("should encode as query string for basic types", () => {

--- a/packages/arcgis-rest-request/test/utils/process-params.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-params.test.ts
@@ -163,7 +163,7 @@ describe("processParams", () => {
         ? new File(["foo"], "foo.txt", {
             type: "text/plain"
           })
-        : new Buffer("");
+        : Buffer.from("");
 
     expect(
       requiresFormData({
@@ -178,7 +178,7 @@ describe("processParams", () => {
         ? new File(["foo"], "foo.txt", {
             type: "text/plain"
           })
-        : new Buffer("");
+        : Buffer.from("");
 
     expect(
       requiresFormData({


### PR DESCRIPTION
… key and name properties

Append a filename to parameters of type File that don't have the key "file". Also append a filename
to blobs (which don't have a "name" property).

My use case for this is uploading dataURLs as Blobs for item and user thumbnails, which use the `thumbnail` property. Currently passing `thumbnail: <File or Blob>` results in the thumbnail being named `blob.png`. This PR would change it to be named  `<filename>.png` (for Files) or `thumbnail.png` (for Blobs).

AFFECTS PACKAGES:
@esri/arcgis-rest-request