### PR TITLE
fix: more types for new services/layer definitions

### DIFF
--- a/packages/arcgis-rest-common-types/src/item.ts
+++ b/packages/arcgis-rest-common-types/src/item.ts
@@ -41,5 +41,5 @@ export interface IItem extends IItemAdd {
   tags: string[];
   created: number;
   modified: number;
-  protected: boolean;
+  protected?: boolean; // not present in search results
 }

--- a/packages/arcgis-rest-common-types/src/webmap.ts
+++ b/packages/arcgis-rest-common-types/src/webmap.ts
@@ -901,6 +901,12 @@ export interface ILayerDefinition extends IHasZM {
    */
   visibilityField?: string;
   relationships?: any[];
+  editFieldsInfo?: {
+    creationDateField?: string;
+    creatorField?: string;
+    editDateField?: string;
+    editorField?: string;
+  };
 }
 
 export interface ITypeInfoDomain {

--- a/packages/arcgis-rest-feature-service-admin/src/create.ts
+++ b/packages/arcgis-rest-feature-service-admin/src/create.ts
@@ -69,6 +69,18 @@ export interface ICreateServiceParams {
    * A JSON object specifying the properties of cross-site scripting prevention.
    */
   xssPreventionInfo?: any;
+  /**
+   * Editor tracking info.
+   */
+  editorTrackingInfo?: {
+    enableEditorTracking?: boolean;
+    enableOwnershipAccessControl?: boolean;
+    allowOthersToUpdate?: boolean;
+    allowOthersToDelete?: boolean;
+    allowOthersToQuery?: boolean;
+    allowAnonymousToUpdate?: boolean;
+    allowAnonymousToDelete?: boolean;
+  };
 }
 
 export interface ICreateServiceRequestOptions extends IItemCrudRequestOptions {

--- a/packages/arcgis-rest-items/test/mocks/search.ts
+++ b/packages/arcgis-rest-items/test/mocks/search.ts
@@ -56,8 +56,7 @@ export const SearchResponse: ISearchResult = {
       numComments: 0,
       numRatings: 0,
       avgRating: 0,
-      numViews: 4,
-      protected: false
+      numViews: 4
     }
   ]
 };


### PR DESCRIPTION
i'm hopeful these are the last typing updates i'll need for pending work in hub.js.

AFFECTS PACKAGES:
@esri/arcgis-rest-common-types
@esri/arcgis-rest-feature-service-admin