### PR TITLE
fix(arcgis-rest-auth): Allow mixed casing of federated server urls

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -708,7 +708,7 @@ export class UserSession implements IAuthenticationManager {
     requestOptions?: ITokenRequestOptions
   ) {
     // requests to /rest/services/ and /rest/admin/services/ are both valid
-    // Federated servers may have inconsisten casing, so loweCase it
+    // Federated servers may have inconsistent casing, so lowerCase it
     const [root] = url.toLowerCase().split(/\/rest(\/admin)?\/services\//);
     const existingToken = this.trustedServers[root];
 

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -656,7 +656,7 @@ export class UserSession implements IAuthenticationManager {
       /^https?:\/\/\S+\.arcgis\.com.+/.test(url)
     ) {
       return this.getFreshToken(requestOptions);
-    } else if (new RegExp(this.portal).test(url)) {
+    } else if (new RegExp(this.portal, "i").test(url)) {
       return this.getFreshToken(requestOptions);
     } else {
       return this.getTokenForServer(url, requestOptions);
@@ -708,7 +708,8 @@ export class UserSession implements IAuthenticationManager {
     requestOptions?: ITokenRequestOptions
   ) {
     // requests to /rest/services/ and /rest/admin/services/ are both valid
-    const [root] = url.split(/\/rest(\/admin)?\/services\//);
+    // Federated servers may have inconsisten casing, so loweCase it
+    const [root] = url.toLowerCase().split(/\/rest(\/admin)?\/services\//);
     const existingToken = this.trustedServers[root];
 
     if (existingToken && existingToken.expires.getTime() > Date.now()) {
@@ -732,7 +733,7 @@ export class UserSession implements IAuthenticationManager {
          */
         if (
           !owningSystemUrl ||
-          !new RegExp(owningSystemUrl).test(this.portal)
+          !new RegExp(owningSystemUrl, "i").test(this.portal)
         ) {
           throw new ArcGISAuthError(
             `${url} is not federated with ${this.portal}.`,

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -129,7 +129,7 @@ describe("UserSession", () => {
         });
     });
 
-    it("should use fetch token when contacting a server that is federated, even if on same domain, regardless of domain casing", done => {
+    it("should fetch token when contacting a server that is federated, even if on same domain, regardless of domain casing", done => {
       // This was a real configuration discovered on a portal instance
       // apparently when federating servers, the UI does not force the
       // server url to lowercase, and this any feature service items generated


### PR DESCRIPTION
When federated servers are configured, the UI does not enforce lower casing of the federated server
name. This can result in hosted services with UPPERCASE urls. This PR ensures that the user session
works with lower-cased urls, and that regardless of casing of inbound requests, the federated token
cache works correctly.

AFFECTS PACKAGES:
@esri/arcgis-rest-auth