### PR TITLE
Reexported IParams and joined fetch common types

### DIFF
--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -8,6 +8,8 @@ import { ArcGISRequestError } from "./utils/ArcGISRequestError";
 import { IRetryAuthError } from "./utils/retryAuthError";
 import { HTTPMethods, IParams, ITokenRequestOptions } from "./utils/params";
 
+export { IParams } from "./utils/params";
+
 /**
  * Authentication can be supplied to `request` via [`UserSession`](../../auth/UserSession/) or [`ApplicationSession`](../../auth/ApplicationSession/). Both classes extend `IAuthenticationManager`.
  * ```js
@@ -215,14 +217,7 @@ export function request(
         case "text":
           return response.text();
         /* istanbul ignore next blob responses are difficult to make cross platform we will just have to trust that isomorphic fetch will do its job */
-        case "image":
-          return response.blob();
-        /* istanbul ignore next */
-        case "zip":
-          return response.blob();
-        /* istanbul ignore next */
         default:
-          // hopefully we never need to handle JSON payloads when no f= parameter is set
           return response.blob();
       }
     })

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -8,8 +8,6 @@ import { ArcGISRequestError } from "./utils/ArcGISRequestError";
 import { IRetryAuthError } from "./utils/retryAuthError";
 import { HTTPMethods, IParams, ITokenRequestOptions } from "./utils/params";
 
-export { IParams } from "./utils/params";
-
 /**
  * Authentication can be supplied to `request` via [`UserSession`](../../auth/UserSession/) or [`ApplicationSession`](../../auth/ApplicationSession/). Both classes extend `IAuthenticationManager`.
  * ```js


### PR DESCRIPTION
1. Re-exported `IParams` to solve transpiler complaint from packages/arcgis-rest-request/dist/esm/utils/check-for-errors.d.ts that `IParams` was not available from request.ts

2. Combined response cases in function `request` because 1) they are handled identically, and 2) the "zip" variant doesn't work with arcgis.com (one gets a `status: 400  Format not allowed for this Item Type` error), so it seemed misleading to include it in the `switch` statement.