### PR TITLE
ensure 'first class citizen' geocode request parameters are passed through

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,9 +116,79 @@
   },
   "contributors": [
     {
+      "name": "Anthony Lukach"
+    },
+    {
+      "name": "Bill Reynolds",
+      "email": "wreynolds@esri.com"
+    },
+    {
+      "name": "City of Veronia GIS"
+    },
+    {
+      "name": "Dave Bouwman",
+      "email": "dbouwman@esri.com"
+    },
+    {
+      "name": "Enguerrand des Vaux"
+    },
+    {
+      "name": "Gavin Rehkemper",
+      "email": "grehkemper@esri.com"
+    },
+    {
+      "name": "Ian Trewella"
+    },
+    {
+      "name": "Idi Eradiri",
+      "email": "ieradiri@esri.com"
+    },
+    {
+      "name": "Jeff Jacobson"
+    },
+    {
+      "name": "John Gravois",
+      "email": "john@esri.com"
+    },
+    {
+      "name": "Junshan Liu",
+      "email": "jliu@esri.com"
+    },
+    {
+      "name": "Max Payson",
+      "email": "mpayson@esri.com"
+    },
+    {
+      "name": "Mike 'Jupe' Juniper",
+      "email": "mjuniper@esri.com"
+    },
+    {
+      "name": "Mike Tschudi",
+      "email": "mtschudi@esri.com"
+    },
+    {
+      "name": "Noah Mulfinger",
+      "email": "nmulfinger@esri.com"
+    },
+    {
       "name": "Patrick Arlt",
       "email": "parlt@esri.com",
       "url": "http://patrickarlt.com/"
+    },
+    {
+      "name": "Richard Hincamp"
+    },
+    {
+      "name": "Steven Kitterman",
+      "email": "skitterman@esri.com"
+    },
+    {
+      "name": "Stephen Sylvia",
+      "email": "ssylvia@esri.com"
+    },
+    {
+      "name": "Tom Wayson",
+      "email": "twayson@esri.com"
     }
   ],
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "release:prepare": "lerna publish --skip-git --skip-npm --yes && node ./support/changelog.js",
     "release:review": "git --no-pager diff --word-diff",
     "release:publish": "./support/publish.sh",
-    "c": "npm run precommit && git-cz"
+    "c": "git-cz"
   },
   "repository": {
     "type": "git",

--- a/packages/arcgis-rest-feature-service/src/add.ts
+++ b/packages/arcgis-rest-feature-service/src/add.ts
@@ -2,13 +2,12 @@
  * Apache-2.0 */
 
 import { IFeature } from "@esri/arcgis-rest-common-types";
-import { request, IRequestOptions } from "@esri/arcgis-rest-request";
-
 import {
-  IEditFeaturesParams,
-  IEditFeatureResult,
+  request,
+  IRequestOptions,
   appendCustomParams
-} from "./helpers";
+} from "@esri/arcgis-rest-request";
+import { IEditFeaturesParams, IEditFeatureResult } from "./helpers";
 
 /**
  * Add features request options. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/add-features.htm) for more information.

--- a/packages/arcgis-rest-feature-service/src/addAttachment.ts
+++ b/packages/arcgis-rest-feature-service/src/addAttachment.ts
@@ -2,7 +2,6 @@
  * Apache-2.0 */
 
 import { request, IRequestOptions } from "@esri/arcgis-rest-request";
-
 import { IEditFeatureResult } from "./helpers";
 
 /**

--- a/packages/arcgis-rest-feature-service/src/delete.ts
+++ b/packages/arcgis-rest-feature-service/src/delete.ts
@@ -1,13 +1,15 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, IRequestOptions } from "@esri/arcgis-rest-request";
-
+import {
+  request,
+  IRequestOptions,
+  appendCustomParams
+} from "@esri/arcgis-rest-request";
 import {
   IEditFeaturesParams,
   IEditFeatureResult,
-  ISharedQueryParams,
-  appendCustomParams
+  ISharedQueryParams
 } from "./helpers";
 
 /**

--- a/packages/arcgis-rest-feature-service/src/deleteAttachments.ts
+++ b/packages/arcgis-rest-feature-service/src/deleteAttachments.ts
@@ -2,7 +2,6 @@
  * Apache-2.0 */
 
 import { request, IRequestOptions } from "@esri/arcgis-rest-request";
