### PR TITLE
use lerna.json to increment sri version

### DIFF
--- a/docs/generate-srihashes.js
+++ b/docs/generate-srihashes.js
@@ -4,8 +4,8 @@
 const { join } = require("path");
 const { readFile, writeFile } = require("fs");
 const { generate } = require("sri-toolbox");
-const version = process.env.npm_package_version;
 const OUTPUT = join(process.cwd(), "docs", "src", `srihashes.json`);
+const version = require(join(process.cwd(), "lerna.json")).version;
 
 const packages = [
   "auth",

--- a/docs/src/srihashes.json
+++ b/docs/src/srihashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.15.1",
+  "version": "1.15.2",
   "packages": {
     "@esri/arcgis-rest-auth": "sha384-/xuQClXPweoBn3CAfanrKB4fCLXUmfEnhNklAG+JkKoAY0fgQd/xzfV5GyEAUtqO",
     "@esri/arcgis-rest-common": "sha384-PYusm8RlBYJ8rLwjKKeKHQq2HXqVROK62Irvte8ub5ECcWb5OfXYvN89SGQIF2CY",


### PR DESCRIPTION
@COV-GIS's PR worked like a charm.

![screenshot 2019-01-17 00 40 23](https://user-images.githubusercontent.com/3011734/51305712-7d819300-19f0-11e9-941f-420321405c6d.png)

https://esri.github.io/arcgis-rest-js/api/

this is just a small change to ensure we use the version specified in the lerna.json file.

