### PR TITLE
fix(portal): allow devs to pass through a bare portal url

### DIFF
--- a/demos/batch-geocoder-node/package.json
+++ b/demos/batch-geocoder-node/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
   "dependencies": {
     "@esri/arcgis-rest-auth": "^1.8.0",
-    "@esri/arcgis-rest-common-types": "^1.7.1",
+    "@esri/arcgis-rest-common-types": "^1.8.0",
     "@esri/arcgis-rest-geocoder": "^1.8.0",
     "@esri/arcgis-rest-request": "^1.8.0",
     "isomorphic-fetch": "^2.2.1",

--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -19,7 +19,7 @@
     "@esri/arcgis-rest-request": "^1.7.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.7.1",
+    "@esri/arcgis-rest-common-types": "^1.8.0",
     "@esri/arcgis-rest-request": "^1.8.0"
   },
   "scripts": {

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -19,7 +19,7 @@
     "@esri/arcgis-rest-request": "^1.7.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.7.1",
+    "@esri/arcgis-rest-common-types": "^1.8.0",
     "@esri/arcgis-rest-request": "^1.8.0"
   },
   "scripts": {

--- a/packages/arcgis-rest-geocoder/package.json
+++ b/packages/arcgis-rest-geocoder/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.8.0",
-    "@esri/arcgis-rest-common-types": "^1.7.1",
+    "@esri/arcgis-rest-common-types": "^1.8.0",
     "@esri/arcgis-rest-request": "^1.8.0"
   },
   "scripts": {

--- a/packages/arcgis-rest-groups/package.json
+++ b/packages/arcgis-rest-groups/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.8.0",
-    "@esri/arcgis-rest-common-types": "^1.7.1",
+    "@esri/arcgis-rest-common-types": "^1.8.0",
     "@esri/arcgis-rest-request": "^1.8.0"
   },
   "scripts": {

--- a/packages/arcgis-rest-items/package.json
+++ b/packages/arcgis-rest-items/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.8.0",
-    "@esri/arcgis-rest-common-types": "^1.7.1",
+    "@esri/arcgis-rest-common-types": "^1.8.0",
     "@esri/arcgis-rest-request": "^1.8.0"
   },
   "scripts": {

--- a/packages/arcgis-rest-request/src/utils/get-portal-url.ts
+++ b/packages/arcgis-rest-request/src/utils/get-portal-url.ts
@@ -12,7 +12,12 @@ import { IRequestOptions } from "../request";
 export function getPortalUrl(requestOptions: IRequestOptions = {}): string {
   // use portal in options if specified
   if (requestOptions.portal) {
-    return requestOptions.portal;
+    if (/https?:\/\//.test(requestOptions.portal)) {
+      return requestOptions.portal;
+    } else {
+      // if no protocol is supplied, assume secure
+      return `https://${requestOptions.portal}`;
+    }
   }
 
   // if auth was passed, use that portal

--- a/packages/arcgis-rest-request/test/utils/get-portal-url.test.ts
+++ b/packages/arcgis-rest-request/test/utils/get-portal-url.test.ts
@@ -5,6 +5,7 @@ describe("getPortalUrl", () => {
     const url = getPortalUrl();
     expect(url).toEqual("https://www.arcgis.com/sharing/rest");
   });
+
   it("should use the portal from authorization if passed", () => {
     const requestOptions = {
       authentication: {
@@ -20,6 +21,14 @@ describe("getPortalUrl", () => {
 
   it("should use the portal in the requestOptions if passed", () => {
     const requestOptions = {
+      portal: "https://bar.com/arcgis/sharing/rest"
+    };
+    const url = getPortalUrl(requestOptions);
+    expect(url).toEqual("https://bar.com/arcgis/sharing/rest");
+  });
+
+  it("should prefer the portal in requestOptions if both are present", () => {
+    const requestOptions = {
       authentication: {
         portal: "https://foo.com/arcgis/sharing/rest",
         getToken() {
@@ -30,5 +39,33 @@ describe("getPortalUrl", () => {
     };
     const url = getPortalUrl(requestOptions);
     expect(url).toEqual("https://bar.com/arcgis/sharing/rest");
+  });
+
+  it("should tack on a protocol if none was supplied in requestOptions.portal", () => {
+    const requestOptions = {
+      authentication: {
+        portal: "https://foo.com/arcgis/sharing/rest",
+        getToken() {
+          return Promise.resolve("fake");
+        }
+      },
+      portal: "bar.com/arcgis/sharing/rest"
+    };
+    const url = getPortalUrl(requestOptions);
+    expect(url).toEqual("https://bar.com/arcgis/sharing/rest");
+  });
+
+  it("should not tack on a protocol if an insecure portal url was supplied in requestOptions.portal", () => {
+    const requestOptions = {
+      authentication: {
+        portal: "https://foo.com/arcgis/sharing/rest",
+        getToken() {
+          return Promise.resolve("fake");
+        }
+      },
+      portal: "http://bar.com/arcgis/sharing/rest"
+    };
+    const url = getPortalUrl(requestOptions);
+    expect(url).toEqual("http://bar.com/arcgis/sharing/rest");
   });
 });

--- a/packages/arcgis-rest-sharing/package.json
+++ b/packages/arcgis-rest-sharing/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.8.0",
-    "@esri/arcgis-rest-common-types": "^1.7.1",
+    "@esri/arcgis-rest-common-types": "^1.8.0",
     "@esri/arcgis-rest-request": "^1.8.0"
   },
   "files": [

--- a/packages/arcgis-rest-users/package.json
+++ b/packages/arcgis-rest-users/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.8.0",
-    "@esri/arcgis-rest-common-types": "^1.7.1",
+    "@esri/arcgis-rest-common-types": "^1.8.0",
     "@esri/arcgis-rest-request": "^1.8.0"
   },
   "scripts": {


### PR DESCRIPTION
a small tweak to make `getPortalUrl()` more resilient in situations where a developer passes through a `portal` without bothering to declare a protocol.

```ts
// old
getPortalUrl({ portal: "bare.com/sharing/rest" } as IRequestOptions)
>> "bare.com/sharing/rest"

// new
getPortalUrl({ portal: "bare.com/sharing/rest" } as IRequestOptions)
>> "https://bare.com/sharing/rest"
```
AFFECTS PACKAGES:
@esri/arcgis-rest-request