### PR TITLE
fix(:bug:): throw a more helpful error message when FormData or Promise are missing

### DIFF
--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -169,17 +169,21 @@ export function request(
     recommendedPackages.push("`isomorphic-fetch`");
   }
 
-  if (!Promise) {
+  if (typeof Promise === "undefined") {
     missingGlobals.push("`Promise`");
     recommendedPackages.push("`es6-promise`");
   }
 
-  if (!FormData) {
+  if (typeof FormData === "undefined") {
     missingGlobals.push("`FormData`");
     recommendedPackages.push("`isomorphic-form-data`");
   }
 
-  if (!options.fetch || !Promise || !FormData) {
+  if (
+    !options.fetch ||
+    typeof Promise === "undefined" ||
+    typeof FormData === "undefined"
+  ) {
     throw new Error(
       `\`arcgis-rest-request\` requires global variables for \`fetch\`, \`Promise\` and \`FormData\` to be present in the global scope. You are missing ${missingGlobals.join(
         ", "


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-request

ISSUES CLOSED: #322