-
 import { IEditFeatureResult } from "./helpers";
 
 /**

--- a/packages/arcgis-rest-feature-service/src/helpers.ts
+++ b/packages/arcgis-rest-feature-service/src/helpers.ts
@@ -7,13 +7,6 @@ import {
   IGeometry,
   ISpatialReference
 } from "@esri/arcgis-rest-common-types";
-import { IRequestOptions } from "@esri/arcgis-rest-request";
-
-import { IQueryFeaturesRequestOptions } from "./query";
-import { IAddFeaturesRequestOptions } from "./add";
-import { IUpdateFeaturesRequestOptions } from "./update";
-import { IDeleteFeaturesRequestOptions } from "./delete";
-import { IQueryRelatedRequestOptions } from "./queryRelated";
 
 export interface ISharedQueryParams {
   where?: string;
@@ -49,32 +42,4 @@ export interface IEditFeaturesParams {
    * Optional parameter to specify if the edits should be applied only if all submitted edits succeed.
    */
   rollbackOnFailure?: boolean;
-}
-
-/**
- * Used internally by the package to ensure that first order request options are passed through as request parameters.
- */
-export function appendCustomParams(
-  oldOptions:
-    | IQueryFeaturesRequestOptions
-    | IAddFeaturesRequestOptions
-    | IUpdateFeaturesRequestOptions
-    | IDeleteFeaturesRequestOptions
-    | IQueryRelatedRequestOptions,
-  newOptions: IRequestOptions
-) {
-  // only pass query parameters through in the request, not generic IRequestOptions props
-  Object.keys(oldOptions).forEach(function(key: string) {
-    if (
-      key !== "url" &&
-      key !== "params" &&
-      key !== "authentication" &&
-      key !== "httpMethod" &&
-      key !== "fetch" &&
-      key !== "portal" &&
-      key !== "maxUrlLength"
-    ) {
-      newOptions.params[key] = (oldOptions as { [key: string]: any })[key];
-    }
-  });
 }

--- a/packages/arcgis-rest-feature-service/src/helpers.ts
+++ b/packages/arcgis-rest-feature-service/src/helpers.ts
@@ -1,6 +1,8 @@
 /* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { appendCustomParams } from "@esri/arcgis-rest-request";
+
 import {
   esriGeometryType,
   SpatialRelationship,
@@ -43,3 +45,6 @@ export interface IEditFeaturesParams {
    */
   rollbackOnFailure?: boolean;
 }
+
+// this function has been moved into @esri/request. it is re-exported here for backwards compatibility
+export { appendCustomParams };

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -2,15 +2,19 @@
  * Apache-2.0 */
 
 import {
+  request,
+  IRequestOptions,
+  appendCustomParams
+} from "@esri/arcgis-rest-request";
+import {
   ISpatialReference,
   IFeatureSet,
   IFeature,
   esriUnits,
   IExtent
 } from "@esri/arcgis-rest-common-types";
-import { request, IRequestOptions } from "@esri/arcgis-rest-request";
+import { ISharedQueryParams } from "./helpers";
 
-import { ISharedQueryParams, appendCustomParams } from "./helpers";
 /**
  * Request options to fetch a feature by id.
  */

--- a/packages/arcgis-rest-feature-service/src/queryRelated.ts
+++ b/packages/arcgis-rest-feature-service/src/queryRelated.ts
@@ -2,14 +2,17 @@
  * Apache-2.0 */
 
 import {
+  request,
+  IRequestOptions,
+  appendCustomParams
+} from "@esri/arcgis-rest-request";
+import {
   ISpatialReference,
   IFeature,
   IHasZM,
   esriGeometryType,
   IField
 } from "@esri/arcgis-rest-common-types";
