### PR TITLE
fix(sharing): ensure internal sharing metadata calls pass through cus…

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -4,6 +4,7 @@
 import * as http from "http";
 import {
   request,
+  IRequestOptions,
   ArcGISAuthError,
   IAuthenticationManager,
   ITokenRequestOptions
@@ -600,17 +601,20 @@ export class UserSession implements IAuthenticationManager {
    *
    * @returns A Promise that will resolve with the data from the response.
    */
-  getUser(): Promise<IUser> {
+  getUser(requestOptions?: IRequestOptions): Promise<IUser> {
     if (this._user && this._user.username === this.username) {
       return new Promise(resolve => resolve(this._user));
     } else {
       const url = `${this.portal}/community/users/${encodeURIComponent(
         this.username
       )}`;
-      return request(url, {
+
+      const options = {
         httpMethod: "GET",
-        authentication: this
-      }).then(response => {
+        authentication: this,
+        ...requestOptions
+      } as IRequestOptions;
+      return request(url, options).then(response => {
         this._user = response;
         return response;
       });

--- a/packages/arcgis-rest-sharing/src/access.ts
+++ b/packages/arcgis-rest-sharing/src/access.ts
@@ -1,13 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import {
-  request,
-  IRequestOptions,
-  getPortalUrl
-} from "@esri/arcgis-rest-request";
-
-import { UserSession } from "@esri/arcgis-rest-auth";
+import { request } from "@esri/arcgis-rest-request";
 
 import {
   ISharingRequestOptions,

--- a/packages/arcgis-rest-sharing/src/helpers.ts
+++ b/packages/arcgis-rest-sharing/src/helpers.ts
@@ -49,7 +49,7 @@ export function isOrgAdmin(
 ): Promise<boolean> {
   const session = requestOptions.authentication as UserSession;
 
-  return session.getUser().then(user => {
+  return session.getUser(requestOptions).then(user => {
     if (!user || user.role !== "org_admin") {
       return false;
     } else {
@@ -67,7 +67,7 @@ export function getUserMembership(
 
   // the response to this call is cached. yay!
   return session
-    .getUser()
+    .getUser(requestOptions)
     .then((user: IUser) => {
       if (user.groups) {
         user.groups.some(function(group: IGroup) {


### PR DESCRIPTION
…tom request options

AFFECTS PACKAGES:
@esri/arcgis-rest-auth
@esri/arcgis-rest-sharing

ISSUES CLOSED: #276