### PR TITLE
chore(docs): fix suggest docs

### DIFF
--- a/packages/arcgis-rest-geocoder/src/suggest.ts
+++ b/packages/arcgis-rest-geocoder/src/suggest.ts
@@ -36,7 +36,7 @@ export interface ISuggestResponse {
  *
  * suggest("Starb")
  *   .then((response) => {
- *     response.address.PlaceName; // => "Starbucks"
+ *     response.text; // => "Starbucks"
  *   });
  * ```
  *


### PR DESCRIPTION
Hoping these are the same docs that drive the online documentation here: https://esri.github.io/arcgis-rest-js/api/geocoder/suggest/