### PR TITLE
docs(api): add cdn script tag to docs api page and package pages

### DIFF
--- a/docs/acetate.config.js
+++ b/docs/acetate.config.js
@@ -203,6 +203,12 @@ module.exports = function(acetate) {
     }@${package.version}/dist/umd/${package.name.replace("@esri/arcgis-rest-", "")}.umd`;
   });
 
+  // <code> friendly script tag string
+  // future entry point for adding SRI hash
+  acetate.helper("scriptTag", function(context, package) {
+     return `&lt;script src="https://unpkg.com/${package.name}@${package.version}/dist/umd/${package.name.replace("@esri/arcgis-rest-", "")}.umd.min.js"&gt;&lt;/script&gt;`;
+  });
+
   acetate.helper("npmInstallCmd", function(context, package) {
     const peers = package.peerDependencies
       ? Object.keys(package.peerDependencies).map(

--- a/docs/src/api/_package.html
+++ b/docs/src/api/_package.html
@@ -3,7 +3,7 @@
 <p class="trailer-half">{{pkg.description}}</p>
 <h2 class="font-size--1 trailer-half">npm install:</h2>
 <pre><code>{% npmInstallCmd pkg %}</code></pre>
-<h3 class="font-size--1 trailer-half">CDN:</h2>
+<h2 class="font-size--1 trailer-half">CDN:</h2>
 <pre><code>{% scriptTag pkg %}</code></pre>
 <hr class="leader-half trailer-half">
 <ul class="list-plain package-contents">

--- a/docs/src/api/_package.html
+++ b/docs/src/api/_package.html
@@ -3,9 +3,7 @@
 <p class="trailer-half">{{pkg.description}}</p>
 <h2 class="font-size--1 trailer-half">npm install:</h2>
 <pre><code>{% npmInstallCmd pkg %}</code></pre>
-<h2 class="font-size--1 trailer-half">CDN url:</h2>
-<pre><code>{% cdnUrl pkg %}.js</code></pre>
-<h3 class="font-size--1 trailer-half">Script tag:</h2>
+<h3 class="font-size--1 trailer-half">CDN:</h2>
 <pre><code>{% scriptTag pkg %}</code></pre>
 <hr class="leader-half trailer-half">
 <ul class="list-plain package-contents">

--- a/docs/src/api/_package.html
+++ b/docs/src/api/_package.html
@@ -5,6 +5,8 @@
 <pre><code>{% npmInstallCmd pkg %}</code></pre>
 <h2 class="font-size--1 trailer-half">CDN url:</h2>
 <pre><code>{% cdnUrl pkg %}.js</code></pre>
+<h3 class="font-size--1 trailer-half">Script tag:</h2>
+<pre><code>{% scriptTag pkg %}</code></pre>
 <hr class="leader-half trailer-half">
 <ul class="list-plain package-contents">
 {% for declaration in declarations %}

--- a/docs/src/api/index.html
+++ b/docs/src/api/index.html
@@ -10,9 +10,7 @@ layout: "api/_layout:content"
   <p>{{package.pkg.description}}</p>
   <h3 class="font-size--1 trailer-half">npm install:</h2>
   <pre><code>{% npmInstallCmd package.pkg %}</code></pre>
-  <h3 class="font-size--1 trailer-half">CDN url:</h2>
-  <pre><code>{% cdnUrl package.pkg %}.js</code></pre>
-  <h3 class="font-size--1 trailer-half">Script tag:</h2>
+  <h3 class="font-size--1 trailer-half">CDN:</h2>
   <pre><code>{% scriptTag package.pkg %}</code></pre>
   <hr class="leader-half trailer-half">
   <ul class="list-plain package-contents">

--- a/docs/src/api/index.html
+++ b/docs/src/api/index.html
@@ -8,9 +8,9 @@ layout: "api/_layout:content"
   <small class="label right">Version {{package.pkg.version}}</small>
   <h2 class="{{package.icon}} font-size-3 trailer-half"> {% link baseUrl + package.pageUrl, package.pkg.name, class="tsd-kind-icon" %}</h2>
   <p>{{package.pkg.description}}</p>
-  <h3 class="font-size--1 trailer-half">npm install:</h2>
+  <h3 class="font-size--1 trailer-half">npm install:</h3>
   <pre><code>{% npmInstallCmd package.pkg %}</code></pre>
-  <h3 class="font-size--1 trailer-half">CDN:</h2>
+  <h3 class="font-size--1 trailer-half">CDN:</h3>
   <pre><code>{% scriptTag package.pkg %}</code></pre>
   <hr class="leader-half trailer-half">
   <ul class="list-plain package-contents">

--- a/docs/src/api/index.html
+++ b/docs/src/api/index.html
@@ -12,6 +12,8 @@ layout: "api/_layout:content"
   <pre><code>{% npmInstallCmd package.pkg %}</code></pre>
   <h3 class="font-size--1 trailer-half">CDN url:</h2>
   <pre><code>{% cdnUrl package.pkg %}.js</code></pre>
+  <h3 class="font-size--1 trailer-half">Script tag:</h2>
+  <pre><code>{% scriptTag package.pkg %}</code></pre>
   <hr class="leader-half trailer-half">
   <ul class="list-plain package-contents">
   {% for declaration in package.declarations %}


### PR DESCRIPTION
As requested in https://github.com/Esri/arcgis-rest-js/issues/321.

Adds basic script tags to api and package pages.

SRI hash proof of concept https://github.com/COV-GIS/arcgis-rest-js/commit/579636bafebff4f2b352c70863dc5331d5650d5e.

Requesting assistance and/or ideas as how to best create SRI hashes for each min js file when starting up the docs build process.