### PR TITLE
chore(lint): make sure *all* the code is linted each commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "lint-staged": {
     "*.ts": [
       "prettier --write --parser typescript --tab-width 2 --use-tabs false",
-      "tslint",
+      "tslint --project tsconfig.json",
       "git add"
     ]
   },
@@ -82,7 +82,7 @@
     "test:firefox": "karma start --single-run --browsers=Firefox",
     "test:node": "jasmine --config=jasmine.json",
     "test:node:debug": "inspect jasmine --config=jasmine.json",
-    "test:ci": "npm run test:node && npm run test:chrome:ci && npm run test:firefox",
+    "test:ci": "npm run lint && npm run test:node && npm run test:chrome:ci && npm run test:firefox",
     "test:all": "npm run test:node && npm run test:firefox && npm run test:chrome",
     "docs:build": "rimraf docs/build && npm run docs:typedoc && npm run docs:build:acetate && npm run docs:build:sass && npm run docs:build:images",
     "docs:build:acetate": "ENV=prod acetate build --config docs/acetate.config.js",
@@ -98,8 +98,8 @@
     "predocs:dev:sass": "npm run docs:build:sass",
     "docs:dev:sass": "node-sass --watch --recursive --output docs/build/css --source-map true --source-map-contents docs/src/sass",
     "docs:dev:js": "cpx \"docs/src/**/{api-search,nav-toggle}.js\" docs/build -w",
-    "lint": "tslint --project tsconfig.json --type-check",
-    "lint:fix": "tslint --project tsconfig.json --type-check --fix",
+    "lint": "tslint --project tsconfig.json",
+    "lint:fix": "tslint --project tsconfig.json --fix",
     "precommit": "lint-staged",
     "bootstrap": "lerna bootstrap",
     "postinstall": "npm run bootstrap",

