### PR TITLE
Rework group membership checking, simplify UserSession.getUser

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -603,7 +603,7 @@ export class UserSession implements IAuthenticationManager {
    */
   getUser(requestOptions?: IRequestOptions): Promise<IUser> {
     if (this._user && this._user.username === this.username) {
-      return new Promise(resolve => resolve(this._user));
+      return Promise.resolve(this._user);
     } else {
       const url = `${this.portal}/community/users/${encodeURIComponent(
         this.username

--- a/packages/arcgis-rest-common-types/src/group.ts
+++ b/packages/arcgis-rest-common-types/src/group.ts
@@ -1,6 +1,9 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+// if you want to get *really* pedantic, nonmember is more _derived_
+export type GroupMembership = "owner" | "admin" | "member" | "nonmember";
+
 /**
  * A [Group](https://developers.arcgis.com/rest/users-groups-and-items/common-parameters.htm) that has not been created yet.
  */
@@ -44,7 +47,7 @@ export interface IGroup extends IGroupAdd {
   autoJoin: boolean;
   userMembership?: {
     username?: string;
-    memberType?: string;
+    memberType?: GroupMembership;
     applications?: number;
   };
   hasCategorySchema?: boolean;

--- a/packages/arcgis-rest-sharing/package.json
+++ b/packages/arcgis-rest-sharing/package.json
@@ -9,17 +9,19 @@
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^1.7.1"
+    "tslib": "^1.8.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.7.1",
-    "@esri/arcgis-rest-common-types": "^1.7.1",
-    "@esri/arcgis-rest-request": "^1.7.1"
+    "@esri/arcgis-rest-auth": "^1.8.0",
+    "@esri/arcgis-rest-common-types": "^1.8.0",
+    "@esri/arcgis-rest-request": "^1.8.0",
+    "@esri/arcgis-rest-groups": "^1.8.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-auth": "^1.8.0",
-    "@esri/arcgis-rest-common-types": "^1.7.1",
-    "@esri/arcgis-rest-request": "^1.8.0"
+    "@esri/arcgis-rest-common-types": "^1.8.0",
+    "@esri/arcgis-rest-request": "^1.8.0",
+    "@esri/arcgis-rest-groups": "^1.8.0"
   },
   "files": [
     "dist/**"

--- a/packages/arcgis-rest-sharing/src/group-sharing.ts
+++ b/packages/arcgis-rest-sharing/src/group-sharing.ts
@@ -1,11 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import {
-  request,
-  IRequestOptions,
-  getPortalUrl
-} from "@esri/arcgis-rest-request";
+import { request, getPortalUrl } from "@esri/arcgis-rest-request";
 import { IItem } from "@esri/arcgis-rest-common-types";
 
 import {

--- a/packages/arcgis-rest-sharing/src/group-sharing.ts
+++ b/packages/arcgis-rest-sharing/src/group-sharing.ts
@@ -120,7 +120,7 @@ function changeGroupSharing(
                 }`;
               } else {
                 // if they are a group admin/owner, use the bare item url
-                if (membership === "admin") {
+                if (membership === "admin" || membership === "owner") {
                   return `${getPortalUrl(requestOptions)}/content/items/${
                     requestOptions.id
                   }/${requestOptions.action}`;
@@ -179,15 +179,18 @@ function isItemSharedWithGroup(
     sortField: "title"
   };
 
+  // we need to append some params into requestOptions, so make a clone
+  // instead of mutating the params on the inbound requestOptions object
+  const options = { ...requestOptions };
   // instead of calling out to "@esri/arcgis-rest-items, make the request manually to forgoe another dependency
-  requestOptions.params = {
+  options.params = {
     ...query,
     ...requestOptions.params
   };
 
-  const url = `${getPortalUrl(requestOptions)}/search`;
+  const url = `${getPortalUrl(options)}/search`;
 
-  return request(url, requestOptions).then(searchResponse => {
+  return request(url, options).then(searchResponse => {
     // if there are no search results at all, we know the item hasnt already been shared with the group
     if (searchResponse.total === 0) {
       return false;

--- a/packages/arcgis-rest-sharing/src/helpers.ts
+++ b/packages/arcgis-rest-sharing/src/helpers.ts
@@ -22,13 +22,6 @@ export interface ISharingRequestOptions extends IRequestOptions {
   owner?: string;
 }
 
-export interface IGroupIdRequestOptions extends IRequestOptions {
-  /**
-   * Group identifier
-   */
-  groupId: string;
-}
-
 export interface ISharingResponse {
   notSharedWith?: string[];
   notUnsharedFrom?: string[];
@@ -76,7 +69,7 @@ export function isOrgAdmin(
  * @returns A Promise that resolves with "owner" | "admin" | "member" | "nonmember"
  */
 export function getUserMembership(
-  requestOptions: IGroupIdRequestOptions
+  requestOptions: IGroupSharingRequestOptions
 ): Promise<GroupMembership> {
   // fetch the group...
   return getGroup(requestOptions.groupId, requestOptions)

--- a/packages/arcgis-rest-sharing/src/helpers.ts
+++ b/packages/arcgis-rest-sharing/src/helpers.ts
@@ -52,7 +52,7 @@ export function isItemOwner(requestOptions: ISharingRequestOptions): boolean {
 /**
  * Check it the user is a full org_admin
  * @param requestOptions
- * @returns {Promise<string>} Promise resolving in a boolean indicating if the user is a full Org Admin
+ * @returns Promise resolving in a boolean indicating if the user is an ArcGIS Organization administrator
  */
 export function isOrgAdmin(
   requestOptions: ISharingRequestOptions

--- a/packages/arcgis-rest-sharing/src/helpers.ts
+++ b/packages/arcgis-rest-sharing/src/helpers.ts
@@ -1,12 +1,10 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
-import {
-  request,
-  IRequestOptions,
-  getPortalUrl
-} from "@esri/arcgis-rest-request";
+
+import { IRequestOptions, getPortalUrl } from "@esri/arcgis-rest-request";
 import { UserSession } from "@esri/arcgis-rest-auth";
-import { IUser, IGroup } from "@esri/arcgis-rest-common-types";
+import { IGroup, IUser, GroupMembership } from "@esri/arcgis-rest-common-types";
+import { getGroup } from "@esri/arcgis-rest-groups";
 import { IGroupSharingRequestOptions } from "./group-sharing";
 
 export interface ISharingRequestOptions extends IRequestOptions {
@@ -22,6 +20,13 @@ export interface ISharingRequestOptions extends IRequestOptions {
    * Item owner, if different from the authenticated user.
    */
   owner?: string;
+}
+
+export interface IGroupIdRequestOptions extends IRequestOptions {
+  /**
+   * Group identifier
+   */
+  groupId: string;
 }
 
 export interface ISharingResponse {
@@ -44,12 +49,17 @@ export function isItemOwner(requestOptions: ISharingRequestOptions): boolean {
   return owner === username;
 }
 
+/**
+ * Check it the user is a full org_admin
+ * @param requestOptions
+ * @returns {Promise<string>} Promise resolving in a boolean indicating if the user is a full Org Admin
+ */
 export function isOrgAdmin(
   requestOptions: ISharingRequestOptions
 ): Promise<boolean> {
   const session = requestOptions.authentication as UserSession;
 
-  return session.getUser(requestOptions).then(user => {
+  return session.getUser(requestOptions).then((user: IUser) => {
     if (!user || user.role !== "org_admin") {
       return false;
     } else {
@@ -58,35 +68,22 @@ export function isOrgAdmin(
   });
 }
 
+/**
+ * Get the User Membership for a particular group. Use this if all you have is the groupId.
+ * If you have the group object, check the `userMembership.memberType` property instead of calling this method.
+ *
+ * @param IGroupIdRequestOptions options to pass through in the request
+ * @returns A Promise that resolves with "owner" | "admin" | "member" | "nonmember"
+ */
 export function getUserMembership(
-  requestOptions: IGroupSharingRequestOptions
-): Promise<string> {
-  // start by assuming the user does not belong to the group
-  let result = "nonmember";
-  const session = requestOptions.authentication as UserSession;
-
-  // the response to this call is cached. yay!
-  return session
-    .getUser(requestOptions)
-    .then((user: IUser) => {
-      if (user.groups) {
-        user.groups.some(function(group: IGroup) {
-          const matchedGroup = group.id === requestOptions.groupId;
-          if (matchedGroup) {
-            result = group.userMembership.memberType;
-          }
-          return matchedGroup;
-        });
-      }
-      return result;
+  requestOptions: IGroupIdRequestOptions
+): Promise<GroupMembership> {
+  // fetch the group...
+  return getGroup(requestOptions.groupId, requestOptions)
+    .then((group: IGroup) => {
+      return group.userMembership.memberType;
     })
-    .catch(
-      /* istanbul ignore next */ err => {
-        throw Error(
-          `failure determining membership of ${session.username} in group:${
-            requestOptions.groupId
-          }: ${err}`
-        );
-      }
-    );
+    .catch(() => {
+      return "nonmember" as GroupMembership;
+    });
 }

--- a/packages/arcgis-rest-sharing/test/access.test.ts
+++ b/packages/arcgis-rest-sharing/test/access.test.ts
@@ -6,8 +6,6 @@ import * as fetchMock from "fetch-mock";
 import { MOCK_USER_SESSION } from "./mocks/sharing";
 import {
   AnonUserResponse,
-  GroupMemberUserResponse,
-  GroupAdminUserResponse,
   OrgAdminUserResponse
 } from "../../arcgis-rest-users/test/mocks/responses";
 

--- a/packages/arcgis-rest-sharing/test/group-sharing.test.ts
+++ b/packages/arcgis-rest-sharing/test/group-sharing.test.ts
@@ -51,7 +51,7 @@ const NoResultsSearchResponse = {
   results: [] as any
 };
 
-const GroupOwnerResponse = {
+export const GroupOwnerResponse = {
   id: "tb6",
   title: "fake group",
   userMembership: {
@@ -59,7 +59,7 @@ const GroupOwnerResponse = {
   }
 };
 
-const GroupMemberResponse = {
+export const GroupMemberResponse = {
   id: "tb6",
   title: "fake group",
   userMembership: {
@@ -67,7 +67,7 @@ const GroupMemberResponse = {
   }
 };
 
-const GroupAdminResponse = {
+export const GroupAdminResponse = {
   id: "tb6",
   title: "fake group",
   userMembership: {
@@ -75,7 +75,7 @@ const GroupAdminResponse = {
   }
 };
 
-const GroupNoAccessResponse = {
+export const GroupNoAccessResponse = {
   error: {
     code: 400,
     messageCode: "COM_0003",

--- a/packages/arcgis-rest-sharing/test/helpers.test.ts
+++ b/packages/arcgis-rest-sharing/test/helpers.test.ts
@@ -18,6 +18,7 @@ describe("sharing helpers ::", () => {
         GroupNoAccessResponse
       );
       getUserMembership({
+        id: "ignoreme",
         groupId: "tb6",
         authentication: MOCK_USER_SESSION
       }).then(result => {
@@ -33,6 +34,7 @@ describe("sharing helpers ::", () => {
         GroupOwnerResponse
       );
       getUserMembership({
+        id: "ignoreme",
         groupId: "tb6",
         authentication: MOCK_USER_SESSION
       }).then(result => {

--- a/packages/arcgis-rest-sharing/test/helpers.test.ts
+++ b/packages/arcgis-rest-sharing/test/helpers.test.ts
@@ -4,31 +4,10 @@
 import * as fetchMock from "fetch-mock";
 import { getUserMembership } from "../src/helpers";
 import { MOCK_USER_SESSION } from "./mocks/sharing";
-
-const GroupOwnerResponse = {
-  id: "tb6",
-  title: "fake group",
-  userMembership: {
-    memberType: "owner"
-  }
-};
-
-const GroupMemberResponse = {
-  id: "tb6",
-  title: "fake group",
-  userMembership: {
-    memberType: "owner"
-  }
-};
-
-const GroupNoAccessResponse = {
-  error: {
-    code: 400,
-    messageCode: "COM_0003",
-    message: "Group does not exist or is inaccessible.",
-    details: [] as any[]
-  }
-};
+import {
+  GroupOwnerResponse,
+  GroupNoAccessResponse
+} from "./group-sharing.test";
 
 describe("sharing helpers ::", () => {
   afterEach(fetchMock.restore);

--- a/packages/arcgis-rest-sharing/test/helpers.test.ts
+++ b/packages/arcgis-rest-sharing/test/helpers.test.ts
@@ -1,0 +1,66 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import * as fetchMock from "fetch-mock";
+import { getUserMembership } from "../src/helpers";
+import { MOCK_USER_SESSION } from "./mocks/sharing";
+
+const GroupOwnerResponse = {
+  id: "tb6",
+  title: "fake group",
+  userMembership: {
+    memberType: "owner"
+  }
+};
+
+const GroupMemberResponse = {
+  id: "tb6",
+  title: "fake group",
+  userMembership: {
+    memberType: "owner"
+  }
+};
+
+const GroupNoAccessResponse = {
+  error: {
+    code: 400,
+    messageCode: "COM_0003",
+    message: "Group does not exist or is inaccessible.",
+    details: [] as any[]
+  }
+};
+
+describe("sharing helpers ::", () => {
+  afterEach(fetchMock.restore);
+  describe("getUserMembership ::", () => {
+    it("should return nonmember if group could not be fetched", done => {
+      fetchMock.once(
+        "https://myorg.maps.arcgis.com/sharing/rest/community/groups/tb6?f=json&token=fake-token",
+        GroupNoAccessResponse
+      );
+      getUserMembership({
+        groupId: "tb6",
+        authentication: MOCK_USER_SESSION
+      }).then(result => {
+        expect(fetchMock.done()).toBeTruthy();
+        expect(result).toBe("nonmember", "should return nonmember");
+        done();
+      });
+    });
+
+    it("should request the group and return the member type", done => {
+      fetchMock.once(
+        "https://myorg.maps.arcgis.com/sharing/rest/community/groups/tb6?f=json&token=fake-token",
+        GroupOwnerResponse
+      );
+      getUserMembership({
+        groupId: "tb6",
+        authentication: MOCK_USER_SESSION
+      }).then(result => {
+        expect(fetchMock.done()).toBeTruthy();
+        expect(result).toBe("owner", "should return owner");
+        done();
+      });
+    });
+  });
+});

--- a/packages/arcgis-rest-users/test/mocks/responses.ts
+++ b/packages/arcgis-rest-users/test/mocks/responses.ts
@@ -67,7 +67,7 @@ export const GroupMemberUserResponse: IUser = {
       access: "org",
       userMembership: {
         username: "jsmith",
-        memberType: "user",
+        memberType: "member",
         applications: 0
       },
       protected: false,
@@ -98,7 +98,7 @@ export const GroupNonMemberUserResponse: IUser = {
       access: "org",
       userMembership: {
         username: "jsmith",
-        memberType: "user",
+        memberType: "member",
         applications: 0
       },
       protected: false,


### PR DESCRIPTION
### Group Membership Checking
Previously this used `UserSession.getUser()` and would check to see if the group in question was in the user's array of groups. However, since `UserSession.getUser()` implements a caching strategy, if you created a group and then attempted to share an item to that group, the `getUserMembership` check would return `nonmember` even though the user is actually the owner. More about this general problem is on #309 

While there is some discussion about possibly adding cache-busting to the `getUser()` call, I opted to simply make a call to the group itself, which will return the same info.

I also fixed `isItemSharedWithGroup` where we mutated an `IRequestOptions.params` but then sent that into a subsequent call, which resulted in an unexpected url. We should be careful not to mutate that as calling apps/libraries will pass the same thing into multiple requests when orchestrating calls

### UserSession.getUser() 
Just simplify `return new Promise(resolve => resolve(this._user)` to `return Promise.resolve(this._user)`