-import { request, IRequestOptions } from "@esri/arcgis-rest-request";
-import { appendCustomParams } from "./helpers";
 
 /**
  * Related record query request options. Additional arguments can be passed via the [params](/arcgis-rest-js/api/feature-service/IQueryRelatedRequestOptions/#params) property. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-feature-service-.htm) for more information and a full list of parameters.

--- a/packages/arcgis-rest-feature-service/src/update.ts
+++ b/packages/arcgis-rest-feature-service/src/update.ts
@@ -2,13 +2,12 @@
  * Apache-2.0 */
 
 import { IFeature } from "@esri/arcgis-rest-common-types";
-import { request, IRequestOptions } from "@esri/arcgis-rest-request";
-
 import {
-  IEditFeaturesParams,
-  IEditFeatureResult,
+  request,
+  IRequestOptions,
   appendCustomParams
-} from "./helpers";
+} from "@esri/arcgis-rest-request";
+import { IEditFeaturesParams, IEditFeatureResult } from "./helpers";
 
 /**
  * Update features request options. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/update-features.htm) for more information.

--- a/packages/arcgis-rest-feature-service/src/updateAttachment.ts
+++ b/packages/arcgis-rest-feature-service/src/updateAttachment.ts
@@ -2,7 +2,6 @@
  * Apache-2.0 */
 
 import { request, IRequestOptions } from "@esri/arcgis-rest-request";
-
 import { IEditFeatureResult } from "./helpers";
 
 /**

--- a/packages/arcgis-rest-geocoder/src/geocode.ts
+++ b/packages/arcgis-rest-geocoder/src/geocode.ts
@@ -1,7 +1,11 @@
 /* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, IParams } from "@esri/arcgis-rest-request";
+import {
+  request,
+  IParams,
+  appendCustomParams
+} from "@esri/arcgis-rest-request";
 
 import {
   IExtent,
@@ -27,6 +31,10 @@ export interface IGeocodeParams extends IParams {
 }
 
 export interface IGeocodeRequestOptions extends IEndpointRequestOptions {
+  /**
+   * use this if all your address info is contained in a single string.
+   */
+  singleLine?: string;
   address?: string;
   address2?: string;
   address3?: string;
@@ -53,25 +61,23 @@ export interface IGeocodeResponse {
 }
 
 /**
- * Used to determine the [location](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm)  of a single address or point of interest.
+ * Used to determine the location of a single address or point of interest. See the [REST Documentation](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm) for more information.
  *
  * ```js
  * import { geocode } from '@esri/arcgis-rest-geocoder';
  *
  * geocode("LAX")
  *   .then((response) => {
- *     response.candidates[0].location; // => { x: -118.409, y: 33.943, spatialReference: { wkid: 4326 }  }
+ *     response.candidates[0].location; // => { x: -118.409, y: 33.943, spatialReference: ...  }
  *   });
  *
  * geocode({
- *   params: {
- *     address: "1600 Pennsylvania Ave",
- *     postal: 20500,
- *     countryCode: "USA"
- *   }
+ *   address: "1600 Pennsylvania Ave",
+ *   postal: 20500,
+ *   countryCode: "USA"
  * })
  *   .then((response) => {
- *     response.candidates[0].location; // => { x: -77.036533, y: 38.898719, spatialReference: { wkid: 4326 } }
+ *     response.candidates[0].location; // => { x: -77.036533, y: 38.898719, spatialReference: ... }
  *   });
  * ```
  *
@@ -94,6 +100,8 @@ export function geocode(
       ...options,
       ...address
     };
+
+    appendCustomParams(address, options);
   }
 
   // add spatialReference property to individual matches

--- a/packages/arcgis-rest-geocoder/src/geocode.ts
+++ b/packages/arcgis-rest-geocoder/src/geocode.ts
@@ -22,9 +22,11 @@ export interface IGeocodeParams extends IParams {
    * import { suggest, geocode } from '@esri/arcgis-rest-geocoder';
    * suggest("LAX")
    *   .then((response) => {
-   *     response.suggestions[2].magicKey; // =>  "dHA9MCNsb2M9Mjk3ODc2MCNsbmc9MzMjcGw9ODkxNDg4I2xicz0xNDoxNDc4MTI1MA=="
-   *   });
-   * geocode("LAX, 1 World Way, Los Angeles, CA, 90045, USA", {magicKey: "dHA9MCN..."})
+   *     geocode({
+   *       singleLine: response.suggestions[1].text,
+   *       magicKey: response.suggestions[0].magicKey
+   *     })
+   *   })
    * ```
    */
   magicKey?: string;
