### PR TITLE
Minor error handling fixes

### DIFF
--- a/packages/arcgis-rest-request/src/utils/ArcGISRequestError.ts
+++ b/packages/arcgis-rest-request/src/utils/ArcGISRequestError.ts
@@ -53,12 +53,15 @@ export class ArcGISRequestError {
    * @param options - The original options and parameters of the request
    */
   constructor(
-    message = "UNKNOWN_ERROR",
-    code: string | number = "UNKNOWN_ERROR_CODE",
+    message?: string,
+    code?: string | number,
     response?: any,
     url?: string,
     options?: IRequestOptions
   ) {
+    message = message || "UNKNOWN_ERROR";
+    code = code || "UNKNOWN_ERROR_CODE";
+
     this.name = "ArcGISRequestError";
     this.message =
       code === "UNKNOWN_ERROR_CODE" ? message : `${code}: ${message}`;

--- a/packages/arcgis-rest-request/src/utils/check-for-errors.ts
+++ b/packages/arcgis-rest-request/src/utils/check-for-errors.ts
@@ -38,7 +38,7 @@ export function checkForErrors(
   }
 
   // error from a status check
-  if (response.status === "failed") {
+  if (response.status === "failed" || response.status === "failure") {
     let message: string;
     let code: string = "UNKNOWN_ERROR_CODE";
 
@@ -46,7 +46,7 @@ export function checkForErrors(
       message = JSON.parse(response.statusMessage).message;
       code = JSON.parse(response.statusMessage).code;
     } catch (e) {
-      message = response.statusMessage;
+      message = response.statusMessage || response.message;
     }
 
     throw new ArcGISRequestError(message, code, response, url, options);

--- a/packages/arcgis-rest-request/test/mocks/errors.ts
+++ b/packages/arcgis-rest-request/test/mocks/errors.ts
@@ -47,6 +47,12 @@ export const BillingError: any = {
   details: null as any
 };
 
+export const BillingErrorWithCode200: any = {
+  code: 200,
+  message: null,
+  status: "failure"
+};
+
 export const TaskErrorWithJSON: any = {
   status: "failed",
   statusMessage:

--- a/packages/arcgis-rest-request/test/utils/ArcGISRequestError.test.ts
+++ b/packages/arcgis-rest-request/test/utils/ArcGISRequestError.test.ts
@@ -37,4 +37,12 @@ describe("ArcGISRequestError", () => {
     expect(error.originalMessage).toBe("UNKNOWN_ERROR");
     expect(error.response).toEqual(undefined);
   });
+
+  it("should still format with a null or empty string message or code", () => {
+    const error = new ArcGISRequestError(null, "");
+    expect(error.message).toBe("UNKNOWN_ERROR");
+    expect(error.code).toEqual("UNKNOWN_ERROR_CODE");
+    expect(error.originalMessage).toBe("UNKNOWN_ERROR");
+    expect(error.response).toEqual(undefined);
+  });
 });

--- a/packages/arcgis-rest-request/test/utils/check-for-errors.test.ts
+++ b/packages/arcgis-rest-request/test/utils/check-for-errors.test.ts
@@ -64,7 +64,7 @@ describe("checkForErrors", () => {
   it("should throw an ArcGISRequestError for an error from the ArcGIS Online Billing Backend with a failure status", () => {
     expect(() => {
       checkForErrors(BillingErrorWithCode200);
-    }).toThrowError(ArcGISRequestError, null);
+    }).toThrowError(ArcGISRequestError, "UNKNOWN_ERROR");
   });
 
   it("should throw an ArcGISRequestError for an error when checking long running tasks in ArcGIS REST API", () => {

--- a/packages/arcgis-rest-request/test/utils/check-for-errors.test.ts
+++ b/packages/arcgis-rest-request/test/utils/check-for-errors.test.ts
@@ -13,7 +13,8 @@ import {
   ArcGISOnlineErrorNoMessageCode,
   ArcGISOnlineErrorNoCode,
   ArcGISServerTokenRequired,
-  ArcGISOnlineAuthError
+  ArcGISOnlineAuthError,
+  BillingErrorWithCode200
 } from "./../mocks/errors";
 
 describe("checkForErrors", () => {
@@ -58,6 +59,12 @@ describe("checkForErrors", () => {
     expect(() => {
       checkForErrors(BillingError);
     }).toThrowError(ArcGISRequestError, "500: Error getting subscription info");
+  });
+
+  it("should throw an ArcGISRequestError for an error from the ArcGIS Online Billing Backend with a failure status", () => {
+    expect(() => {
+      checkForErrors(BillingErrorWithCode200);
+    }).toThrowError(ArcGISRequestError, null);
   });
 
   it("should throw an ArcGISRequestError for an error when checking long running tasks in ArcGIS REST API", () => {


### PR DESCRIPTION
Two commits:
- check for errors function: throw an error for a response with a `failure` status
- ArcGISRequestError: In the case that null or an empty string is passed to the constructor, replace with UNKNOWN_ERROR or UNKNOWN_ERROR_CODE

Pretty minor edge cases that I doubt others will encounter, but shouldn't hurt to handle them.