### PR TITLE
chore: standardize portal urls passed to auth and routing

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -7,7 +7,8 @@ import {
   IRequestOptions,
   ArcGISAuthError,
   IAuthenticationManager,
-  ITokenRequestOptions
+  ITokenRequestOptions,
+  cleanUrl
 } from "@esri/arcgis-rest-request";
 import { generateToken } from "./generate-token";
 import { fetchToken, IFetchTokenResponse } from "./fetch-token";
@@ -315,7 +316,9 @@ export class UserSession implements IAuthenticationManager {
     this.password = options.password;
     this._token = options.token;
     this._tokenExpires = options.tokenExpires;
-    this.portal = options.portal || "https://www.arcgis.com/sharing/rest";
+    this.portal = options.portal
+      ? cleanUrl(options.portal)
+      : "https://www.arcgis.com/sharing/rest";
     this.ssl = options.ssl;
     this.provider = options.provider || "arcgis";
     this.tokenDuration = options.tokenDuration || 20160;

--- a/packages/arcgis-rest-feature-service-admin/src/addTo.ts
+++ b/packages/arcgis-rest-feature-service-admin/src/addTo.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request } from "@esri/arcgis-rest-request";
+import { request, cleanUrl } from "@esri/arcgis-rest-request";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 import {
   ILayer,
@@ -55,7 +55,8 @@ export function addToServiceDefinition(
   requestOptions: IAddToServiceDefinitionRequestOptions
 ): Promise<IAddToServiceDefinitionResult> {
   const adminUrl =
-    url.replace("/rest/services", "/rest/admin/services") + "/addToDefinition";
+    cleanUrl(url).replace("/rest/services", "/rest/admin/services") +
+    "/addToDefinition";
 
   requestOptions.params = {
     addToDefinition: {},

--- a/packages/arcgis-rest-request/src/utils/get-portal-url.ts
+++ b/packages/arcgis-rest-request/src/utils/get-portal-url.ts
@@ -17,7 +17,8 @@ export function getPortalUrl(requestOptions: IRequestOptions = {}): string {
 
   // if auth was passed, use that portal
   if (requestOptions.authentication) {
-    return cleanUrl(requestOptions.authentication.portal);
+    // the portal url is already scrubbed in the auth package
+    return requestOptions.authentication.portal;
   }
 
   // default to arcgis.com

--- a/packages/arcgis-rest-routing/src/helpers.ts
+++ b/packages/arcgis-rest-routing/src/helpers.ts
@@ -5,7 +5,7 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 
 // https always
 export const worldRoutingService =
-  "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/";
+  "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World";
 
 // nice to have: verify custom endpoints contain 'NAServer' and end in a '/'
 export interface IEndpointRequestOptions extends IRequestOptions {

--- a/packages/arcgis-rest-routing/src/solveRoute.ts
+++ b/packages/arcgis-rest-routing/src/solveRoute.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request } from "@esri/arcgis-rest-request";
+import { request, cleanUrl } from "@esri/arcgis-rest-request";
 
 import {
   ILocation,
@@ -94,7 +94,7 @@ export function solveRoute(
   });
   options.params.stops = stops.join(";");
 
-  return request(options.endpoint + "solve", options);
+  return request(`${cleanUrl(options.endpoint)}/solve`, options);
 }
 
 export default {


### PR DESCRIPTION
i _think_ this is the last of them.

AFFECTS PACKAGES:
@esri/arcgis-rest-auth
@esri/arcgis-rest-feature-service-admin
@esri/arcgis-rest-request
@esri/arcgis-rest-routing