### PR TITLE
chore: include raw /src in common-types npm package

### DIFF
--- a/packages/arcgis-rest-common-types/package.json
+++ b/packages/arcgis-rest-common-types/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "license": "Apache-2.0",
   "files": [
-    "dist/types/*.d.ts"
+    "dist/types/*.d.ts",
+    "src/**/*.ts"
   ],
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION
to help downstream karma-typescript users sidestep errors when the bundler doesn't find any JavaScript.

ref: https://github.com/ArcGIS/arcgis-clone-js/pull/8

personally i don't see a downside to doing this for **every** package.

AFFECTS PACKAGES:
@esri/arcgis-rest-common-types