### PR TITLE
manual bump to v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### [Unreleased][HEAD]
 
+## [1.11.0] - September 19th 2018
+
+### @esri/arcgis-rest-request
+
+* Bug Fixes
+   * **item**: use fileName parameter to name Blobs when present [`9f5c093`](https://github.com/Esri/arcgis-rest-js/commit/9f5c09390696f7945d78b8f45b431d2705b53c16)
+
+### @esri/arcgis-rest-auth
+
+* Bug Fixes
+   * **portal**: tokens are now fetched correctly for calls to ArcGIS Enterprise "rest/admin/services" [`9f5c093`](https://github.com/Esri/arcgis-rest-js/commit/79dda000e9cc3d8cf270ab3ace65d70d20d5ac57) 🙏dpbayer🙏
+
 ## [1.10.0] - September 17th 2018
 
 ### @esri/arcgis-rest-feature-service-admin
@@ -772,4 +784,5 @@ Initial Public Release
 [1.8.0]: https://github.com/Esri/arcgis-rest-js/compare/v1.7.1...v1.8.0 "v1.8.0"
 [1.9.0]: https://github.com/Esri/arcgis-rest-js/compare/v1.8.0...v1.9.0 "v1.9.0"
 [1.10.0]: https://github.com/Esri/arcgis-rest-js/compare/v1.9.0...v1.10.0 "v1.10.0"
-[HEAD]: https://github.com/Esri/arcgis-rest-js/compare/v1.10.0...HEAD "Unreleased Changes"
+[1.11.0]: https://github.com/Esri/arcgis-rest-js/compare/v1.10.0...v1.11.0 "v1.11.0"
+[HEAD]: https://github.com/Esri/arcgis-rest-js/compare/v1.11.0...HEAD "Unreleased Changes"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Some useful commands include:
 * [`@esri/arcgis-rest-sharing`](./packages/arcgis-rest-sharing) - Methods for updating permissions for ArcGIS Online/Enterprise content.
 * [`@esri/arcgis-rest-feature-service`](./packages/arcgis-rest-feature-service) - Functions for working with feature services
 * [`@esri/arcgis-rest-geocoder`](./packages/arcgis-rest-geocoder) - Geocoding wrapper for `@esri/arcgis-rest-js`
+* [`@esri/arcgis-rest-feature-service-admin`](./packages/arcgis-rest-feature-service-admin) - Functions for creating and updating feature services
 
 
 ### Frequently Asked Questions

--- a/demos/ago-node-cli/package.json
+++ b/demos/ago-node-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cli",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "arcgis-rest-js node command-line item search example",
   "main": "ago.js",
   "scripts": {
@@ -18,9 +18,9 @@
   "author": "Dave Bouwman <dbouwman@esri.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-items": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0",
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-items": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0",
     "chalk": "^2.3.0",
     "commander": "^2.12.2",
     "isomorphic-fetch": "^2.2.1",

--- a/demos/attachments/package.json
+++ b/demos/attachments/package.json
@@ -1,13 +1,13 @@
 {
   "name": "attachments",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "description": "Vanilla JavaScript demo of attachment methods of @esri/arcgis-rest-feature-service",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-feature-service": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-feature-service": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
     "http-server": "*"

--- a/demos/batch-geocoder-node/package.json
+++ b/demos/batch-geocoder-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "batch-geocoder",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "arcgis-rest-js batch geocode sample",
   "main": "batch-geocode.js",
   "scripts": {
@@ -27,10 +27,10 @@
   },
   "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-geocoder": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0",
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-geocoder": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0",
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-form-data": "^2.0.0",
     "node-fetch": "^2.2.0",

--- a/demos/express/package.json
+++ b/demos/express/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@esri/arcgis-rest-demo-express",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "description": "Demo of @esri/arcgis-rest-* packages in an Express server",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0",
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0",
     "express": "^4.16.3",
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-form-data": "^2.0.0"

--- a/demos/feature-service-browser/package.json
+++ b/demos/feature-service-browser/package.json
@@ -1,13 +1,13 @@
 {
   "name": "feature-service-browser",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "description": "Vanilla JavaScript demo of @esri/arcgis-rest-feature-service",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-feature-service": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-feature-service": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
     "http-server": "*"

--- a/demos/geocoder-browser/package.json
+++ b/demos/geocoder-browser/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@esri/arcgis-rest-geocoder-vanilla",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "description": "Vanilla JavaScript demo of @esri/arcgis-rest-geocoder",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-geocoder": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-geocoder": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
     "http-server": "0.11.1"

--- a/demos/jsapi-integration/package.json
+++ b/demos/jsapi-integration/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@esri/jsapi-integration",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "description": "to do",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-items": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-items": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
     "http-server": "*"

--- a/demos/oauth2-browser/package.json
+++ b/demos/oauth2-browser/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@esri/arcgis-rest-demo-vanilla",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "description": "Vanilla JavaScript demo of @esri/arcgis-rest-* packages",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
     "http-server": "*"

--- a/demos/vue/package.json
+++ b/demos/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@esri/arcgis-rest-demo-vue-with-popup",
   "description": "VueJS demo of @esri/arcgis-rest-* packages.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "author": "",
   "license": "Apache-2.0",
   "private": true,
@@ -12,8 +12,8 @@
     "start": "npm run serve"
   },
   "dependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0",
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0",
     "vue": "^2.5.17",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-js",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-js",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Compact, modular JavaScript wrappers for the ArcGIS REST API that run in Node.js and modern browsers.",
   "devDependencies": {
     "@types/es6-promise": "0.0.32",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "date-fns": "^1.29.0",
     "fetch-mock": "^5.13.1",
     "gh-pages": "^1.1.0",
-    "gh-release": "^3.2.1",
+    "gh-release": "3.2.1",
     "husky": "^0.14.3",
     "inspect-process": "^0.5.0",
     "jasmine": "^2.8.0",

--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-auth",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Authentication helpers for @esri/arcgis-rest-*.",
   "main": "dist/node/index.js",
   "browser": "dist/umd/auth.umd.js",
@@ -15,12 +15,12 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-common-types/package.json
+++ b/packages/arcgis-rest-common-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-common-types",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Common TypeScript types for @esri/arcgis-rest-* packages.",
   "types": "dist/types/index.d.ts",
   "author": "",

--- a/packages/arcgis-rest-feature-service-admin/package.json
+++ b/packages/arcgis-rest-feature-service-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-feature-service-admin",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Feature service administration helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/umd/feature-service-admin.umd.js",
@@ -15,16 +15,16 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-items": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-items": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-items": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-items": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-feature-service",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Feature service helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/umd/feature-service.umd.js",
@@ -15,12 +15,12 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-geocoder/package.json
+++ b/packages/arcgis-rest-geocoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-geocoder",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Geocoding helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/umd/geocoder.umd.js",
@@ -15,14 +15,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-groups/package.json
+++ b/packages/arcgis-rest-groups/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-groups",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Portal Group helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/umd/groups.umd.js",
@@ -15,14 +15,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-items/package.json
+++ b/packages/arcgis-rest-items/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-items",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Portal Item helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/umd/items.umd.js",
@@ -15,14 +15,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-request",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Common methods and utilities for @esri/arcgis-rest-* packages.",
   "main": "dist/node/index.js",
   "browser": "dist/umd/request.umd.js",

--- a/packages/arcgis-rest-sharing/package.json
+++ b/packages/arcgis-rest-sharing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-sharing",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Helper utilities for managing access to ArcGIS content in Node.js and modern browsers.",
   "main": "dist/node/index.js",
   "browser": "dist/umd/sharing.umd.js",
@@ -12,16 +12,16 @@
     "tslib": "^1.8.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-groups": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-groups": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-groups": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-groups": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "files": [
     "dist/**"

--- a/packages/arcgis-rest-users/package.json
+++ b/packages/arcgis-rest-users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-users",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Portal user helpers for @esri/arcgis-rest-request",
   "main": "dist/node/index.js",
   "browser": "dist/umd/users.umd.js",
@@ -15,14 +15,14 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.10.0",
-    "@esri/arcgis-rest-common-types": "^1.10.0",
-    "@esri/arcgis-rest-request": "^1.10.0"
+    "@esri/arcgis-rest-auth": "^1.11.0",
+    "@esri/arcgis-rest-common-types": "^1.11.0",
+    "@esri/arcgis-rest-request": "^1.11.0"
   },
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION
![screenshot 2018-09-25 11 29 47](https://user-images.githubusercontent.com/3011734/46034785-5c4e0d00-c0b6-11e8-8906-e167bed63703.png)

@dbouwman published [`v1.11.0`](https://www.npmjs.com/package/@esri/arcgis-rest-request) to npm successfully last week, but when he hit https://github.com/hypermodules/gh-release/issues/82 it derailed pushing the SHA up to `master`

consider this a _better late than never_ PR.

> note: i added a temporary revlock for `gh-release` too.