### PR TITLE
Add "access" param to IItemResourceRequestOptions.

### DIFF
--- a/packages/arcgis-rest-items/src/add.ts
+++ b/packages/arcgis-rest-items/src/add.ts
@@ -95,6 +95,7 @@ export function addItemResource(
     file: requestOptions.resource,
     fileName: requestOptions.name,
     text: requestOptions.content,
+    access: requestOptions.access,
     ...requestOptions.params
   };
 

--- a/packages/arcgis-rest-items/src/helpers.ts
+++ b/packages/arcgis-rest-items/src/helpers.ts
@@ -31,6 +31,11 @@ export interface IItemResourceRequestOptions extends IItemIdRequestOptions {
    * Text input to be added as a file resource.
    */
   content?: string;
+  /**
+   * Set file resource to be private regardless of the item access level, or revert it by setting
+   * it to inherit which makes the item resource have the same access as the item.
+   */
+  access?: "private" | "inherit";
   resource?: any;
 }
 

--- a/packages/arcgis-rest-items/src/update.ts
+++ b/packages/arcgis-rest-items/src/update.ts
@@ -82,6 +82,7 @@ export function updateItemResource(
 
   // mix in user supplied params
   requestOptions.params = {
+    file: requestOptions.resource,
     fileName: requestOptions.name,
     text: requestOptions.content,
     ...requestOptions.params

--- a/packages/arcgis-rest-items/src/update.ts
+++ b/packages/arcgis-rest-items/src/update.ts
@@ -84,7 +84,8 @@ export function updateItemResource(
   requestOptions.params = {
     ...requestOptions.params,
     fileName: requestOptions.name,
-    text: requestOptions.content
+    text: requestOptions.content,
+    access: requestOptions.access
   };
 
   return request(url, requestOptions);

--- a/packages/arcgis-rest-items/test/add.test.ts
+++ b/packages/arcgis-rest-items/test/add.test.ts
@@ -242,7 +242,7 @@ describe("search", () => {
             expect(params.get("token")).toEqual("fake-token");
             expect(params.get("f")).toEqual("json");
             expect(params.get("file")).toEqual(file);
-            expect(params.get("access")).toEqual("inherit");
+            expect(params.get("access")).toEqual("private");
             expect(params.get("fileName")).toEqual("thebigkahuna");
           }
 

--- a/packages/arcgis-rest-items/test/add.test.ts
+++ b/packages/arcgis-rest-items/test/add.test.ts
@@ -187,6 +187,7 @@ describe("search", () => {
         id: "3ef",
         // File() is only available in the browser
         resource: file,
+        access: "private",
         name: "thebigkahuna",
         ...MOCK_USER_REQOPTS
       })
@@ -203,6 +204,7 @@ describe("search", () => {
             expect(params.get("token")).toEqual("fake-token");
             expect(params.get("f")).toEqual("json");
             expect(params.get("file")).toEqual(file);
+            expect(params.get("access")).toEqual("private");
             expect(params.get("fileName")).toEqual("thebigkahuna");
           }
 

--- a/packages/arcgis-rest-items/test/add.test.ts
+++ b/packages/arcgis-rest-items/test/add.test.ts
@@ -187,7 +187,7 @@ describe("search", () => {
         id: "3ef",
         // File() is only available in the browser
         resource: file,
-        access: "private",
+        access: "inherit",
         name: "thebigkahuna",
         ...MOCK_USER_REQOPTS
       })
@@ -204,7 +204,7 @@ describe("search", () => {
             expect(params.get("token")).toEqual("fake-token");
             expect(params.get("f")).toEqual("json");
             expect(params.get("file")).toEqual(file);
-            expect(params.get("access")).toEqual("private");
+            expect(params.get("access")).toEqual("inherit");
             expect(params.get("fileName")).toEqual("thebigkahuna");
           }
 

--- a/packages/arcgis-rest-items/test/update.test.ts
+++ b/packages/arcgis-rest-items/test/update.test.ts
@@ -155,6 +155,7 @@ describe("search", () => {
         owner: "dbouwman",
         name: "image/banner.png",
         content: "jumbotron",
+        access: "inherit",
         ...MOCK_USER_REQOPTS
       })
         .then(response => {
@@ -168,6 +169,7 @@ describe("search", () => {
             encodeParam("fileName", "image/banner.png")
           );
           expect(options.body).toContain(encodeParam("text", "jumbotron"));
+          expect(options.body).toContain(encodeParam("access", "inherit"));
           expect(options.body).toContain(encodeParam("token", "fake-token"));
           done();
         })


### PR DESCRIPTION
Items now support `private` resource items: https://developers.arcgis.com/rest/users-groups-and-items/add-resources.htm. This PR adds a param to the types to support this.