### PR TITLE
proposed tweaks to #436

### DIFF
--- a/packages/arcgis-rest-auth/src/generate-token.ts
+++ b/packages/arcgis-rest-auth/src/generate-token.ts
@@ -5,7 +5,8 @@ import {
   request,
   IRequestOptions,
   IGenerateTokenParams,
-  ITokenRequestOptions
+  ITokenRequestOptions,
+  NODEJS_DEFAULT_REFERER_HEADER
 } from "@esri/arcgis-rest-request";
 
 export interface IGenerateTokenResponse {
@@ -18,7 +19,7 @@ export function generateToken(
   url: string,
   requestOptions: IGenerateTokenParams | ITokenRequestOptions
 ): Promise<IGenerateTokenResponse> {
-  // TODO: remove union type and type guard next breaking change and just expect IGenerateTokenRequestOptions
+  // TODO: remove union type and type guard next breaking change and just expect IGenerateTokenParams
   const options: IRequestOptions = (requestOptions as ITokenRequestOptions)
     .params
     ? (requestOptions as IRequestOptions)
@@ -32,7 +33,7 @@ export function generateToken(
   ) {
     options.params.referer = window.location.host;
   } else {
-    options.params.referer = "@esri/arcgis-rest";
+    options.params.referer = NODEJS_DEFAULT_REFERER_HEADER;
   }
 
   return request(url, options);

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -6,7 +6,12 @@ import { encodeQueryString } from "./utils/encode-query-string";
 import { requiresFormData } from "./utils/process-params";
 import { ArcGISRequestError } from "./utils/ArcGISRequestError";
 import { IRetryAuthError } from "./utils/retryAuthError";
-import { HTTPMethods, IParams, ITokenRequestOptions } from "./utils/params";
+import {
+  HTTPMethods,
+  IParams,
+  ITokenRequestOptions,
+  IHeaders
+} from "./utils/params";
 
 /**
  * Authentication can be supplied to `request` via [`UserSession`](../../auth/UserSession/) or [`ApplicationSession`](../../auth/ApplicationSession/). Both classes extend `IAuthenticationManager`.
@@ -62,6 +67,11 @@ export interface IRequestOptions {
    * If the length of a GET request's URL exceeds `maxUrlLength` the request will use POST instead.
    */
   maxUrlLength?: number;
+
+  /**
+   * Additional headers to pass into the request.
+   */
+  headers?: IHeaders;
 }
 
 /**
@@ -178,10 +188,15 @@ export function request(
         fetchOptions.body = encodeFormData(params);
       }
 
-      fetchOptions.headers = {};
+      // Mixin headers from request options
+      fetchOptions.headers = { ...requestOptions.headers };
 
       /* istanbul ignore next - karma reports coverage on browser tests only */
-      if (typeof window === "undefined") {
+      if (
+        typeof window === "undefined" &&
+        requestOptions.headers === undefined
+      ) {
+        // set default header only in Node and when optional headers haven't been passed
         fetchOptions.headers["referer"] = "@esri/arcgis-rest";
       }
 

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -6,12 +6,7 @@ import { encodeQueryString } from "./utils/encode-query-string";
 import { requiresFormData } from "./utils/process-params";
 import { ArcGISRequestError } from "./utils/ArcGISRequestError";
 import { IRetryAuthError } from "./utils/retryAuthError";
-import {
-  HTTPMethods,
-  IParams,
-  ITokenRequestOptions,
-  IHeaders
-} from "./utils/params";
+import { HTTPMethods, IParams, ITokenRequestOptions } from "./utils/params";
 
 /**
  * Authentication can be supplied to `request` via [`UserSession`](../../auth/UserSession/) or [`ApplicationSession`](../../auth/ApplicationSession/). Both classes extend `IAuthenticationManager`.
@@ -69,10 +64,12 @@ export interface IRequestOptions {
   maxUrlLength?: number;
 
   /**
-   * Additional headers to pass into the request.
+   * Additional [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) to pass into the request.
    */
-  headers?: IHeaders;
+  headers?: { [key: string]: any };
 }
+
+export const NODEJS_DEFAULT_REFERER_HEADER = `@esri/arcgis-rest-js`;
 
 /**
  * ```js
@@ -189,16 +186,12 @@ export function request(
       }
 
       // Mixin headers from request options
-      fetchOptions.headers = { ...requestOptions.headers };
-
       /* istanbul ignore next - karma reports coverage on browser tests only */
-      if (
-        typeof window === "undefined" &&
-        requestOptions.headers === undefined
-      ) {
-        // set default header only in Node and when optional headers haven't been passed
-        fetchOptions.headers["referer"] = "@esri/arcgis-rest";
-      }
+      fetchOptions.headers = {
+        referer:
+          typeof window === "undefined" ? NODEJS_DEFAULT_REFERER_HEADER : null,
+        ...requestOptions.headers
+      };
 
       /* istanbul ignore else blob responses are difficult to make cross platform we will just have to trust the isomorphic fetch will do its job */
       if (!requiresFormData(params)) {

--- a/packages/arcgis-rest-request/src/utils/params.ts
+++ b/packages/arcgis-rest-request/src/utils/params.ts
@@ -50,3 +50,7 @@ export interface ITokenRequestOptions {
   httpMethod?: HTTPMethods;
   fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 }
+
+export interface IHeaders {
+  [key: string]: any;
+}

--- a/packages/arcgis-rest-request/src/utils/params.ts
+++ b/packages/arcgis-rest-request/src/utils/params.ts
@@ -50,7 +50,3 @@ export interface ITokenRequestOptions {
   httpMethod?: HTTPMethods;
   fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 }
-
-export interface IHeaders {
-  [key: string]: any;
-}

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -298,7 +298,7 @@ describe("request()", () => {
   });
 
   if (typeof window === "undefined") {
-    it("should tack on a generic referer header in Node.js only", done => {
+    it("should tack on a generic referer header - in Node.js only", done => {
       fetchMock.once("*", WebMapAsJSON);
 
       request("https://www.arcgis.com/sharing/rest/content/items/43a/data")
@@ -311,6 +311,54 @@ describe("request()", () => {
           expect(options.method).toBe("POST");
           expect(options.headers).toEqual({
             referer: "@esri/arcgis-rest",
+            "Content-Type": "application/x-www-form-urlencoded"
+          });
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should use referer header from request options - in Node.js only", done => {
+      fetchMock.once("*", WebMapAsJSON);
+
+      request("https://www.arcgis.com/sharing/rest/content/items/43a/data", {
+        headers: { referer: "test/referer" }
+      })
+        .then(() => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://www.arcgis.com/sharing/rest/content/items/43a/data"
+          );
+          expect(options.method).toBe("POST");
+          console.log("HERE!!!!" + JSON.stringify(options.headers));
+          expect(options.headers).toEqual({
+            referer: "test/referer",
+            "Content-Type": "application/x-www-form-urlencoded"
+          });
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should leave referer header undefined when request options include headers object without 'referer' - in Node.js only", done => {
+      fetchMock.once("*", WebMapAsJSON);
+
+      request("https://www.arcgis.com/sharing/rest/content/items/43a/data", {
+        headers: {}
+      })
+        .then(() => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://www.arcgis.com/sharing/rest/content/items/43a/data"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.headers).toEqual({
             "Content-Type": "application/x-www-form-urlencoded"
           });
           done();

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -255,6 +255,7 @@ describe("request()", () => {
       FormData = oldFormData;
       Function("return this")().fetch = oldFetch;
     });
+
     it("should throw for missing dependencies", () => {
       expect(() => {
         request("https://www.arcgis.com/sharing/rest/info").catch();
@@ -310,7 +311,7 @@ describe("request()", () => {
           );
           expect(options.method).toBe("POST");
           expect(options.headers).toEqual({
-            referer: "@esri/arcgis-rest",
+            referer: "@esri/arcgis-rest-js",
             "Content-Type": "application/x-www-form-urlencoded"
           });
           done();
@@ -333,7 +334,6 @@ describe("request()", () => {
             "https://www.arcgis.com/sharing/rest/content/items/43a/data"
           );
           expect(options.method).toBe("POST");
-          console.log("HERE!!!!" + JSON.stringify(options.headers));
           expect(options.headers).toEqual({
             referer: "test/referer",
             "Content-Type": "application/x-www-form-urlencoded"
@@ -345,11 +345,11 @@ describe("request()", () => {
         });
     });
 
-    it("should leave referer header undefined when request options include headers object without 'referer' - in Node.js only", done => {
+    it("if no referer header is provided, but other headers are passed, a default should still be set - in Node.js only", done => {
       fetchMock.once("*", WebMapAsJSON);
 
       request("https://www.arcgis.com/sharing/rest/content/items/43a/data", {
-        headers: {}
+        headers: { foo: "bar" }
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
@@ -359,7 +359,9 @@ describe("request()", () => {
           );
           expect(options.method).toBe("POST");
           expect(options.headers).toEqual({
-            "Content-Type": "application/x-www-form-urlencoded"
+            "Content-Type": "application/x-www-form-urlencoded",
+            referer: "@esri/arcgis-rest-js",
+            foo: "bar"
           });
           done();
         })


### PR DESCRIPTION
* use `@esri/arcgis-rest-js` as the default referer instead of `@esri/arcgis-rest` (don't ask)
* skip declaring an `IHeaders` interface (and just link to MDN instead)
* use a ternary 
* continue to set the default `referer` in Node.js applications unless a different `referer` is provided explicitly
* add another test to confirm ^^
