### PR TITLE
fix(item): use fileName parameter to name Blobs when present

### DIFF
--- a/packages/arcgis-rest-request/src/utils/encode-form-data.ts
+++ b/packages/arcgis-rest-request/src/utils/encode-form-data.ts
@@ -16,8 +16,13 @@ export function encodeFormData(params: any): FormData | string {
     const formData = new FormData();
     Object.keys(newParams).forEach((key: any) => {
       if (typeof Blob !== "undefined" && newParams[key] instanceof Blob) {
-        // Pass on the explicit file name to override default name such as "blob"
-        formData.append(key, newParams[key], newParams[key].name || key);
+        /* To name the Blob:
+         1. look to an alternate request parameter called 'fileName'
+         2. see if 'name' has been tacked onto the Blob manually
+         3. if all else fails, use the request parameter
+        */
+        const filename = newParams["fileName"] || newParams[key].name || key;
+        formData.append(key, newParams[key], filename);
       } else {
         formData.append(key, newParams[key]);
       }

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,7 @@
     "ordered-imports": ["any"],
     "only-arrow-functions": [false],
     "object-literal-sort-keys": false,
-    "interface-name": [true, "always-prefix"]
+    "interface-name": [true, "always-prefix"],
+    "no-string-literal": false
   }
 }


### PR DESCRIPTION
@dbouwman and i trapped a bug this morning in which `/addResources` complains of an invalid file extension even though the correct name was passed along in the request.

this is because internally we set the name of the `Blob` using the parameter name (which doesn't include a file extension) when it wasn't set previously.

```js
fetch("http://edn.maps.arcgis.com/sharing/rest/community/users/jgravois/info/headshot-pacifier.jpg")
  .then(response => response.blob())
  .then(image => {
    const session = new UserSession({
      username: "you",
      password: "shhhh"
    });
    
    // prior to this fix, this is necessary even though 'name' isn't an actual property of Blobs
    // image.name = "headshot.jpg"; 

    addItemResource({
      id: "guidofitemyouown",
      owner: "you",
      name: "headshot.jpg", // fileName
      resource: image,
      authentication: session
    })
      .then(response => console.log(response));
  });  
```
AFFECTS PACKAGES:
@esri/arcgis-rest-request