### PR TITLE
chore: bump to tslint-config-standard and resolve new lint errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14543,30 +14543,39 @@
       "dev": true
     },
     "tslint-config-standard": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tslint-config-standard/-/tslint-config-standard-6.0.1.tgz",
-      "integrity": "sha1-oEugp5R1nodyhwVvVJsIHkelbWw=",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/tslint-config-standard/-/tslint-config-standard-8.0.1.tgz",
+      "integrity": "sha512-OWG+NblgjQlVuUS/Dmq3ax2v5QDZwRx4L0kEuDi7qFY9UI6RJhhNfoCV1qI4el8Fw1c5a5BTrjQJP0/jhGXY/Q==",
       "dev": true,
       "requires": {
-        "tslint-eslint-rules": "^4.0.0"
+        "tslint-eslint-rules": "^5.3.1"
       }
     },
     "tslint-eslint-rules": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-4.1.1.tgz",
-      "integrity": "sha1-fDDniC8mvCdr/5HSOEl1xp2viLo=",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz",
+      "integrity": "sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==",
       "dev": true,
       "requires": {
-        "doctrine": "^0.7.2",
-        "tslib": "^1.0.0",
-        "tsutils": "^1.4.0"
+        "doctrine": "0.7.2",
+        "tslib": "1.9.0",
+        "tsutils": "^3.0.0"
       },
       "dependencies": {
-        "tsutils": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
-          "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
           "dev": true
+        },
+        "tsutils": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.7.0.tgz",
+          "integrity": "sha512-n+e+3q7Jx2kfZw7tjfI9axEIWBY0sFMOlC+1K70X0SeXpO/UYSB+PN+E9tIJNqViB7oiXQdqD7dNchnvoneZew==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ts-node": "^3.3.0",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.6.0",
-    "tslint-config-standard": "^6.0.1",
+    "tslint-config-standard": "^8.0.1",
     "typedoc": "^0.12.0",
     "typescript": "^3.0.0"
   },
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "build": "lerna run build",
-    "test": "npm run test:node && npm run test:chrome",
+    "test": "npm run lint && npm run test:node && npm run test:chrome",
     "test:chrome:debug": "karma start --auto-watch --no-single-run --browsers=Chrome",
     "test:chrome": "karma start --single-run --browsers=Chrome",
     "test:chrome:ci": "karma start --single-run --browsers ChromeHeadlessCI karma.conf.js",

