### PR TITLE
manually bump request to 1.12.0

### DIFF
--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/arcgis-rest-request",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Common methods and utilities for @esri/arcgis-rest-* packages.",
   "main": "dist/node/index.js",
   "browser": "dist/umd/request.umd.js",


### PR DESCRIPTION
with every release its _something_...

somehow our publish script bumped `@esri/arcgis-rest-request` long enough to ensure the npm release looks correct and then must have reverted the change.

https://unpkg.com/@esri/arcgis-rest-request@1.12.0/package.json