### PR TITLE
fix(geocoder): Geocoder checks for null extent before assigning spatial ref.

### DIFF
--- a/packages/arcgis-rest-geocoder/src/geocode.ts
+++ b/packages/arcgis-rest-geocoder/src/geocode.ts
@@ -57,7 +57,8 @@ export interface IGeocodeResponse {
   candidates: Array<{
     address: string;
     location: IPoint;
-    extent: IExtent;
+    extent?: IExtent;
+    score: number;
     attributes: object;
   }>;
 }
@@ -112,10 +113,12 @@ export function geocode(
       const sr = response.spatialReference;
       response.candidates.forEach(function(candidate: {
         location: IPoint;
-        extent: IExtent;
+        extent?: IExtent;
       }) {
         candidate.location.spatialReference = sr;
-        candidate.extent.spatialReference = sr;
+        if (candidate.extent) {
+          candidate.extent.spatialReference = sr;
+        }
       });
       return response;
     }

--- a/packages/arcgis-rest-geocoder/test/geocode.test.ts
+++ b/packages/arcgis-rest-geocoder/test/geocode.test.ts
@@ -5,7 +5,7 @@ import { geocode } from "../src/geocode";
 
 import * as fetchMock from "fetch-mock";
 
-import { FindAddressCandidates } from "./mocks/responses";
+import { FindAddressCandidates, FindAddressCandidatesNullExtent } from "./mocks/responses";
 
 const customGeocoderUrl =
   "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/";
@@ -139,6 +139,29 @@ describe("geocode", () => {
         expect(options.method).toBe("GET");
         // the only property this lib tacks on
         expect(response.spatialReference.wkid).toEqual(4326);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
+  it("should handle geocoders that return null extents for location candidates", done => {
+    fetchMock.once("*", FindAddressCandidatesNullExtent);
+
+    geocode("LAX")
+      .then(response => {
+        expect(fetchMock.called()).toEqual(true);
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+        );
+        expect(options.method).toBe("POST");
+        expect(options.body).toContain("f=json");
+        expect(options.body).toContain("singleLine=LAX");
+        // the only property this lib tacks on
+        expect(response.spatialReference.wkid).toEqual(4326);
+        expect(response.candidates.every( candidate => candidate.extent == null ));
         done();
       })
       .catch(e => {

--- a/packages/arcgis-rest-geocoder/test/mocks/responses.ts
+++ b/packages/arcgis-rest-geocoder/test/mocks/responses.ts
@@ -3,7 +3,7 @@
 
 import { IGeocodeResponse } from "../../src/geocode";
 
-export const FindAddressCandidates : IGeocodeResponse = {
+export const FindAddressCandidates: IGeocodeResponse = {
   spatialReference: {
     wkid: 4326,
     latestWkid: 4326
@@ -57,7 +57,7 @@ export const FindAddressCandidates : IGeocodeResponse = {
   ]
 };
 
-export const FindAddressCandidatesNullExtent : IGeocodeResponse = {
+export const FindAddressCandidatesNullExtent: IGeocodeResponse = {
   spatialReference: {
     wkid: 4326,
     latestWkid: 4326
@@ -70,8 +70,7 @@ export const FindAddressCandidatesNullExtent : IGeocodeResponse = {
         y: 33.942510000000027
       },
       score: 100,
-      attributes: {},
-      extent: null
+      attributes: {}
     },
     {
       address: "LAX",
@@ -80,8 +79,7 @@ export const FindAddressCandidatesNullExtent : IGeocodeResponse = {
         y: 33.945610000000045
       },
       score: 100,
-      attributes: {},
-      extent: null
+      attributes: {}
     },
     {
       address: "Lax, Georgia",
@@ -90,8 +88,7 @@ export const FindAddressCandidatesNullExtent : IGeocodeResponse = {
         y: 31.473250000000064
       },
       score: 100,
-      attributes: {},
-      extent: null
+      attributes: {}
     }
   ]
 };

--- a/packages/arcgis-rest-geocoder/test/mocks/responses.ts
+++ b/packages/arcgis-rest-geocoder/test/mocks/responses.ts
@@ -1,7 +1,9 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-export const FindAddressCandidates = {
+import { IGeocodeResponse } from "../../src/geocode";
+
+export const FindAddressCandidates : IGeocodeResponse = {
   spatialReference: {
     wkid: 4326,
     latestWkid: 4326
@@ -51,6 +53,45 @@ export const FindAddressCandidates = {
         xmax: -83.101539999999986,
         ymax: 31.493250000000064
       }
+    }
+  ]
+};
+
+export const FindAddressCandidatesNullExtent : IGeocodeResponse = {
+  spatialReference: {
+    wkid: 4326,
+    latestWkid: 4326
+  },
+  candidates: [
+    {
+      address: "LAX",
+      location: {
+        x: -118.40896999999995,
+        y: 33.942510000000027
+      },
+      score: 100,
+      attributes: {},
+      extent: null
+    },
+    {
+      address: "LAX",
+      location: {
+        x: -118.39223999999996,
+        y: 33.945610000000045
+      },
+      score: 100,
+      attributes: {},
+      extent: null
+    },
+    {
+      address: "Lax, Georgia",
+      location: {
+        x: -83.121539999999982,
+        y: 31.473250000000064
+      },
+      score: 100,
+      attributes: {},
+      extent: null
     }
   ]
 };


### PR DESCRIPTION
Implemented a truthy check for an address candidate extent prior to assigning a spatial reference to
the extent object. Also updated tests to account for this change, as well as updated typescrypt
interfaces to work  with the candidate data.

AFFECTS PACKAGES:
@esri/arcgis-rest-geocoder

ISSUES CLOSED: #376