### PR TITLE
Fix: ensure searchItems mixes in parameters and the provided form

### DIFF
--- a/packages/arcgis-rest-items/src/search.ts
+++ b/packages/arcgis-rest-items/src/search.ts
@@ -54,11 +54,16 @@ export function searchItems(
   if (typeof search === "string") {
     options.params.q = search;
   } else {
-    options.params = search.searchForm;
-    // mixin, giving user supplied requestOptions precedence
+    // mixin user supplied requestOptions with defaults
     options = {
       ...options,
       ...search
+    };
+
+    // mixin arbitrary request parameters with search form
+    options.params = {
+      ...search.params,
+      ...search.searchForm
     };
   }
 

--- a/packages/arcgis-rest-items/test/search.test.ts
+++ b/packages/arcgis-rest-items/test/search.test.ts
@@ -81,6 +81,35 @@ describe("search", () => {
       });
   });
 
+  it("should mixin generic params with the search form", done => {
+    fetchMock.once("*", SearchResponse);
+
+    searchItems({
+      searchForm: {
+        q: "DC AND typekeywords:hubSiteApplication",
+        num: 12,
+        start: 22,
+        sortField: "title",
+        sortDir: "desc"
+      },
+      params: {
+        foo: "bar"
+      }
+    })
+      .then(() => {
+        expect(fetchMock.called()).toEqual(true);
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          "https://www.arcgis.com/sharing/rest/search?f=json&foo=bar&q=DC%20AND%20typekeywords%3AhubSiteApplication&num=12&start=22&sortField=title&sortDir=desc"
+        );
+        expect(options.method).toBe("GET");
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
   describe("Authenticated methods", () => {
     // setup a UserSession to use in all these tests
     const MOCK_USER_SESSION = new UserSession({


### PR DESCRIPTION
this will allow us to _fake_ an authenticated session in ArcGIS Hub by passing in a token manually.

```js
searchItems({
  searchForm: { q: "DC AND typekeywords:hubSiteApplication" },
  params: { token: "fake" }
})
```

AFFECTS PACKAGES:
@esri/arcgis-rest-items