### PR TITLE
ensure refreshSession() clears cached user info

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -688,6 +688,8 @@ export class UserSession implements IAuthenticationManager {
    * Manually refreshes the current `token` and `tokenExpires`.
    */
   refreshSession(requestOptions?: ITokenRequestOptions): Promise<UserSession> {
+    // make sure subsequent calls to getUser() don't returned cached metadata
+    this._user = null;
     if (this.username && this.password) {
       return this.refreshWithUsernameAndPassword(requestOptions);
     }


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-auth

RESOLVES #291