--- a/packages/arcgis-rest-auth/src/ApplicationSession.ts
+++ b/packages/arcgis-rest-auth/src/ApplicationSession.ts
@@ -31,7 +31,7 @@ export interface IApplicationSessionOptions {
    * Expiration date for the `token`
    */
   expires?: Date;
-  
+
   /**
    * URL of ArcGIS REST base, defaults to "https://www.arcgis.com/sharing/rest"
    */
@@ -39,7 +39,7 @@ export interface IApplicationSessionOptions {
 
   /**
    * Duration of requested tokens in minutes. defaults to 7200 (5 days).
-  */
+   */
   duration?: number;
 }
 
@@ -79,7 +79,7 @@ export class ApplicationSession implements IAuthenticationManager {
   }
 
   // url isnt actually read or passed through.
-  getToken(
+  public getToken(
     url: string,
     requestOptions?: ITokenRequestOptions
   ): Promise<string> {
@@ -96,7 +96,7 @@ export class ApplicationSession implements IAuthenticationManager {
     return this._pendingTokenRequest;
   }
 
-  refreshToken(requestOptions?: ITokenRequestOptions): Promise<string> {
+  public refreshToken(requestOptions?: ITokenRequestOptions): Promise<string> {
     const options = {
       params: {
         client_id: this.clientId,
@@ -116,7 +116,7 @@ export class ApplicationSession implements IAuthenticationManager {
     );
   }
 
-  refreshSession() {
+  public refreshSession() {
     return this.refreshToken().then(() => this);
   }
 }

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -206,129 +206,6 @@ export interface IUserSessionOptions {
  */
 export class UserSession implements IAuthenticationManager {
   /**
-   * Client ID being used for authentication if provided in the `constructor`.
-   */
-  readonly clientId: string;
-
-  /**
-   * The currently authenticated user if provided in the `constructor`.
-   */
-  readonly username: string;
-
-  /**
-   * The currently authenticated user's password if provided in the `constructor`.
-   */
-  readonly password: string;
-
-  /**
-   * The current portal the user is authenticated with.
-   */
-  readonly portal: string;
-
-  /**
-   * This value is set to true automatically if the ArcGIS Organization requires that requests be made over https.
-   */
-  readonly ssl: boolean;
-
-  /**
-   * The authentication provider to use.
-   */
-  readonly provider: AuthenticationProvider;
-
-  /**
-   * Determines how long new tokens requested are valid.
-   */
-  readonly tokenDuration: number;
-
-  /**
-   * A valid redirect URI for this application if provided in the `constructor`.
-   */
-  readonly redirectUri: string;
-
-  /**
-   * Duration of new OAuth 2.0 refresh token validity.
-   */
-  readonly refreshTokenTTL: number;
-
-  /**
-   * Hydrated by a call to [getUser()](#getUser-summary).
-   */
-  _user: IUser;
-
-  private _token: string;
-  private _tokenExpires: Date;
-  private _refreshToken: string;
-  private _refreshTokenExpires: Date;
-
-  /**
-   * Internal object to keep track of pending token requests. Used to prevent
-   *  duplicate token requests.
-   */
-  private _pendingTokenRequests: {
-    [key: string]: Promise<string>;
-  };
-
-  /**
-   * Internal list of trusted 3rd party servers (federated servers) that have
-   *  been validated with `generateToken`.
-   */
-  private trustedServers: {
-    [key: string]: {
-      token: string;
-      expires: Date;
-    };
-  };
-
-  /**
-   * The current ArcGIS Online or ArcGIS Enterprise `token`.
-   */
-  get token() {
-    return this._token;
-  }
-
-  /**
-   * The expiration time of the current `token`.
-   */
-  get tokenExpires() {
-    return this._tokenExpires;
-  }
-
-  /**
-   * The current token to ArcGIS Online or ArcGIS Enterprise.
-   */
-  get refreshToken() {
-    return this._refreshToken;
-  }
-
-  /**
-   * The expiration time of the current `refreshToken`.
-   */
-  get refreshTokenExpires() {
-    return this._refreshTokenExpires;
-  }
-
-  constructor(options: IUserSessionOptions) {
-    this.clientId = options.clientId;
-    this._refreshToken = options.refreshToken;
-    this._refreshTokenExpires = options.refreshTokenExpires;
-    this.username = options.username;
-    this.password = options.password;
-    this._token = options.token;
-    this._tokenExpires = options.tokenExpires;
-    this.portal = options.portal
-      ? cleanUrl(options.portal)
-      : "https://www.arcgis.com/sharing/rest";
-    this.ssl = options.ssl;
-    this.provider = options.provider || "arcgis";
-    this.tokenDuration = options.tokenDuration || 20160;
-    this.redirectUri = options.redirectUri;
-    this.refreshTokenTTL = options.refreshTokenTTL || 1440;
-
-    this.trustedServers = {};
-    this._pendingTokenRequests = {};
-  }
-
-  /**
    * Begins a new browser-based OAuth 2.0 sign in. If `options.popup` is true the
    * authentication window will open in a new tab/window otherwise the user will
    * be redirected to the authorization page in their current tab.
@@ -336,7 +213,7 @@ export class UserSession implements IAuthenticationManager {
    * @browserOnly
    */
   /* istanbul ignore next */
-  static beginOAuth2(options: IOauth2Options, win: any = window) {
+  public static beginOAuth2(options: IOauth2Options, win: any = window) {
     const {
       portal,
       provider,
@@ -417,7 +294,7 @@ export class UserSession implements IAuthenticationManager {
    * @browserOnly
    */
   /* istanbul ignore next */
-  static completeOAuth2(options: IOauth2Options, win: any = window) {
+  public static completeOAuth2(options: IOauth2Options, win: any = window) {
     const { portal, clientId }: IOauth2Options = {
       ...{ portal: "https://www.arcgis.com/sharing/rest" },
       ...options
@@ -494,7 +371,10 @@ export class UserSession implements IAuthenticationManager {
    *
    * @nodeOnly
    */
-  static authorize(options: IOauth2Options, response: http.ServerResponse) {
+  public static authorize(
+    options: IOauth2Options,
+    response: http.ServerResponse
+  ) {
     const { portal, clientId, duration, redirectUri }: IOauth2Options = {
       ...{ portal: "https://arcgis.com/sharing/rest", duration: 20160 },
       ...options
@@ -515,7 +395,7 @@ export class UserSession implements IAuthenticationManager {
    *
    * @nodeOnly
    */
-  static exchangeAuthorizationCode(
+  public static exchangeAuthorizationCode(
     options: IOauth2Options,
     authorizationCode: string
   ): Promise<UserSession> {
@@ -550,7 +430,7 @@ export class UserSession implements IAuthenticationManager {
     });
   }
 
-  static deserialize(str: string) {
+  public static deserialize(str: string) {
     const options = JSON.parse(str);
     return new UserSession({
       clientId: options.clientId,
@@ -580,7 +460,7 @@ export class UserSession implements IAuthenticationManager {
    *
    * @returns UserSession
    */
-  static fromCredential(credential: ICredential) {
+  public static fromCredential(credential: ICredential) {
     return new UserSession({
       portal: credential.server.includes("sharing/rest")
         ? credential.server
@@ -593,6 +473,129 @@ export class UserSession implements IAuthenticationManager {
   }
 
   /**
+   * Client ID being used for authentication if provided in the `constructor`.
+   */
+  public readonly clientId: string;
+
+  /**
+   * The currently authenticated user if provided in the `constructor`.
+   */
+  public readonly username: string;
+
+  /**
+   * The currently authenticated user's password if provided in the `constructor`.
+   */
+  public readonly password: string;
+
+  /**
+   * The current portal the user is authenticated with.
+   */
+  public readonly portal: string;
+
+  /**
+   * This value is set to true automatically if the ArcGIS Organization requires that requests be made over https.
+   */
+  public readonly ssl: boolean;
+
+  /**
+   * The authentication provider to use.
+   */
+  public readonly provider: AuthenticationProvider;
+
+  /**
+   * Determines how long new tokens requested are valid.
+   */
+  public readonly tokenDuration: number;
+
+  /**
+   * A valid redirect URI for this application if provided in the `constructor`.
+   */
+  public readonly redirectUri: string;
+
+  /**
+   * Duration of new OAuth 2.0 refresh token validity.
+   */
+  public readonly refreshTokenTTL: number;
+
+  /**
+   * Hydrated by a call to [getUser()](#getUser-summary).
+   */
+  private _user: IUser;
+
+  private _token: string;
+  private _tokenExpires: Date;
+  private _refreshToken: string;
+  private _refreshTokenExpires: Date;
+
+  /**
+   * Internal object to keep track of pending token requests. Used to prevent
+   *  duplicate token requests.
+   */
+  private _pendingTokenRequests: {
+    [key: string]: Promise<string>;
+  };
+
+  /**
+   * Internal list of trusted 3rd party servers (federated servers) that have
+   *  been validated with `generateToken`.
+   */
+  private trustedServers: {
+    [key: string]: {
+      token: string;
+      expires: Date;
+    };
+  };
+
+  /**
+   * The current ArcGIS Online or ArcGIS Enterprise `token`.
+   */
+  get token() {
+    return this._token;
+  }
+
+  /**
+   * The expiration time of the current `token`.
+   */
+  get tokenExpires() {
+    return this._tokenExpires;
+  }
+
+  /**
+   * The current token to ArcGIS Online or ArcGIS Enterprise.
+   */
+  get refreshToken() {
+    return this._refreshToken;
+  }
+
+  /**
+   * The expiration time of the current `refreshToken`.
+   */
+  get refreshTokenExpires() {
+    return this._refreshTokenExpires;
+  }
+
+  constructor(options: IUserSessionOptions) {
+    this.clientId = options.clientId;
+    this._refreshToken = options.refreshToken;
+    this._refreshTokenExpires = options.refreshTokenExpires;
+    this.username = options.username;
+    this.password = options.password;
+    this._token = options.token;
+    this._tokenExpires = options.tokenExpires;
+    this.portal = options.portal
+      ? cleanUrl(options.portal)
+      : "https://www.arcgis.com/sharing/rest";
+    this.ssl = options.ssl;
+    this.provider = options.provider || "arcgis";
+    this.tokenDuration = options.tokenDuration || 20160;
+    this.redirectUri = options.redirectUri;
+    this.refreshTokenTTL = options.refreshTokenTTL || 1440;
+
+    this.trustedServers = {};
+    this._pendingTokenRequests = {};
+  }
+
+  /**
    * Returns authentication in a format useable in the [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/).
    *
    * ```js
@@ -601,7 +604,7 @@ export class UserSession implements IAuthenticationManager {
    *
    * @returns ICredential
    */
-  toCredential(): ICredential {
+  public toCredential(): ICredential {
     return {
       expires: this.tokenExpires.getTime(),
       server: this.portal,
@@ -623,7 +626,7 @@ export class UserSession implements IAuthenticationManager {
    *
    * @returns A Promise that will resolve with the data from the response.
    */
-  getUser(requestOptions?: IRequestOptions): Promise<IUser> {
+  public getUser(requestOptions?: IRequestOptions): Promise<IUser> {
     if (this._user && this._user.username === this.username) {
       return Promise.resolve(this._user);
     } else {
@@ -650,7 +653,7 @@ export class UserSession implements IAuthenticationManager {
    * the request is to an unknown server we will validate the server with a request
    * to our current `portal`.
    */
-  getToken(url: string, requestOptions?: ITokenRequestOptions) {
+  public getToken(url: string, requestOptions?: ITokenRequestOptions) {
     if (
       /^https?:\/\/\S+\.arcgis\.com\/sharing\/rest/.test(this.portal) &&
       /^https?:\/\/\S+\.arcgis\.com.+/.test(url)
@@ -663,7 +666,7 @@ export class UserSession implements IAuthenticationManager {
     }
   }
 
-  toJSON(): IUserSessionOptions {
+  public toJSON(): IUserSessionOptions {
     return {
       clientId: this.clientId,
       refreshToken: this.refreshToken,
@@ -680,14 +683,16 @@ export class UserSession implements IAuthenticationManager {
     };
   }
 
-  serialize() {
+  public serialize() {
     return JSON.stringify(this);
   }
 
   /**
    * Manually refreshes the current `token` and `tokenExpires`.
    */
-  refreshSession(requestOptions?: ITokenRequestOptions): Promise<UserSession> {
+  public refreshSession(
+    requestOptions?: ITokenRequestOptions
+  ): Promise<UserSession> {
     if (this.username && this.password) {
       return this.refreshWithUsernameAndPassword(requestOptions);
     }

--- a/packages/arcgis-rest-feature-service-admin/src/create.ts
+++ b/packages/arcgis-rest-feature-service-admin/src/create.ts
@@ -183,23 +183,27 @@ export function createFeatureService(
     // If the service is destined for a subfolder, catch the results of the request and then move
     // the item to the desired folder
     return new Promise((resolve, reject) => {
-      request(url, requestOptions).then(createResults => {
-        if (createResults.success) {
-          moveItem({
-            itemId: createResults.itemId,
-            folderId: requestOptions.folderId,
-            authentication: requestOptions.authentication
-          }).then(moveResults => {
-            if (moveResults.success) {
-              resolve(createResults);
-            } else {
-              reject({ success: false });
-            }
-          });
-        } else {
-          reject({ success: false });
-        }
-      });
+      request(url, requestOptions)
+        .then(createResults => {
+          if (createResults.success) {
+            moveItem({
+              itemId: createResults.itemId,
+              folderId: requestOptions.folderId,
+              authentication: requestOptions.authentication
+            })
+              .then(moveResults => {
+                if (moveResults.success) {
+                  resolve(createResults);
+                } else {
+                  reject({ success: false });
+                }
+              })
+              .catch();
+          } else {
+            reject({ success: false });
+          }
+        })
+        .catch();
     });
   }
 }

--- a/packages/arcgis-rest-geocoder/test/bulk.test.ts
+++ b/packages/arcgis-rest-geocoder/test/bulk.test.ts
@@ -15,13 +15,17 @@ const addresses = [
   {
     OBJECTID: 2,
     SingleLine: "1 World Way Los Angeles 90045"
+  },
+  {
+    OBJECTID: 3,
+    SingleLine: "foo bar baz"
   }
 ];
 
 describe("geocode", () => {
   afterEach(fetchMock.restore);
 
-  it("should make a bulk geocoding request", done => {
+  it("should make a bulk geocoding request, even with an unmatchable record", done => {
     fetchMock.once("*", GeocodeAddresses);
 
     const MOCK_AUTH = {
@@ -42,7 +46,7 @@ describe("geocode", () => {
         expect(options.body).toContain("f=json");
         expect(options.body).toContain(
           `addresses=${encodeURIComponent(
-            '{"records":[{"attributes":{"OBJECTID":1,"SingleLine":"380 New York St. Redlands 92373"}},{"attributes":{"OBJECTID":2,"SingleLine":"1 World Way Los Angeles 90045"}}]}'
+            '{"records":[{"attributes":{"OBJECTID":1,"SingleLine":"380 New York St. Redlands 92373"}},{"attributes":{"OBJECTID":2,"SingleLine":"1 World Way Los Angeles 90045"}},{"attributes":{"OBJECTID":3,"SingleLine":"foo bar baz"}}]}'
           )}`
         );
         expect(options.body).toContain("token=token");
@@ -55,6 +59,7 @@ describe("geocode", () => {
         expect(response.locations[0].location.spatialReference.wkid).toEqual(
           4326
         );
+        expect(response.locations[2].score).toEqual(0);
         done();
       })
       .catch(e => {
@@ -94,7 +99,7 @@ describe("geocode", () => {
         expect(options.body).toContain("f=json");
         expect(options.body).toContain(
           `addresses=${encodeURIComponent(
-            '{"records":[{"attributes":{"OBJECTID":1,"SingleLine":"380 New York St. Redlands 92373"}},{"attributes":{"OBJECTID":2,"SingleLine":"1 World Way Los Angeles 90045"}}]}'
+            '{"records":[{"attributes":{"OBJECTID":1,"SingleLine":"380 New York St. Redlands 92373"}},{"attributes":{"OBJECTID":2,"SingleLine":"1 World Way Los Angeles 90045"}},{"attributes":{"OBJECTID":3,"SingleLine":"foo bar baz"}}]}'
           )}`
         );
         // expect(options.body).toContain("token=token");
@@ -107,6 +112,7 @@ describe("geocode", () => {
         expect(response.locations[0].location.spatialReference.wkid).toEqual(
           4326
         );
+        expect(response.locations[2].address).toEqual("foo bar baz");
         done();
       });
   });

--- a/packages/arcgis-rest-geocoder/test/mocks/responses.ts
+++ b/packages/arcgis-rest-geocoder/test/mocks/responses.ts
@@ -291,6 +291,11 @@ export const GeocodeAddresses = {
         Ymin: 33.943172211706106,
         Ymax: 33.945172211706101
       }
+    },
+    {
+      address: "foo bar baz",
+      score: 0,
+      attributes: {}
     }
   ]
 };

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -251,7 +251,7 @@ export class ArcGISAuthError extends ArcGISRequestError {
       code === "AUTHENTICATION_ERROR_CODE" ? message : `${code}: ${message}`;
   }
 
-  retry(getSession: IRetryAuthError, retryLimit = 3) {
+  public retry(getSession: IRetryAuthError, retryLimit = 3) {
     let tries = 0;
 
     const retryRequest = (resolve: any, reject: any) => {

--- a/packages/arcgis-rest-request/src/utils/ArcGISRequestError.ts
+++ b/packages/arcgis-rest-request/src/utils/ArcGISRequestError.ts
@@ -11,37 +11,37 @@ export class ArcGISRequestError {
   /**
    * The name of this error. Will always be `"ArcGISRequestError"` to conform with the [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) class.
    */
-  name: string;
+  public name: string;
 
   /**
    * Formatted error message. See the [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) class for more details.
    */
-  message: string;
+  public message: string;
 
   /**
    * The errror message return from the request.
    */
-  originalMessage: string;
+  public originalMessage: string;
 
   /**
    * The error code returned from the request.
    */
-  code: string | number;
+  public code: string | number;
 
   /**
    * The original JSON response the caused the error.
    */
-  response: any;
+  public response: any;
 
   /**
    * The URL of the original request that caused the error
    */
-  url: string;
+  public url: string;
 
   /**
    * The options of the original request that caused the error
    */
-  options: IRequestOptions;
+  public options: IRequestOptions;
 
   /**
    * Create a new `ArcGISRequestError`  object.

--- a/packages/arcgis-rest-sharing/src/helpers.ts
+++ b/packages/arcgis-rest-sharing/src/helpers.ts
@@ -50,7 +50,7 @@ export function isItemOwner(requestOptions: ISharingRequestOptions): boolean {
 export function isOrgAdmin(
   requestOptions: ISharingRequestOptions
 ): Promise<boolean> {
-  const session = requestOptions.authentication as UserSession;
+  const session = requestOptions.authentication;
 
   return session.getUser(requestOptions).then((user: IUser) => {
     if (!user || user.role !== "org_admin") {

--- a/packages/arcgis-rest-users/test/get.test.ts
+++ b/packages/arcgis-rest-users/test/get.test.ts
@@ -25,19 +25,10 @@ describe("users", () => {
     const session = new UserSession({
       username: "c@sey",
       password: "123456",
+      token: "fake-token",
+      tokenExpires: TOMORROW,
       portal: "https://myorg.maps.arcgis.com/sharing/rest"
     });
-
-    fetchMock.postOnce(
-      "https://myorg.maps.arcgis.com/sharing/rest/generateToken",
-      {
-        token: "token",
-        expires: TOMORROW.getTime(),
-        username: " c@sey"
-      }
-    );
-
-    session.refreshSession();
 
     it("should make a simple, unauthenticated request for information about a user", done => {
       fetchMock.once("*", AnonUserResponse);
@@ -65,7 +56,7 @@ describe("users", () => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(
-            "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey?f=json&token=token"
+            "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey?f=json&token=fake-token"
           );
           expect(options.method).toBe("GET");
           done();
@@ -86,7 +77,7 @@ describe("users", () => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(
-            "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=token"
+            "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token"
           );
           expect(options.method).toBe("GET");
           done();

--- a/packages/arcgis-rest-users/test/invitation.test.ts
+++ b/packages/arcgis-rest-users/test/invitation.test.ts
@@ -29,21 +29,12 @@ describe("invitations", () => {
   const session = new UserSession({
     username: "c@sey",
     password: "123456",
+    token: "fake-token",
+    tokenExpires: TOMORROW,
     portal: "https://myorg.maps.arcgis.com/sharing/rest"
   });
 
-  fetchMock.postOnce(
-    "https://myorg.maps.arcgis.com/sharing/rest/generateToken",
-    {
-      token: "fake-token",
-      expires: TOMORROW.getTime(),
-      username: "c@sey"
-    }
-  );
-
   describe("getUserInvitations", () => {
-    session.refreshSession();
-
     it("should make an authenticated request for user invitations", done => {
       fetchMock.once("*", UserInvitationsResponse);
 
@@ -65,17 +56,6 @@ describe("invitations", () => {
   });
 
   describe("getUserInvitation", () => {
-    fetchMock.postOnce(
-      "https://myorg.maps.arcgis.com/sharing/rest/generateToken",
-      {
-        token: "fake-token",
-        expires: TOMORROW.getTime(),
-        username: "c@sey"
-      }
-    );
-
-    session.refreshSession();
-
     it("should make an authenticated request for a user invitation", done => {
       fetchMock.once("*", UserInvitationResponse);
 
@@ -98,17 +78,6 @@ describe("invitations", () => {
   });
 
   describe("acceptInvitation", () => {
-    fetchMock.postOnce(
-      "https://myorg.maps.arcgis.com/sharing/rest/generateToken",
-      {
-        token: "fake-token",
-        expires: TOMORROW.getTime(),
-        username: "c@sey"
-      }
-    );
-
-    session.refreshSession();
-
     it("should accept an invitation", done => {
       fetchMock.once("*", { success: true });
 
@@ -133,17 +102,6 @@ describe("invitations", () => {
   });
 
   describe("declineInvitation", () => {
-    fetchMock.postOnce(
-      "https://myorg.maps.arcgis.com/sharing/rest/generateToken",
-      {
-        token: "fake-token",
-        expires: TOMORROW.getTime(),
-        username: "c@sey"
-      }
-    );
-
-    session.refreshSession();
-
     it("should decline an invitation", done => {
       fetchMock.once("*", { success: true });
 

--- a/packages/arcgis-rest-users/test/notification.test.ts
+++ b/packages/arcgis-rest-users/test/notification.test.ts
@@ -25,19 +25,10 @@ describe("users", () => {
     const session = new UserSession({
       username: "c@sey",
       password: "123456",
+      token: "fake-token",
+      tokenExpires: TOMORROW,
       portal: "https://myorg.maps.arcgis.com/sharing/rest"
     });
-
-    fetchMock.postOnce(
-      "https://myorg.maps.arcgis.com/sharing/rest/generateToken",
-      {
-        token: "fake-token",
-        expires: TOMORROW.getTime(),
-        username: "c@sey"
-      }
-    );
-
-    session.refreshSession();
 
     it("should make an authenticated request for user notifications", done => {
       fetchMock.once("*", UserNotificationsResponse);


### PR DESCRIPTION
now _thats_ what i call a goose chase.

* fixed stupid `*` alignment lint error
* handled a few more promises correctly
* bumped `tslint-config-standard` to resolve a nag
* fixed a _huge_ pile of new lint errors that cropped up
* simplified a few of @mjuniper's notification/invitation tests
* added coverage for #427 (coveralls must have been sleeping) 	

AFFECTS PACKAGES:
@esri/arcgis-rest-auth
@esri/arcgis-rest-feature-service-admin
@esri/arcgis-rest-geocoder
@esri/arcgis-rest-request
@esri/arcgis-rest-sharing
@esri/arcgis-rest-users