### PR TITLE
fix: make it possible to update a service using a layer definition

### DIFF
--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -93,6 +93,8 @@ export interface IField {
   length?: number;
   /** A Boolean defining whether this field can have a null value. */
   nullable?: boolean;
+  /** The value written in for new records by default. */
+  defaultValue?: any;
 }
 
 /**

--- a/packages/arcgis-rest-common-types/src/webmap.ts
+++ b/packages/arcgis-rest-common-types/src/webmap.ts
@@ -886,7 +886,7 @@ export interface ILayerDefinition extends IHasZM {
   /** Boolean value indicating whether the validateSQL operation is supported across a feature service layer. */
   supportsValidateSql?: boolean;
   /** A property of the layer definition when there are no types defined; otherwise, templates are defined as properties of the types. */
-  templates?: ITemplate;
+  templates?: ITemplate[];
   /** The time info metadata of the layer. May be set for feature layers inside a feature collection item. */
   timeInfo?: any;
   /** Indicates whether the layerDefinition applies to a Feature Layer or a Table. */
@@ -900,6 +900,7 @@ export interface ILayerDefinition extends IHasZM {
    * The field's values are 0 = do not display, 1 = display.
    */
   visibilityField?: string;
+  relationships?: any[];
 }
 
 export interface ITypeInfoDomain {

--- a/packages/arcgis-rest-feature-service-admin/src/addTo.ts
+++ b/packages/arcgis-rest-feature-service-admin/src/addTo.ts
@@ -3,14 +3,18 @@
 
 import { request } from "@esri/arcgis-rest-request";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
-import { ILayer, ITable } from "@esri/arcgis-rest-common-types";
+import {
+  ILayer,
+  ILayerDefinition,
+  ITable
+} from "@esri/arcgis-rest-common-types";
 
 export interface IAddToServiceDefinitionRequestOptions
   extends IUserRequestOptions {
   /**
    * Layers to add
    */
-  layers?: ILayer[];
+  layers?: ILayer[] | ILayerDefinition[];
   /**
    * Tables to add
    */

--- a/packages/arcgis-rest-feature-service-admin/test/addTo.test.ts
+++ b/packages/arcgis-rest-feature-service-admin/test/addTo.test.ts
@@ -12,6 +12,8 @@ import {
   AddToFeatureServiceError
 } from "./mocks/service";
 
+import { layerDefinitionSid } from "./mocks/layerDefinition";
+
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { TOMORROW } from "@esri/arcgis-rest-auth/test/utils";
 import { encodeParam, ErrorTypes } from "@esri/arcgis-rest-request";
@@ -209,6 +211,47 @@ describe("add to feature service", () => {
               JSON.stringify({
                 layers: [layerDescriptionCyd],
                 tables: [tableDescriptionGene]
+              })
+            )
+          );
+
+          // Check response
+          expect(response).toEqual(
+            AddToFeatureServiceSuccessResponseCydAndGene
+          );
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should add a layer definition", done => {
+      fetchMock.once("*", AddToFeatureServiceSuccessResponseCydAndGene);
+
+      addToServiceDefinition(
+        "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
+        {
+          layers: [layerDefinitionSid],
+          ...MOCK_USER_REQOPTS
+        }
+      )
+        .then(response => {
+          // Check service call
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+
+          expect(url).toEqual(
+            "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain("f=json");
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          expect(options.body).toContain(
+            encodeParam(
+              "addToDefinition",
+              JSON.stringify({
+                layers: [layerDefinitionSid]
               })
             )
           );

--- a/packages/arcgis-rest-feature-service-admin/test/mocks/layerDefinition.ts
+++ b/packages/arcgis-rest-feature-service-admin/test/mocks/layerDefinition.ts
@@ -1,0 +1,79 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { ILayerDefinition, IExtent } from "@esri/arcgis-rest-common-types";
+
+const defaultExtent: IExtent = {
+  xmin: -180,
+  ymin: -90,
+  xmax: 180,
+  ymax: 90,
+  spatialReference: {
+    wkid: 4326,
+    latestWkid: 4326
+  }
+};
+
+export const layerDefinitionSid: ILayerDefinition = {
+  allowGeometryUpdates: true,
+  capabilities: "Create,Delete,Query,Update,Editing",
+  copyrightText: "",
+  defaultVisibility: true,
+  description: "",
+  drawingInfo: {
+    transparency: 0,
+    labelingInfo: null,
+    renderer: {
+      type: "simple",
+      symbol: {
+        color: [20, 158, 206, 70],
+        outline: {
+          color: [255, 255, 255, 229],
+          width: 2.25,
+          type: "esriSLS",
+          style: "esriSLSSolid"
+        },
+        type: "esriSFS",
+        style: "esriSFSSolid"
+      }
+    }
+  },
+  extent: defaultExtent,
+  fields: [
+    {
+      name: "OBJECTID",
+      type: "esriFieldTypeOID",
+      alias: "OBJECTID",
+      nullable: false,
+      editable: false,
+      domain: null
+    },
+    {
+      name: "author",
+      type: "esriFieldTypeString",
+      alias: "author",
+      length: 256,
+      nullable: false,
+      editable: true,
+      domain: null,
+      defaultValue: null
+    }
+  ],
+  geometryType: "esriGeometryPolygon",
+  hasAttachments: true,
+  hasZ: false,
+  hasStaticData: false,
+  htmlPopupType: "esriServerHTMLPopupTypeNone",
+  isDataVersioned: false,
+  maxRecordCount: 2000,
+  name: "hub_annotations",
+  objectIdField: "OBJECTID",
+  relationships: [],
+  supportsAdvancedQueries: true,
+  supportsRollbackOnFailureParameter: true,
+  supportsStatistics: true,
+  type: "Feature Layer",
+  typeIdField: "",
+  types: [],
+  timeInfo: {}
+};


### PR DESCRIPTION
i threw in a couple typings fixes too.

AFFECTS PACKAGES:
@esri/arcgis-rest-common-types
@esri/arcgis-rest-feature-service-admin