### PR TITLE
fix(:bug:): dont set referer to null in browser apps

### DIFF
--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -186,12 +186,14 @@ export function request(
       }
 
       // Mixin headers from request options
-      /* istanbul ignore next - karma reports coverage on browser tests only */
       fetchOptions.headers = {
-        referer:
-          typeof window === "undefined" ? NODEJS_DEFAULT_REFERER_HEADER : null,
         ...requestOptions.headers
       };
+
+      /* istanbul ignore next - karma reports coverage on browser tests only */
+      if (typeof window === "undefined" && !fetchOptions.headers.referer) {
+        fetchOptions.headers.referer = NODEJS_DEFAULT_REFERER_HEADER;
+      }
 
       /* istanbul ignore else blob responses are difficult to make cross platform we will just have to trust the isomorphic fetch will do its job */
       if (!requiresFormData(params)) {


### PR DESCRIPTION
when we landed #437 i did some cursory testing that proved that in the browser native fetch would ignore attempts to set a referer header.

today @benstoltz learned that the custom fetch implementation we use in ArcGIS Hub isn't so forgiving.

AFFECTS PACKAGES:
@esri/arcgis-rest-request