### PR TITLE
fix: ensure decodeValues() isnt derailled by attributes not present in metadata

### DIFF
--- a/packages/arcgis-rest-feature-service/src/decodeValues.ts
+++ b/packages/arcgis-rest-feature-service/src/decodeValues.ts
@@ -92,10 +92,14 @@ export function decodeValues(
       for (const key in feature.attributes) {
         /* istanbul ignore next */
         if (!feature.attributes.hasOwnProperty(key)) continue;
-        feature.attributes[key] = convertAttribute(
-          feature.attributes,
-          fieldsObject[key]
-        );
+
+        // trap for summary statistics fields or anything else not present in the raw dataset
+        if (fieldsObject[key]) {
+          feature.attributes[key] = convertAttribute(
+            feature.attributes,
+            fieldsObject[key]
+          );
+        }
       }
     });
     return clonedResponse;

--- a/packages/arcgis-rest-feature-service/test/mocks/cvdQueryResponse.ts
+++ b/packages/arcgis-rest-feature-service/test/mocks/cvdQueryResponse.ts
@@ -83,6 +83,12 @@ export const cvdQueryResponse: IQueryFeaturesResponse = {
       alias: "Floor Number",
       type: "esriFieldTypeString",
       length: 5
+    },
+    {
+      name: "floor_SUM",
+      alias: "Floor Number Summary (not in raw dataset, only from stat query",
+      type: "esriFieldTypeString",
+      length: 10
     }
   ],
   features: [
@@ -99,7 +105,8 @@ export const cvdQueryResponse: IQueryFeaturesResponse = {
         status: "Closed",
         globalid: "{2F47ACF0-CEE3-4548-90A8-785ED7BE01C9}",
         building: null,
-        floor: null
+        floor: null,
+        floor_SUM: "something"
       },
       geometry: {
         x: -9603128.0234949309,
@@ -119,7 +126,8 @@ export const cvdQueryResponse: IQueryFeaturesResponse = {
         status: "Closed",
         globalid: "{9937CFDD-E811-49D1-8CC8-A1ABF0DE7F14}",
         building: null,
-        floor: null
+        floor: null,
+        floor_SUM: "something"
       },
       geometry: {
         x: -9603103.0477722641,
@@ -139,7 +147,8 @@ export const cvdQueryResponse: IQueryFeaturesResponse = {
         status: "Unassigned",
         globalid: "{D840094C-F94D-42EA-AB21-7A84B2E27962}",
         building: null,
-        floor: "0"
+        floor: "0",
+        floor_SUM: "something"
       },
       geometry: {
         x: -9814396.0827533137,
@@ -163,7 +172,8 @@ export const cvdFeaturesFormatted: IFeature[] = [
       status: "Closed",
       globalid: "{2F47ACF0-CEE3-4548-90A8-785ED7BE01C9}",
       building: null,
-      floor: null
+      floor: null,
+      floor_SUM: "something"
     },
     geometry: {
       x: -9603128.0234949309,
@@ -183,7 +193,8 @@ export const cvdFeaturesFormatted: IFeature[] = [
       status: "Closed",
       globalid: "{9937CFDD-E811-49D1-8CC8-A1ABF0DE7F14}",
       building: null,
-      floor: null
+      floor: null,
+      floor_SUM: "something"
     },
     geometry: {
       x: -9603103.0477722641,
@@ -203,7 +214,8 @@ export const cvdFeaturesFormatted: IFeature[] = [
       status: "Unassigned",
       globalid: "{D840094C-F94D-42EA-AB21-7A84B2E27962}",
       building: null,
-      floor: "0"
+      floor: "0",
+      floor_SUM: "something"
     },
     geometry: {
       x: -9814396.0827533137,

--- a/packages/arcgis-rest-feature-service/test/mocks/fields.ts
+++ b/packages/arcgis-rest-feature-service/test/mocks/fields.ts
@@ -51,15 +51,6 @@ export const serviceFields: IField[] = [
     length: 100
   },
   {
-    name: "comments",
-    type: "esriFieldTypeString",
-    alias: "Comments",
-    domain: null,
-    editable: true,
-    nullable: true,
-    length: 255
-  },
-  {
     name: "name",
     type: "esriFieldTypeString",
     alias: "Name",


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-feature-service