### PR TITLE
fix(:bug:): ensure that custom headers arent misidentified as request parameters

### DIFF
--- a/packages/arcgis-rest-request/src/utils/append-custom-params.ts
+++ b/packages/arcgis-rest-request/src/utils/append-custom-params.ts
@@ -4,12 +4,14 @@
 import { IRequestOptions } from "../request";
 
 /**
- * Helper for methods with lots of first order request options to pass them through as request parameters.
+ * Helper for methods with lots of first order request options to pass through as request parameters.
  */
 export function appendCustomParams(
   oldOptions: IRequestOptions,
   newOptions: IRequestOptions
 ) {
+  // at v2.0.0, this should be refactored as a nonmutating method that takes a single argument, mixes in everything and returns a new instance of IRequestOptions
+
   // only pass query parameters through in the request, not generic IRequestOptions props
   Object.keys(oldOptions).forEach(function(key: string) {
     if (
@@ -20,6 +22,7 @@ export function appendCustomParams(
       key !== "fetch" &&
       key !== "portal" &&
       key !== "maxUrlLength" &&
+      key !== "headers" &&
       key !== "endpoint" &&
       key !== "decodeValues"
     ) {

--- a/packages/arcgis-rest-request/test/utils/append-params.test.ts
+++ b/packages/arcgis-rest-request/test/utils/append-params.test.ts
@@ -1,0 +1,32 @@
+/* Copyright (c) 2018-2019 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { appendCustomParams, IRequestOptions } from "../../src/index";
+
+describe("appendCustomParams", () => {
+  it("should not mis-identify standard request options as parameters.", () => {
+    const oldOptions: any = {
+      foo: "bar",
+      headers: {
+        Cookie: "monster"
+      },
+      httpMethod: "GET",
+      params: { baz: "luhrman" },
+      maxUrlLength: 1064
+    };
+    
+    const newOptions: IRequestOptions = {
+      params: {}
+    };
+    
+    appendCustomParams(oldOptions, newOptions);
+    
+    // all other request options should be mixed in outside this helper method
+    expect(typeof newOptions.headers).toEqual("undefined");
+    expect(typeof newOptions.httpMethod).toEqual("undefined");
+    expect(typeof newOptions.maxUrlLength).toEqual("undefined");
+    expect(typeof newOptions.params.baz).toEqual("undefined");
+    
+    expect(newOptions.params.foo).toEqual("bar");
+  });
+});

--- a/packages/arcgis-rest-request/test/utils/process-params.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-params.test.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+/* Copyright (c) 2018-2019 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
 import { processParams, requiresFormData } from "../../src/index";


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-request

ISSUES CLOSED: #290