### PR TITLE
Add a "headers" option to IRequestOptions

### DIFF
--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -6,7 +6,12 @@ import { encodeQueryString } from "./utils/encode-query-string";
 import { requiresFormData } from "./utils/process-params";
 import { ArcGISRequestError } from "./utils/ArcGISRequestError";
 import { IRetryAuthError } from "./utils/retryAuthError";
-import { HTTPMethods, IParams, ITokenRequestOptions } from "./utils/params";
+import {
+  HTTPMethods,
+  IParams,
+  ITokenRequestOptions,
+  IHeaders
+} from "./utils/params";
 
 /**
  * Authentication can be supplied to `request` via [`UserSession`](../../auth/UserSession/) or [`ApplicationSession`](../../auth/ApplicationSession/). Both classes extend `IAuthenticationManager`.
@@ -62,6 +67,11 @@ export interface IRequestOptions {
    * If the length of a GET request's URL exceeds `maxUrlLength` the request will use POST instead.
    */
   maxUrlLength?: number;
+
+  /**
+   * Additional headers to pass into the request.
+   */
+  headers?: IHeaders;
 }
 
 /**
@@ -178,10 +188,15 @@ export function request(
         fetchOptions.body = encodeFormData(params);
       }
 
-      fetchOptions.headers = {};
+      // Mixin headers from request options
+      fetchOptions.headers = { ...requestOptions.headers };
 
       /* istanbul ignore next - karma reports coverage on browser tests only */
-      if (typeof window === "undefined") {
+      if (
+        typeof window === "undefined" &&
+        requestOptions.headers === undefined
+      ) {
+        // set default header only in Node and when optional headers haven't been passed
         fetchOptions.headers["referer"] = "@esri/arcgis-rest";
       }
 

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -194,7 +194,7 @@ export function request(
       /* istanbul ignore next - karma reports coverage on browser tests only */
       if (
         typeof window === "undefined" &&
-        requestOptions.headers === undefined
+        (!requestOptions.headers || !requestOptions.headers.referer)
       ) {
         // set default header only in Node and when optional headers haven't been passed
         fetchOptions.headers["referer"] = "@esri/arcgis-rest";

--- a/packages/arcgis-rest-request/src/utils/params.ts
+++ b/packages/arcgis-rest-request/src/utils/params.ts
@@ -50,3 +50,7 @@ export interface ITokenRequestOptions {
   httpMethod?: HTTPMethods;
   fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 }
+
+export interface IHeaders {
+  [key: string]: any;
+}

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -333,7 +333,6 @@ describe("request()", () => {
             "https://www.arcgis.com/sharing/rest/content/items/43a/data"
           );
           expect(options.method).toBe("POST");
-          console.log("HERE!!!!" + JSON.stringify(options.headers));
           expect(options.headers).toEqual({
             referer: "test/referer",
             "Content-Type": "application/x-www-form-urlencoded"

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -298,7 +298,7 @@ describe("request()", () => {
   });
 
   if (typeof window === "undefined") {
-    it("should tack on a generic referer header in Node.js only", done => {
+    it("should tack on a generic referer header - in Node.js only", done => {
       fetchMock.once("*", WebMapAsJSON);
 
       request("https://www.arcgis.com/sharing/rest/content/items/43a/data")
@@ -311,6 +311,54 @@ describe("request()", () => {
           expect(options.method).toBe("POST");
           expect(options.headers).toEqual({
             referer: "@esri/arcgis-rest",
+            "Content-Type": "application/x-www-form-urlencoded"
+          });
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should use referer header from request options - in Node.js only", done => {
+      fetchMock.once("*", WebMapAsJSON);
+
+      request("https://www.arcgis.com/sharing/rest/content/items/43a/data", {
+        headers: { referer: "test/referer" }
+      })
+        .then(() => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://www.arcgis.com/sharing/rest/content/items/43a/data"
+          );
+          expect(options.method).toBe("POST");
+          console.log("HERE!!!!" + JSON.stringify(options.headers));
+          expect(options.headers).toEqual({
+            referer: "test/referer",
+            "Content-Type": "application/x-www-form-urlencoded"
+          });
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should leave referer header undefined when request options include headers object without 'referer' - in Node.js only", done => {
+      fetchMock.once("*", WebMapAsJSON);
+
+      request("https://www.arcgis.com/sharing/rest/content/items/43a/data", {
+        headers: {}
+      })
+        .then(() => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://www.arcgis.com/sharing/rest/content/items/43a/data"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.headers).toEqual({
             "Content-Type": "application/x-www-form-urlencoded"
           });
           done();


### PR DESCRIPTION
This PR does the following

1) adds a `headers` option to IRequestOptions. Optional headers are passed on to the target request. 

2) in Node environments, the presence of the `headers` options prevents the default `referer` header
`"@esri/arcgis-rest"` from being set on the request. If a `referer` is desired, it can be set with the header option.

I have found that (2) is critical in a particular case; ArcGIS search service sometimes rejects a request with a valid token when the `referer` is set to `"@esri/arcgis-rest"`.  (Note that in such cases, ArcGIS search returns a `498 Invalid token` response; but stripping the referer header from the request results in a success response, which indicates the problem is not with the token.)
