### PR TITLE
Doc fixes

### DIFF
--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -298,7 +298,7 @@ export function getItemData(
 /**
  * Update an Item
  *
- * * ```js
+ * ```js
  * import { updateItem } from '@esri/arcgis-rest-items';
  *
  * updateItem({
@@ -334,7 +334,7 @@ export function updateItem(
 /**
  * Remove an item from the portal
  *
- * *
+ *
  * ```js
  * import { removeItem } from '@esri/arcgis-rest-items';
  *

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -183,7 +183,7 @@ export function createItemInFolder(
  *   authentication: userSession,
  *   item: {
  *     title: "The Amazing Voyage",
- *     type: "Webmap"
+ *     type: "Web Map"
  *   }
  * })
  * ```

--- a/packages/arcgis-rest-items/src/items.ts
+++ b/packages/arcgis-rest-items/src/items.ts
@@ -189,6 +189,7 @@ export function createItemInFolder(
  * ```
  *
  * @param requestOptions - Options for the request
+ * @returns A Promise that creates an item.
  */
 export function createItem(
   requestOptions: IItemAddRequestOptions
@@ -312,7 +313,7 @@ export function getItemData(
  *
  * @param item - The item to update.
  * @param requestOptions - Options for the request.
- * @returns A Promise that resolves with the status of the operation.
+ * @returns A Promise that updates an item.
  */
 export function updateItem(
   requestOptions: IItemUpdateRequestOptions
@@ -415,7 +416,7 @@ export function getItemResources(
  * Update a resource associated with an item
  *
  * @param requestOptions - Options for the request
- * @returns A Promise to unprotect an item.
+ * @returns A Promise that updates an item resource.
  */
 export function updateItemResource(
   requestOptions: IItemResourceRequestOptions
@@ -439,7 +440,7 @@ export function updateItemResource(
  * Remove a resource associated with an item
  *
  * @param requestOptions - Options for the request
- * @returns A Promise to unprotect an item.
+ * @returns A Promise that deletes an item resource.
  */
 export function removeItemResource(
   requestOptions: IItemResourceRequestOptions


### PR DESCRIPTION
- Fixed `Web Map` syntax issue mentioned in #283
- updated "returns" wording for add/update/remove items in documentation (Second half of #281). I'm not totally sure it's the best wording, but at least it's now consistent with the other pages and not blatantly incorrect.
- fixed issue on `updateItem` & `removeItem` doc page where the example code block was not displaying correctly