@@ -77,7 +79,7 @@ export interface IGeocodeResponse {
  *   countryCode: "USA"
  * })
  *   .then((response) => {
- *     response.candidates[0].location; // => { x: -77.036533, y: 38.898719, spatialReference: ... }
+ *     response.candidates[1].location; // => { x: -77.036533, y: 38.898719, spatialReference: ... }
  *   });
  * ```
  *

--- a/packages/arcgis-rest-geocoder/src/suggest.ts
+++ b/packages/arcgis-rest-geocoder/src/suggest.ts
@@ -12,9 +12,11 @@ export interface ISuggestRequestOptions extends IEndpointRequestOptions {
    * import { suggest, geocode } from '@esri/arcgis-rest-geocoder';
    * suggest("LAX")
    *   .then((response) => {
-   *     response.suggestions[2].magicKey; // =>  "dHA9MCNsb2M9Mjk3ODc2MCNsbmc9MzMjcGw9ODkxNDg4I2xicz0xNDoxNDc4MTI1MA=="
-   *   });
-   * geocode("LAX, 1 World Way, Los Angeles, CA, 90045, USA", {magicKey: "dHA9MCN..."})
+   *     geocode({
+   *       singleLine: response.suggestions[1].text,
+   *       magicKey: response.suggestions[1].magicKey
+   *     })
+   *   })
    * ```
    */
   magicKey?: string;

--- a/packages/arcgis-rest-geocoder/src/suggest.ts
+++ b/packages/arcgis-rest-geocoder/src/suggest.ts
@@ -49,7 +49,7 @@ export function suggest(
 ): Promise<ISuggestResponse> {
   const options: ISuggestRequestOptions = {
     endpoint: worldGeocoder,
-    params: { text: partialText },
+    params: {},
     ...requestOptions
   };
 

--- a/packages/arcgis-rest-geocoder/src/suggest.ts
+++ b/packages/arcgis-rest-geocoder/src/suggest.ts
@@ -49,20 +49,15 @@ export function suggest(
 ): Promise<ISuggestResponse> {
   const options: ISuggestRequestOptions = {
     endpoint: worldGeocoder,
-    params: {},
+    params: { text: partialText },
     ...requestOptions
   };
 
-  // is this the most concise way to mixin these optional parameters?
-  if (requestOptions && requestOptions.params) {
-    options.params = requestOptions.params;
-  }
+  options.params.text = partialText;
 
   if (requestOptions && requestOptions.magicKey) {
     options.params.magicKey = requestOptions.magicKey;
   }
-
-  options.params.text = partialText;
 
   return request(options.endpoint + "suggest", options);
 }

--- a/packages/arcgis-rest-geocoder/test/geocode.test.ts
+++ b/packages/arcgis-rest-geocoder/test/geocode.test.ts
@@ -35,6 +35,33 @@ describe("geocode", () => {
       });
   });
 
