### PR TITLE
fix(portal): fetch tokens for rest admin requests to services federated with Portal too

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -677,7 +677,8 @@ export class UserSession implements IAuthenticationManager {
     url: string,
     requestOptions?: ITokenRequestOptions
   ) {
-    const [root] = url.split("/rest/services/");
+    // requests to /rest/services/ and /rest/admin/services/ are both valid
+    const [root] = url.split(/\/rest(\/admin)?\/services\//);
     const existingToken = this.trustedServers[root];
 
     if (existingToken && existingToken.expires.getTime() > Date.now()) {

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -193,6 +193,57 @@ describe("UserSession", () => {
         });
     });
 
+    it("should generate a token for an untrusted, federated server admin call", done => {
+      const session = new UserSession({
+        clientId: "id",
+        token: "token",
+        refreshToken: "refresh",
+        tokenExpires: TOMORROW,
+        portal: "https://gis.city.gov/sharing/rest"
+      });
+
+      fetchMock.postOnce("https://gisservices.city.gov/public/rest/info", {
+        currentVersion: 10.51,
+        fullVersion: "10.5.1.120",
+        owningSystemUrl: "https://gis.city.gov",
+        authInfo: {
+          isTokenBasedSecurity: true,
+          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken"
+        }
+      });
+
+      fetchMock.postOnce("https://gis.city.gov/sharing/rest/info", {
+        owningSystemUrl: "http://gis.city.gov",
+        authInfo: {
+          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken",
+          isTokenBasedSecurity: true
+        }
+      });
+
+      fetchMock.postOnce("https://gis.city.gov/sharing/generateToken", {
+        token: "serverToken",
+        expires: TOMORROW
+      });
+
+      session
+        .getToken(
+          "https://gisservices.city.gov/public/rest/admin/services/trees/FeatureServer/addToDefinition"
+        )
+        .then(token => {
+          expect(token).toBe("serverToken");
+          return session.getToken(
+            "https://gisservices.city.gov/public/rest/admin/services/trees/FeatureServer/addToDefinition"
+          );
+        })
+        .then(token => {
+          expect(token).toBe("serverToken");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
     it("should generate a token for an untrusted, federated server with user credentials", done => {
       const session = new UserSession({
         username: "c@sey",


### PR DESCRIPTION
i went with a regex instead of the if/else block @dpbayer suggested.

AFFECTS PACKAGES:
@esri/arcgis-rest-auth

ISSUES CLOSED: #329