### PR TITLE
bulkGeocode: Add check for undefined location property

### DIFF
--- a/packages/arcgis-rest-geocoder/src/bulk.ts
+++ b/packages/arcgis-rest-geocoder/src/bulk.ts
@@ -91,7 +91,9 @@ export function bulkGeocode(
   ).then(response => {
     const sr = response.spatialReference;
     response.locations.forEach(function(address: { location: IPoint }) {
-      address.location.spatialReference = sr;
+      if (address.location) {
+        address.location.spatialReference = sr;
+      }
     });
     return response;
   });


### PR DESCRIPTION
When using `bulkGeocode` in _arcgis-rest-geocoder_ If geocoding returns 0 candidates for a given address, the value returned for that address is:
```
{
  "address": "",
  "score": 0,
  "attributes": { . . . }
}
```

Due to the code assuming the `location` property is present, this results in:
`TypeError: Cannot set property 'spatialReference' of undefined`
in the following line of code:
`address.location.spatialReference = sr;`

A quick way to reproduce this is to try a bulkGeocode that includes a nonsense singleLine like `sldafjsedoifhsoaifhsdoifh`. 