+  it("should a geocoding request with custom parameters", done => {
+    fetchMock.once("*", FindAddressCandidates);
+
+    geocode({ address: "1600 Pennsylvania Avenue", city: "Washington D.C." })
+      .then(response => {
+        expect(fetchMock.called()).toEqual(true);
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+        );
+        expect(options.method).toBe("POST");
+        expect(options.body).toContain("f=json");
+        expect(options.body).toContain(
+          `address=${encodeURIComponent("1600 Pennsylvania Avenue")}`
+        );
+        expect(options.body).toContain(
+          `city=${encodeURIComponent("Washington D.C.")}`
+        );
+        // the only property this lib tacks on
+        expect(response.spatialReference.wkid).toEqual(4326);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
   it("should make a simple, single geocoding request with a custom parameter", done => {
     fetchMock.once("*", FindAddressCandidates);
 

--- a/packages/arcgis-rest-geocoder/test/helpers.test.ts
+++ b/packages/arcgis-rest-geocoder/test/helpers.test.ts
@@ -2,9 +2,7 @@
  * Apache-2.0 */
 
 import { serviceInfo, getGeocodeService } from "../src/helpers";
-
 import * as fetchMock from "fetch-mock";
-
 import { SharingInfo } from "./mocks/responses";
 
 const customGeocoderUrl =

--- a/packages/arcgis-rest-geocoder/test/suggest.test.ts
+++ b/packages/arcgis-rest-geocoder/test/suggest.test.ts
@@ -2,9 +2,7 @@
  * Apache-2.0 */
 
 import { suggest } from "../src/suggest";
-
 import * as fetchMock from "fetch-mock";
-
 import { Suggest } from "./mocks/responses";
 
 describe("geocode", () => {
@@ -66,6 +64,29 @@ describe("geocode", () => {
         expect(options.method).toBe("POST");
         expect(options.body).toContain("f=json");
         expect(options.body).toContain("text=LAX");
+        expect(options.body).toContain("category=Address%2CPostal");
+        expect(response).toEqual(Suggest); // this introspects the entire response
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
+  it("should make a request for suggestions with magic key and other parameters", done => {
+    fetchMock.once("*", Suggest);
+
+    suggest("LAX", { magicKey: "foo", params: { category: "Address,Postal" } })
+      .then(response => {
+        expect(fetchMock.called()).toEqual(true);
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest"
+        );
+        expect(options.method).toBe("POST");
+        expect(options.body).toContain("f=json");
+        expect(options.body).toContain("text=LAX");
+        expect(options.body).toContain("magicKey=foo");
         expect(options.body).toContain("category=Address%2CPostal");
         expect(response).toEqual(Suggest); // this introspects the entire response
         done();

--- a/packages/arcgis-rest-request/src/index.ts
+++ b/packages/arcgis-rest-request/src/index.ts
@@ -11,3 +11,4 @@ export * from "./utils/ErrorTypes";
 export * from "./utils/process-params";
 export * from "./utils/get-portal";
 export * from "./utils/get-portal-url";
+export * from "./utils/append-custom-params";

--- a/packages/arcgis-rest-request/src/utils/append-custom-params.ts
+++ b/packages/arcgis-rest-request/src/utils/append-custom-params.ts
@@ -1,0 +1,28 @@
+/* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { IRequestOptions } from "../request";
+
+/**
+ * Helper for methods with lots of first order request options to pass them through as request parameters.
+ */
+export function appendCustomParams(
+  oldOptions: IRequestOptions,
+  newOptions: IRequestOptions
+) {
+  // only pass query parameters through in the request, not generic IRequestOptions props
+  Object.keys(oldOptions).forEach(function(key: string) {
+    if (
+      key !== "url" &&
+      key !== "params" &&
+      key !== "authentication" &&
+      key !== "httpMethod" &&
+      key !== "fetch" &&
+      key !== "portal" &&
+      key !== "maxUrlLength" &&
+      key !== "endpoint"
+    ) {
+      newOptions.params[key] = (oldOptions as { [key: string]: any })[key];
+    }
+  });
+}


### PR DESCRIPTION
if you aren't just passing a string to be geocoded, currently this is how you do it:
```js
geocode({
  params: {
    address: "123 Main St."
  }
})
```
the tweaks here ensure you can do this too
```js
geocode({ address: "123 Main St." })
```
### related:
- [X] moved utility `appendCustomParams()` method that was previously in @esri/arcgis-rest-feature-service into @esri/request

### unrelated:
- [X] made a small tweak to stop the tslint precommit hook from running twice
- [X] added the 20 folks (:100:) that have already contributed to this project to the package.json

cc/ @gavinr 