### PR TITLE
chore: remove rogue .js files from common-types

### DIFF
--- a/packages/arcgis-rest-common-types/src/group.js
+++ b/packages/arcgis-rest-common-types/src/group.js
@@ -1,2 +1,0 @@
-/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
- * Apache-2.0 */

--- a/packages/arcgis-rest-common-types/src/index.js
+++ b/packages/arcgis-rest-common-types/src/index.js
@@ -1,2 +1,0 @@
-/* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
- * Apache-2.0 */

--- a/packages/arcgis-rest-common-types/src/item.js
+++ b/packages/arcgis-rest-common-types/src/item.js
@@ -1,2 +1,0 @@
-/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
- * Apache-2.0 */

--- a/packages/arcgis-rest-common-types/src/webmap.js
+++ b/packages/arcgis-rest-common-types/src/webmap.js
@@ -1,2 +1,0 @@
-/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
- * Apache-2.0 */


### PR DESCRIPTION
accidentally introduced when we tagged [`v1.10.0`](https://github.com/Esri/arcgis-rest-js/blame/master/packages/arcgis-rest-common-types/src/group.js)

it'd probably be worth poking a stick at the gremlins inside @tomwayson's machine through the DVD drive.

AFFECTS PACKAGES:
@esri/arcgis-rest-common-types