--- a/packages/arcgis-rest-auth/src/ApplicationSession.ts
+++ b/packages/arcgis-rest-auth/src/ApplicationSession.ts
@@ -31,11 +31,6 @@ export interface IApplicationSessionOptions {
    * Expiration date for the `token`
    */
   expires?: Date;
-
-  /**
-   * Duration of requested tokens in minutes. Used when requesting tokens with `username` and `password` for when validating the identities of unknown servers. Defaults to 2 weeks.
-   */
-  duration?: number;
 }
 
 export class ApplicationSession implements IAuthenticationManager {
@@ -44,7 +39,6 @@ export class ApplicationSession implements IAuthenticationManager {
   private clientSecret: string;
   private token: string;
   private expires: Date;
-  private duration: number;
 
   /**
    * Internal object to keep track of pending token requests. Used to prevent
@@ -58,7 +52,6 @@ export class ApplicationSession implements IAuthenticationManager {
     this.token = options.token;
     this.expires = options.expires;
     this.portal = "https://www.arcgis.com/sharing/rest";
-    this.duration = options.duration || 20160;
   }
 
   // url isnt actually read or passed through.

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -495,16 +495,9 @@ export class UserSession implements IAuthenticationManager {
     options: IOauth2Options,
     authorizationCode: string
   ): Promise<UserSession> {
-    const {
-      portal,
-      clientId,
-      duration,
-      redirectUri,
-      refreshTokenTTL
-    }: IOauth2Options = {
+    const { portal, clientId, redirectUri, refreshTokenTTL }: IOauth2Options = {
       ...{
         portal: "https://www.arcgis.com/sharing/rest",
-        duration: 20160,
         refreshTokenTTL: 1440
       },
       ...options

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -852,13 +852,15 @@ describe("UserSession", () => {
         .getUser()
         .then(response => {
           expect(response.role).toEqual("org_publisher");
-          session.getUser().then(cachedResponse => {
-            expect(cachedResponse.fullName).toEqual("John Smith");
-            done();
-          });
-          // .catch(e => {
-          //   fail(e);
-          // });
+          session
+            .getUser()
+            .then(cachedResponse => {
+              expect(cachedResponse.fullName).toEqual("John Smith");
+              done();
+            })
+            .catch(e => {
+              fail(e);
+            });
         })
         .catch(e => {
           fail(e);

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -102,6 +102,9 @@ describe("UserSession", () => {
         .then(token => {
           expect(token).toBe("token");
           done();
+        })
+        .catch(e => {
+          fail(e);
         });
     });
 
@@ -184,6 +187,9 @@ describe("UserSession", () => {
         .then(token => {
           expect(token).toBe("serverToken");
           done();
+        })
+        .catch(e => {
+          fail(e);
         });
     });
 
@@ -224,6 +230,9 @@ describe("UserSession", () => {
         .then(token => {
           expect(token).toBe("serverToken");
           done();
+        })
+        .catch(e => {
+          fail(e);
         });
     });
 
@@ -278,14 +287,18 @@ describe("UserSession", () => {
         session.getToken(
           "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query"
         )
-      ]).then(([token1, token2]) => {
-        expect(token1).toBe("serverToken");
-        expect(token2).toBe("serverToken");
-        expect(
-          fetchMock.calls("https://gis.city.gov/sharing/generateToken").length
-        ).toBe(1);
-        done();
-      });
+      ])
+        .then(([token1, token2]) => {
+          expect(token1).toBe("serverToken");
+          expect(token2).toBe("serverToken");
+          expect(
+            fetchMock.calls("https://gis.city.gov/sharing/generateToken").length
+          ).toBe(1);
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
     });
 
     it("should throw an ArcGISAuthError when the owning system doesn't match", done => {
@@ -835,13 +848,21 @@ describe("UserSession", () => {
         password: "123456"
       });
 
-      session.getUser().then(response => {
-        expect(response.role).toEqual("org_publisher");
-        session.getUser().then(cachedResponse => {
-          expect(cachedResponse.fullName).toEqual("John Smith");
-          done();
+      session
+        .getUser()
+        .then(response => {
+          expect(response.role).toEqual("org_publisher");
+          session.getUser().then(cachedResponse => {
+            expect(cachedResponse.fullName).toEqual("John Smith");
+            done();
+          });
+          // .catch(e => {
+          //   fail(e);
+          // });
+        })
+        .catch(e => {
+          fail(e);
         });
-      });
     });
   });
 

--- a/packages/arcgis-rest-feature-service/src/updateAttachment.ts
+++ b/packages/arcgis-rest-feature-service/src/updateAttachment.ts
@@ -3,7 +3,7 @@
 
 import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 
-import { IEditFeatureResult, appendCustomParams } from "./helpers";
+import { IEditFeatureResult } from "./helpers";
 
 /**
  * Request options to for updating a related attachment to a feature by id. See [Update Attachment](https://developers.arcgis.com/rest/services-reference/update-attachment.htm) for more information.

--- a/packages/arcgis-rest-feature-service/test/attachments.test.ts
+++ b/packages/arcgis-rest-feature-service/test/attachments.test.ts
@@ -49,19 +49,23 @@ describe("attachment methods", () => {
       httpMethod: "GET"
     } as IGetAttachmentsOptions;
     fetchMock.once("*", getAttachmentsResponse);
-    getAttachments(requestOptions).then(response => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(
-        `${requestOptions.url}/${
-          requestOptions.featureId
-        }/attachments?f=json&gdbVersion=SDE.DEFAULT`
-      );
-      expect(options.method).toBe("GET");
-      expect(getAttachmentsResponse.attachmentInfos.length).toEqual(2);
-      expect(getAttachmentsResponse.attachmentInfos[0].id).toEqual(409);
-      done();
-    });
+    getAttachments(requestOptions)
+      .then(() => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          `${requestOptions.url}/${
+            requestOptions.featureId
+          }/attachments?f=json&gdbVersion=SDE.DEFAULT`
+        );
+        expect(options.method).toBe("GET");
+        expect(getAttachmentsResponse.attachmentInfos.length).toEqual(2);
+        expect(getAttachmentsResponse.attachmentInfos[0].id).toEqual(409);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should return objectId of the added attachment and a truthy success", done => {
@@ -74,22 +78,31 @@ describe("attachment methods", () => {
       }
     } as IAddAttachmentOptions;
     fetchMock.once("*", addAttachmentResponse);
-    addAttachment(requestOptions).then(response => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(
-        `${requestOptions.url}/${requestOptions.featureId}/addAttachment`
-      );
-      expect(options.method).toBe("POST");
-      expect(options.body instanceof FormData).toBeTruthy();
-      const params = options.body as FormData;
-      // we could introspect FormData in Chrome this way, but not Node.js
-      // more info: https://github.com/form-data/form-data/issues/124
-      // expect(params.get("returnEditMoment")).toEqual("true");
-      expect(addAttachmentResponse.addAttachmentResult.objectId).toEqual(1001);
-      expect(addAttachmentResponse.addAttachmentResult.success).toEqual(true);
-      done();
-    });
+    addAttachment(requestOptions)
+      .then(() => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          `${requestOptions.url}/${requestOptions.featureId}/addAttachment`
+        );
+        expect(options.method).toBe("POST");
+
+        const params = options.body as FormData;
+        expect(params instanceof FormData).toBeTruthy();
+        // we can introspect FormData in Chrome this way, but not Node.js
+        // more info: https://github.com/form-data/form-data/issues/124
+        if (params.get) {
+          expect(params.get("returnEditMoment")).toEqual("true");
+        }
+        expect(addAttachmentResponse.addAttachmentResult.objectId).toEqual(
+          1001
+        );
+        expect(addAttachmentResponse.addAttachmentResult.success).toEqual(true);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should return an error for a service/feature which does not have attachments", done => {
@@ -104,7 +117,7 @@ describe("attachment methods", () => {
     } as IAddAttachmentOptions;
     fetchMock.once("*", genericInvalidResponse);
     addAttachment(requestOptions)
-      .then(response => {
+      .then(() => {
         // nothing to test here forcing error
         fail();
       })
@@ -134,21 +147,25 @@ describe("attachment methods", () => {
       }
     } as IUpdateAttachmentOptions;
     fetchMock.once("*", updateAttachmentResponse);
-    updateAttachment(requestOptions).then(response => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(
-        `${requestOptions.url}/${requestOptions.featureId}/updateAttachment`
-      );
-      expect(options.method).toBe("POST");
-      expect(updateAttachmentResponse.updateAttachmentResult.objectId).toEqual(
-        1001
-      );
-      expect(updateAttachmentResponse.updateAttachmentResult.success).toEqual(
-        true
-      );
-      done();
-    });
+    updateAttachment(requestOptions)
+      .then(() => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          `${requestOptions.url}/${requestOptions.featureId}/updateAttachment`
+        );
+        expect(options.method).toBe("POST");
+        expect(
+          updateAttachmentResponse.updateAttachmentResult.objectId
+        ).toEqual(1001);
+        expect(updateAttachmentResponse.updateAttachmentResult.success).toEqual(
+          true
+        );
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should return objectId of the deleted attachment and a truthy success", done => {
@@ -161,22 +178,26 @@ describe("attachment methods", () => {
       }
     } as IDeleteAttachmentsOptions;
     fetchMock.once("*", deleteAttachmentsResponse);
-    deleteAttachments(requestOptions).then(response => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(
-        `${requestOptions.url}/${requestOptions.featureId}/deleteAttachments`
-      );
-      expect(options.body).toContain("attachmentIds=1001");
-      expect(options.body).toContain("returnEditMoment=true");
-      expect(options.method).toBe("POST");
-      expect(
-        deleteAttachmentsResponse.deleteAttachmentResults[0].objectId
-      ).toEqual(1001);
-      expect(
-        deleteAttachmentsResponse.deleteAttachmentResults[0].success
-      ).toEqual(true);
-      done();
-    });
+    deleteAttachments(requestOptions)
+      .then(() => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          `${requestOptions.url}/${requestOptions.featureId}/deleteAttachments`
+        );
+        expect(options.body).toContain("attachmentIds=1001");
+        expect(options.body).toContain("returnEditMoment=true");
+        expect(options.method).toBe("POST");
+        expect(
+          deleteAttachmentsResponse.deleteAttachmentResults[0].objectId
+        ).toEqual(1001);
+        expect(
+          deleteAttachmentsResponse.deleteAttachmentResults[0].success
+        ).toEqual(true);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 });

--- a/packages/arcgis-rest-feature-service/test/features.test.ts
+++ b/packages/arcgis-rest-feature-service/test/features.test.ts
@@ -36,14 +36,18 @@ describe("feature", () => {
       id: 42
     };
     fetchMock.once("*", featureResponse);
-    getFeature(requestOptions).then(response => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(`${requestOptions.url}/42?f=json`);
-      expect(options.method).toBe("GET");
-      expect(response.attributes.FID).toEqual(42);
-      done();
-    });
+    getFeature(requestOptions)
+      .then(response => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(`${requestOptions.url}/42?f=json`);
+        expect(options.method).toBe("GET");
+        expect(response.attributes.FID).toEqual(42);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should supply default query parameters", done => {
@@ -51,15 +55,19 @@ describe("feature", () => {
       url: serviceUrl
     };
     fetchMock.once("*", queryResponse);
-    queryFeatures(requestOptions).then(response => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(
-        `${requestOptions.url}/query?f=json&where=1%3D1&outFields=*`
-      );
-      expect(options.method).toBe("GET");
-      done();
-    });
+    queryFeatures(requestOptions)
+      .then(() => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          `${requestOptions.url}/query?f=json&where=1%3D1&outFields=*`
+        );
+        expect(options.method).toBe("GET");
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should use passed in query parameters", done => {
@@ -69,18 +77,22 @@ describe("feature", () => {
       outFields: ["FID", "Tree_ID", "Cmn_Name", "Condition"]
     };
     fetchMock.once("*", queryResponse);
-    queryFeatures(requestOptions).then(response => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(
-        `${
-          requestOptions.url
-        }/query?f=json&where=Condition%3D'Poor'&outFields=FID%2CTree_ID%2CCmn_Name%2CCondition`
-      );
-      expect(options.method).toBe("GET");
-      // expect(response.attributes.FID).toEqual(42);
-      done();
-    });
+    queryFeatures(requestOptions)
+      .then(() => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          `${
+            requestOptions.url
+          }/query?f=json&where=Condition%3D'Poor'&outFields=FID%2CTree_ID%2CCmn_Name%2CCondition`
+        );
+        expect(options.method).toBe("GET");
+        // expect(response.attributes.FID).toEqual(42);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should return objectId of the added feature and a truthy success", done => {
@@ -105,21 +117,25 @@ describe("feature", () => {
       ]
     };
     fetchMock.once("*", addFeaturesResponse);
-    addFeatures(requestOptions).then(response => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(`${requestOptions.url}/addFeatures`);
-      expect(options.body).toContain(
-        "features=" +
-          encodeURIComponent(
-            '[{"geometry":{"x":-9177311.62541634,"y":4247151.205222242,"spatialReference":{"wkid":102100,"latestWkid":3857}},"attributes":{"Tree_ID":102,"Collected":1349395200000,"Crew":"Linden+ Forrest+ Johnny"}}]'
-          )
-      );
-      expect(options.method).toBe("POST");
-      expect(response.addResults[0].objectId).toEqual(1001);
-      expect(response.addResults[0].success).toEqual(true);
-      done();
-    });
+    addFeatures(requestOptions)
+      .then(response => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(`${requestOptions.url}/addFeatures`);
+        expect(options.body).toContain(
+          "features=" +
+            encodeURIComponent(
+              '[{"geometry":{"x":-9177311.62541634,"y":4247151.205222242,"spatialReference":{"wkid":102100,"latestWkid":3857}},"attributes":{"Tree_ID":102,"Collected":1349395200000,"Crew":"Linden+ Forrest+ Johnny"}}]'
+            )
+        );
+        expect(options.method).toBe("POST");
+        expect(response.addResults[0].objectId).toEqual(1001);
+        expect(response.addResults[0].success).toEqual(true);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should return objectId of the updated feature and a truthy success", done => {
@@ -137,21 +153,25 @@ describe("feature", () => {
       rollbackOnFailure: false
     } as IUpdateFeaturesRequestOptions;
     fetchMock.once("*", updateFeaturesResponse);
-    updateFeatures(requestOptions).then(response => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(`${requestOptions.url}/updateFeatures`);
-      expect(options.method).toBe("POST");
-      expect(options.body).toContain(
-        "features=" +
-          encodeURIComponent(
-            '[{"attributes":{"OBJECTID":1001,"Street":"NO","Native":"YES"}}]'
-          )
-      );
-      expect(options.body).toContain("rollbackOnFailure=false");
-      expect(response.updateResults[0].success).toEqual(true);
-      done();
-    });
+    updateFeatures(requestOptions)
+      .then(response => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(`${requestOptions.url}/updateFeatures`);
+        expect(options.method).toBe("POST");
+        expect(options.body).toContain(
+          "features=" +
+            encodeURIComponent(
+              '[{"attributes":{"OBJECTID":1001,"Street":"NO","Native":"YES"}}]'
+            )
+        );
+        expect(options.body).toContain("rollbackOnFailure=false");
+        expect(response.updateResults[0].success).toEqual(true);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should return objectId of the deleted feature and a truthy success", done => {
@@ -161,19 +181,23 @@ describe("feature", () => {
       where: "1=1"
     } as IDeleteFeaturesRequestOptions;
     fetchMock.once("*", deleteFeaturesResponse);
-    deleteFeatures(requestOptions).then(response => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(`${requestOptions.url}/deleteFeatures`);
-      expect(options.body).toContain("objectIds=1001");
-      expect(options.body).toContain("where=1%3D1");
-      expect(options.method).toBe("POST");
-      expect(response.deleteResults[0].objectId).toEqual(
-        requestOptions.deletes[0]
-      );
-      expect(response.deleteResults[0].success).toEqual(true);
-      done();
-    });
+    deleteFeatures(requestOptions)
+      .then(response => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(`${requestOptions.url}/deleteFeatures`);
+        expect(options.body).toContain("objectIds=1001");
+        expect(options.body).toContain("where=1%3D1");
+        expect(options.method).toBe("POST");
+        expect(response.deleteResults[0].objectId).toEqual(
+          requestOptions.deletes[0]
+        );
+        expect(response.deleteResults[0].success).toEqual(true);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should supply default query related parameters", done => {
@@ -181,17 +205,21 @@ describe("feature", () => {
       url: serviceUrl
     };
     fetchMock.once("*", queryRelatedResponse);
-    queryRelated(requestOptions).then(() => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(
-        `${
-          requestOptions.url
-        }/queryRelatedRecords?f=json&definitionExpression=1%3D1&outFields=*&relationshipId=0`
-      );
-      expect(options.method).toBe("GET");
-      done();
-    });
+    queryRelated(requestOptions)
+      .then(() => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          `${
+            requestOptions.url
+          }/queryRelatedRecords?f=json&definitionExpression=1%3D1&outFields=*&relationshipId=0`
+        );
+        expect(options.method).toBe("GET");
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should use passed in query related parameters", done => {
@@ -203,16 +231,22 @@ describe("feature", () => {
       httpMethod: "POST"
     } as IQueryRelatedRequestOptions;
     fetchMock.once("*", queryRelatedResponse);
-    queryRelated(requestOptions).then(() => {
-      expect(fetchMock.called()).toBeTruthy();
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
-      expect(url).toEqual(`${requestOptions.url}/queryRelatedRecords`);
-      expect(options.method).toBe("POST");
-      expect(options.body).toContain("f=json");
-      expect(options.body).toContain("relationshipId=1");
-      expect(options.body).toContain("definitionExpression=APPROXACRE%3C10000");
-      expect(options.body).toContain("outFields=APPROXACRE%2CFIELD_NAME");
-      done();
-    });
+    queryRelated(requestOptions)
+      .then(() => {
+        expect(fetchMock.called()).toBeTruthy();
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(`${requestOptions.url}/queryRelatedRecords`);
+        expect(options.method).toBe("POST");
+        expect(options.body).toContain("f=json");
+        expect(options.body).toContain("relationshipId=1");
+        expect(options.body).toContain(
+          "definitionExpression=APPROXACRE%3C10000"
+        );
+        expect(options.body).toContain("outFields=APPROXACRE%2CFIELD_NAME");
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 });

--- a/packages/arcgis-rest-feature-service/test/mocks/feature.ts
+++ b/packages/arcgis-rest-feature-service/test/mocks/feature.ts
@@ -1,8 +1,6 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IFeature } from "@esri/arcgis-rest-common-types";
-
 export const featureResponse = {
   feature: {
     attributes: {

--- a/packages/arcgis-rest-geocoder/src/helpers.ts
+++ b/packages/arcgis-rest-geocoder/src/helpers.ts
@@ -3,8 +3,6 @@
 
 import { request, IRequestOptions, warn } from "@esri/arcgis-rest-request";
 
-import { IPoint } from "@esri/arcgis-rest-common-types";
-
 // https always
 export const worldGeocoder =
   "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/";

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -13,6 +13,11 @@ export type GrantTypes =
   | "client_credentials"
   | "exchange_refresh_token";
 
+export interface IParams {
+  f?: ResponseFormats;
+  [key: string]: any;
+}
+
 export interface IGenerateTokenParams extends IParams {
   username?: string;
   password?: string;
@@ -72,11 +77,6 @@ export type ResponseFormats =
   | "html"
   | "image"
   | "zip";
-
-export interface IParams {
-  f?: ResponseFormats;
-  [key: string]: any;
-}
 
 /**
  * Options for the `request()` method.

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -257,7 +257,7 @@ describe("request()", () => {
     });
     it("should throw for missing dependencies", () => {
       expect(() => {
-        request("https://www.arcgis.com/sharing/rest/info");
+        request("https://www.arcgis.com/sharing/rest/info").catch();
       }).toThrowError(
         "`arcgis-rest-request` requires global variables for `fetch`, `Promise` and `FormData` to be present in the global scope. You are missing `fetch`, `Promise`, `FormData`. We recommend installing the `isomorphic-fetch`, `es6-promise`, `isomorphic-form-data` modules at the root of your application to add these to the global scope. See https://bit.ly/2KNwWaJ for more info."
       );

--- a/packages/arcgis-rest-sharing/test/group-sharing.test.ts
+++ b/packages/arcgis-rest-sharing/test/group-sharing.test.ts
@@ -128,6 +128,9 @@ describe("shareItemWithGroup() ::", () => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/jsmith/items/n3v/share"
         );
+        expect(url).toBe(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/jsmith/items/n3v/share"
+        );
         expect(options.method).toBe("POST");
         expect(response).toEqual(SharingResponse);
         expect(options.body).toContain("f=json");
@@ -203,6 +206,9 @@ describe("shareItemWithGroup() ::", () => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
         );
+        expect(url).toBe(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
+        );
         expect(options.method).toBe("POST");
         expect(response).toEqual(SharingResponse);
         expect(options.body).toContain("f=json");
@@ -247,6 +253,9 @@ describe("shareItemWithGroup() ::", () => {
           "All fetchMocks should have been called"
         );
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+        );
+        expect(url).toBe(
           "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
         );
         expect(options.method).toBe("POST");
@@ -398,6 +407,9 @@ describe("unshareItemWithGroup() ::", () => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/jsmith/items/a5b/unshare"
         );
+        expect(url).toBe(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/jsmith/items/a5b/unshare"
+        );
         expect(options.method).toBe("POST");
         expect(response).toEqual(UnsharingResponse);
         expect(options.body).toContain("f=json");
@@ -443,6 +455,9 @@ describe("unshareItemWithGroup() ::", () => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/a5b/unshare"
         );
+        expect(url).toBe(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/a5b/unshare"
+        );
         expect(options.method).toBe("POST");
         expect(response).toEqual(UnsharingResponse);
         expect(options.body).toContain("f=json");
@@ -483,6 +498,9 @@ describe("unshareItemWithGroup() ::", () => {
     })
       .then(response => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/items/a5b/unshare"
+        );
+        expect(url).toBe(
           "https://myorg.maps.arcgis.com/sharing/rest/content/items/a5b/unshare"
         );
         expect(options.method).toBe("POST");

--- a/packages/arcgis-rest-sharing/test/helpers.test.ts
+++ b/packages/arcgis-rest-sharing/test/helpers.test.ts
@@ -21,11 +21,15 @@ describe("sharing helpers ::", () => {
         id: "ignoreme",
         groupId: "tb6",
         authentication: MOCK_USER_SESSION
-      }).then(result => {
-        expect(fetchMock.done()).toBeTruthy();
-        expect(result).toBe("nonmember", "should return nonmember");
-        done();
-      });
+      })
+        .then(result => {
+          expect(fetchMock.done()).toBeTruthy();
+          expect(result).toBe("nonmember", "should return nonmember");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
     });
 
     it("should request the group and return the member type", done => {
@@ -37,11 +41,15 @@ describe("sharing helpers ::", () => {
         id: "ignoreme",
         groupId: "tb6",
         authentication: MOCK_USER_SESSION
-      }).then(result => {
-        expect(fetchMock.done()).toBeTruthy();
-        expect(result).toBe("owner", "should return owner");
-        done();
-      });
+      })
+        .then(result => {
+          expect(fetchMock.done()).toBeTruthy();
+          expect(result).toBe("owner", "should return owner");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
     });
   });
 });


### PR DESCRIPTION
> should we be running lint before commits and in CI?

yes! we actually always have been, we just weren't passing through the appropriate `tslint` configuration options in husky's precommit hook. whoops!

* thats fixed now
* manual lint fixes
* adding a step in CI to ensure linting is run there too.

AFFECTS PACKAGES:
@esri/arcgis-rest-auth
@esri/arcgis-rest-feature-service
@esri/arcgis-rest-geocoder
@esri/arcgis-rest-request
@esri/arcgis-rest-sharing

ISSUES CLOSED: #301

