### PR TITLE
fix(:bug:): use same referer consistently in Node.js applications

### DIFF
--- a/packages/arcgis-rest-auth/src/generate-token.ts
+++ b/packages/arcgis-rest-auth/src/generate-token.ts
@@ -32,7 +32,7 @@ export function generateToken(
   ) {
     options.params.referer = window.location.host;
   } else {
-    options.params.referer = "@esri.arcgis-rest";
+    options.params.referer = "@esri/arcgis-rest";
   }
 
   return request(url, options);


### PR DESCRIPTION
somehow in #389 i missed that we use `@esri/` for referers in request and `@esri.` in auth. 🤦‍♂️ 	

https://github.com/Esri/arcgis-rest-js/blob/fdae3b64b1f31847489c51d6edeafe150591cc4c/packages/arcgis-rest-request/src/request.ts#L199

https://github.com/Esri/arcgis-rest-js/blob/fdae3b64b1f31847489c51d6edeafe150591cc4c/packages/arcgis-rest-auth/src/generate-token.ts#L35

🎩tip to haoliangyu for the find.

AFFECTS PACKAGES:
@esri/arcgis-rest-auth