### PR TITLE
docs(api): ensure example code appears in docs for addFeatures

### DIFF
--- a/packages/arcgis-rest-feature-service/src/add.ts
+++ b/packages/arcgis-rest-feature-service/src/add.ts
@@ -43,7 +43,6 @@ export interface IAddFeaturesResult {
 /**
  * Add features request. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/add-features.htm) for more information.
  *
- * @param requestOptions - Options for the request.
  * ```js
  * import { addFeatures } from '@esri/arcgis-rest-feature-service';
  *


### PR DESCRIPTION
Remove duplicate `@param` so docs show code example.