### PR TITLE
chore: dont point TypeDoc at test suite

### DIFF
--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -1,5 +1,5 @@
 const spawn = require("cross-spawn");
-const { join, resolve } = require("path");
+const { join } = require("path");
 const { readFile, writeFile } = require("fs");
 const _ = require("lodash");
 const OUTPUT = join(process.cwd(), "docs", "src", `typedoc.json`);
@@ -17,6 +17,8 @@ const md = new MarkdownIt();
       [
         "-json",
         OUTPUT,
+        "--exclude",
+        "**/*test.ts",
         "--ignoreCompilerErrors",
         "--module",
         "common",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,18 +32,18 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.8.tgz",
-      "integrity": "sha512-Z5nu9Pbxj9yNeXIK3UwGlRdJth4cZ5sCq05nI7FaI6B0oz28nxkOtp6Lsz0ZnmLHJGvOJfB/VHxSTbVq/i6ujA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
+      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/glob": {
-      "version": "5.0.35",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
-      "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
       "dev": true,
       "requires": {
         "@types/events": "*",
@@ -52,15 +52,15 @@
       }
     },
     "@types/handlebars": {
-      "version": "4.0.37",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.37.tgz",
-      "integrity": "sha512-c/g99PQsJEFYdK3LT1qgPAZ61fu/oFOaEhov/6ZuUNMi1xQFbAOSThlX8fAQLf+QoGXtyv4S39OjIRXf3HkBtw==",
+      "version": "4.0.39",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.39.tgz",
+      "integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA==",
       "dev": true
     },
     "@types/highlight.js": {
-      "version": "9.12.2",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
-      "integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
+      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
       "dev": true
     },
     "@types/isomorphic-fetch": {
@@ -76,21 +76,21 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.109",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.109.tgz",
-      "integrity": "sha512-hop8SdPUEzbcJm6aTsmuwjIYQo1tqLseKCM+s2bBqTU2gErwI4fE+aqUVOlscPSQbKHKgtMMPoC+h4AIGOJYvw==",
+      "version": "4.14.116",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.116.tgz",
+      "integrity": "sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg==",
       "dev": true
     },
     "@types/marked": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.0.28.tgz",
-      "integrity": "sha1-RLp1Tp+lFDJYPo6zCnxN0km1L6o=",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
+      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
       "dev": true
     },
     "@types/minimatch": {
-      "version": "2.0.29",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.29.tgz",
-      "integrity": "sha1-UALhT3Xi1x5WQoHfBDHIwbSio2o=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/mz": {
@@ -109,9 +109,9 @@
       "dev": true
     },
     "@types/shelljs": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.9.tgz",
-      "integrity": "sha1-Or7LctnK2c1LDny4btEKl9k7pgI=",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.0.tgz",
+      "integrity": "sha512-vs1hCC8RxLHRu2bwumNyYRNrU3o8BtZhLysH5A4I98iYmA2APl6R3uNQb5ihl+WiwH0xdC9LLO+vRrXLs/Kyxg==",
       "dev": true,
       "requires": {
         "@types/glob": "*",
@@ -9487,9 +9487,9 @@
       }
     },
     "marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
       "dev": true
     },
     "math-random": {
@@ -14031,34 +14031,34 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.8.0.tgz",
-      "integrity": "sha1-1xcrxqKZZPRRt2CcAFvq2t7+I2E=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.12.0.tgz",
+      "integrity": "sha512-dsdlaYZ7Je8JC+jQ3j2Iroe4uyD0GhqzADNUVyBRgLuytQDP/g0dPkAw5PdM/4drnmmJjRzSWW97FkKo+ITqQg==",
       "dev": true,
       "requires": {
-        "@types/fs-extra": "^4.0.0",
-        "@types/handlebars": "^4.0.31",
-        "@types/highlight.js": "^9.1.8",
-        "@types/lodash": "^4.14.37",
-        "@types/marked": "0.0.28",
-        "@types/minimatch": "^2.0.29",
-        "@types/shelljs": "^0.7.0",
-        "fs-extra": "^4.0.0",
+        "@types/fs-extra": "^5.0.3",
+        "@types/handlebars": "^4.0.38",
+        "@types/highlight.js": "^9.12.3",
+        "@types/lodash": "^4.14.110",
+        "@types/marked": "^0.4.0",
+        "@types/minimatch": "3.0.3",
+        "@types/shelljs": "^0.8.0",
+        "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.13.1",
-        "marked": "^0.3.5",
+        "lodash": "^4.17.10",
+        "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",
-        "shelljs": "^0.7.0",
+        "shelljs": "^0.8.2",
         "typedoc-default-themes": "^0.5.0",
-        "typescript": "2.4.1"
+        "typescript": "3.0.x"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+          "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14075,11 +14075,16 @@
             "graceful-fs": "^4.1.6"
           }
         },
-        "typescript": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
-          "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
-          "dev": true
+        "shelljs": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+          "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "tslint": "^5.8.0",
     "tslint-config-prettier": "^1.6.0",
     "tslint-config-standard": "^6.0.1",
-    "typedoc": "^0.8.0",
+    "typedoc": "^0.12.0",
     "typescript": "^3.0.0"
   },
   "dependencies": {

--- a/packages/arcgis-rest-items/src/update.ts
+++ b/packages/arcgis-rest-items/src/update.ts
@@ -31,9 +31,9 @@ export interface IItemMoveRequestOptions extends IItemCrudRequestOptions {
 }
 
 /**
- * Update an Item
+ * Update an Item. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/update-item.htm) for more information.
  *
- * * ```js
+ * ```js
  * import { updateItem } from '@esri/arcgis-rest-items';
  *
  * updateItem({


### PR DESCRIPTION
- [X] bump TypeDoc version to start using `typescript@3`
- [X] ignore the `.ts` files in our test suite.

ISSUES CLOSED: #347 

extra credit:
- [X] fixed typo in inline `updateItem()` code snippet to make sure it renders correctly in the API reference.