### PR TITLE
Modified feature service creation to handle HTTP 400 errors

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,11 +29,11 @@ module.exports = function(config) {
         }
       },
       reports: {
-        "text": "",
         "json": {
           "directory": "coverage",
           "filename": "coverage.json"
-      },
+        },
+        "html": "coverage"
       },
       compilerOptions: {
         module: "commonjs"

--- a/packages/arcgis-rest-feature-service-admin/src/create.ts
+++ b/packages/arcgis-rest-feature-service-admin/src/create.ts
@@ -201,12 +201,12 @@ export function createFeatureService(
                   reject({ success: false });
                 }
               })
-              .catch();
+              .catch(() => reject({ success: false }));
           } else {
             reject({ success: false });
           }
         })
-        .catch();
+        .catch(() => reject({ success: false }));
     });
   }
 }

--- a/packages/arcgis-rest-feature-service-admin/src/create.ts
+++ b/packages/arcgis-rest-feature-service-admin/src/create.ts
@@ -167,7 +167,6 @@ export function createFeatureService(
   requestOptions: ICreateServiceRequestOptions
 ): Promise<ICreateServiceResult> {
   const owner = determineOwner(requestOptions);
-
   const baseUrl = `${getPortalUrl(requestOptions)}/content/users/${owner}`;
   const url = `${baseUrl}/createService`;
 
@@ -179,34 +178,30 @@ export function createFeatureService(
   };
 
   if (!requestOptions.folderId || requestOptions.folderId === "/") {
-    // If the service is destined for the root folder, just send the request and return the promise;
-    // services are created in the root folder
+    // If the service is destined for the root folder, just send the request
     return request(url, requestOptions);
   } else {
-    // If the service is destined for a subfolder, catch the results of the request and then move
-    // the item to the desired folder
-    return new Promise((resolve, reject) => {
-      request(url, requestOptions)
-        .then(createResults => {
-          if (createResults.success) {
-            moveItem({
-              itemId: createResults.itemId,
-              folderId: requestOptions.folderId,
-              authentication: requestOptions.authentication
-            })
-              .then(moveResults => {
-                if (moveResults.success) {
-                  resolve(createResults);
-                } else {
-                  reject({ success: false });
-                }
-              })
-              .catch(() => reject({ success: false }));
+    // If the service is destined for a subfolder, move it (via another call)
+    return request(url, requestOptions).then(createResponse => {
+      if (createResponse.success) {
+        return moveItem({
+          itemId: createResponse.itemId,
+          folderId: requestOptions.folderId,
+          authentication: requestOptions.authentication
+        }).then(moveResponse => {
+          if (moveResponse.success) {
+            return createResponse;
           } else {
-            reject({ success: false });
+            throw Error(
+              `A problem was encountered when trying to move the service to a different folder.`
+            );
           }
-        })
-        .catch(() => reject({ success: false }));
+        });
+      } else {
+        throw Error(
+          `A problem was encountered when trying to create the service.`
+        );
+      }
     });
   }
 }

--- a/packages/arcgis-rest-feature-service-admin/test/create.test.ts
+++ b/packages/arcgis-rest-feature-service-admin/test/create.test.ts
@@ -5,16 +5,8 @@ import * as fetchMock from "fetch-mock";
 
 import { createFeatureService } from "../src/create";
 
-import {
-  FeatureServiceSuccessResponse,
-  FeatureServiceFailResponse,
-  FeatureServiceFailResponse400,
-  AddToFeatureServiceBadRequest
-} from "./mocks/service";
-import {
-  MoveToFolderSuccessResponse,
-  MoveToFolderFailResponse
-} from "./mocks/move";
+import { FeatureServiceResponse } from "./mocks/service";
+import { MoveToFolderResponse } from "./mocks/move";
 
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { TOMORROW } from "@esri/arcgis-rest-auth/test/utils";
@@ -74,7 +66,7 @@ describe("create feature service", () => {
     };
 
     it("should create a feature service defaulting to the root folder", done => {
-      fetchMock.mock("end:createService", FeatureServiceSuccessResponse, {});
+      fetchMock.mock("end:createService", FeatureServiceResponse, {});
 
       createFeatureService({
         item: serviceDescription,
@@ -107,7 +99,7 @@ describe("create feature service", () => {
             );
 
             // Check response
-            expect(response).toEqual(FeatureServiceSuccessResponse);
+            expect(response).toEqual(FeatureServiceResponse);
 
             done();
           },
@@ -121,7 +113,7 @@ describe("create feature service", () => {
     });
 
     it("should create a feature service specified for the root folder 1", done => {
-      fetchMock.mock("end:createService", FeatureServiceSuccessResponse, {});
+      fetchMock.mock("end:createService", FeatureServiceResponse, {});
       const folderId = "";
 
       createFeatureService({
@@ -156,7 +148,7 @@ describe("create feature service", () => {
             );
 
             // Check response
-            expect(response).toEqual(FeatureServiceSuccessResponse);
+            expect(response).toEqual(FeatureServiceResponse);
 
             done();
           },
@@ -170,7 +162,7 @@ describe("create feature service", () => {
     });
 
     it("should create a feature service specified for the root folder 2", done => {
-      fetchMock.mock("end:createService", FeatureServiceSuccessResponse, {});
+      fetchMock.mock("end:createService", FeatureServiceResponse, {});
       const folderId = "/";
 
       createFeatureService({
@@ -205,7 +197,7 @@ describe("create feature service", () => {
             );
 
             // Check response
-            expect(response).toEqual(FeatureServiceSuccessResponse);
+            expect(response).toEqual(FeatureServiceResponse);
 
             done();
           },
@@ -220,8 +212,8 @@ describe("create feature service", () => {
 
     it("should create a feature service in a particular folder", done => {
       fetchMock
-        .mock("end:createService", FeatureServiceSuccessResponse, {})
-        .mock("end:move", MoveToFolderSuccessResponse, {});
+        .mock("end:createService", FeatureServiceResponse, {})
+        .mock("end:move", MoveToFolderResponse, {});
       const folderId = "83216cba44bf4357bf06687ec88a847b";
 
       createFeatureService({
@@ -273,7 +265,7 @@ describe("create feature service", () => {
             );
 
             // Check response
-            expect(response).toEqual(FeatureServiceSuccessResponse);
+            expect(response).toEqual(FeatureServiceResponse);
 
             done();
           },
@@ -286,106 +278,9 @@ describe("create feature service", () => {
         });
     });
 
-    it("should fail to create a feature service defaulting to the root folder with success=false", done => {
-      fetchMock.mock("end:createService", FeatureServiceFailResponse, {});
-      const folderId = "";
-
-      createFeatureService({
-        item: serviceDescription,
-        folderId,
-        ...MOCK_USER_REQOPTS
-      })
-        .then(
-          response => {
-            expect(fetchMock.called("end:createService")).toEqual(true);
-            expect(fetchMock.called("end:move")).toEqual(false);
-
-            // Check create service call
-            const [urlCreate, optionsCreate]: [
-              string,
-              RequestInit
-            ] = fetchMock.lastCall("end:createService");
-            expect(urlCreate).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
-            );
-            expect(optionsCreate.method).toBe("POST");
-            expect(optionsCreate.body).toContain("f=json");
-            expect(optionsCreate.body).toContain(
-              encodeParam(
-                "createParameters",
-                JSON.stringify(serviceDescription)
-              )
-            );
-            expect(optionsCreate.body).toContain("outputType=featureService");
-            expect(optionsCreate.body).toContain(
-              encodeParam("token", "fake-token")
-            );
-
-            // Check response
-            expect(response).toEqual(FeatureServiceFailResponse);
-
-            done();
-          },
-          () => fail()
-        )
-        .catch(e => {
-          fail(e);
-        });
-    });
-
-    it("should fail to create a feature service defaulting to the root folder with HTTP 400", done => {
-      fetchMock.mock("end:createService", FeatureServiceFailResponse400, {});
-      const folderId = "";
-
-      createFeatureService({
-        item: serviceDescription,
-        folderId,
-        ...MOCK_USER_REQOPTS
-      })
-        .then(
-          () => fail(),
-          error => {
-            expect(fetchMock.called("end:createService")).toEqual(true);
-            expect(fetchMock.called("end:move")).toEqual(false);
-
-            // Check create service call
-            const [urlCreate, optionsCreate]: [
-              string,
-              RequestInit
-            ] = fetchMock.lastCall("end:createService");
-            expect(urlCreate).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
-            );
-            expect(optionsCreate.method).toBe("POST");
-            expect(optionsCreate.body).toContain("f=json");
-            expect(optionsCreate.body).toContain(
-              encodeParam(
-                "createParameters",
-                JSON.stringify(serviceDescription)
-              )
-            );
-            expect(optionsCreate.body).toContain("outputType=featureService");
-            expect(optionsCreate.body).toContain(
-              encodeParam("token", "fake-token")
-            );
-
-            // Check response
-            expect(error.code).toEqual(AddToFeatureServiceBadRequest.code);
-            expect(error.name).toEqual(AddToFeatureServiceBadRequest.name);
-            expect(error.message).toEqual(
-              AddToFeatureServiceBadRequest.message
-            );
-
-            done();
-          }
-        )
-        .catch(e => {
-          fail(e);
-        });
-    });
-
     it("should fail to create a feature service destined for a particular folder with success=false", done => {
-      fetchMock.mock("end:createService", FeatureServiceFailResponse, {});
+      fetchMock.mock("end:createService", { success: false });
+
       const folderId = "83216cba44bf4357bf06687ec88a847b";
 
       createFeatureService({
@@ -393,48 +288,38 @@ describe("create feature service", () => {
         folderId,
         ...MOCK_USER_REQOPTS
       })
-        .then(
-          () => {
-            fail(); // call is supposed to fail
-          },
-          response => {
-            expect(fetchMock.called("end:createService")).toEqual(true);
-            expect(fetchMock.called("end:move")).toEqual(false);
-
-            // Check create service call
-            const [urlCreate, optionsCreate]: [
-              string,
-              RequestInit
-            ] = fetchMock.lastCall("end:createService");
-            expect(urlCreate).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
-            );
-            expect(optionsCreate.method).toBe("POST");
-            expect(optionsCreate.body).toContain("f=json");
-            expect(optionsCreate.body).toContain(
-              encodeParam(
-                "createParameters",
-                JSON.stringify(serviceDescription)
-              )
-            );
-            expect(optionsCreate.body).toContain("outputType=featureService");
-            expect(optionsCreate.body).toContain(
-              encodeParam("token", "fake-token")
-            );
-
-            // Check response
-            expect(response).toEqual(FeatureServiceFailResponse);
-
-            done();
-          }
-        )
+        .then(() => fail())
         .catch(e => {
-          fail(e);
+          expect(fetchMock.called("end:createService")).toEqual(true);
+          expect(fetchMock.called("end:move")).toEqual(false);
+
+          // Check create service call
+          const [urlCreate, optionsCreate]: [
+            string,
+            RequestInit
+          ] = fetchMock.lastCall("end:createService");
+          expect(urlCreate).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
+          );
+          expect(optionsCreate.method).toBe("POST");
+          expect(optionsCreate.body).toContain("f=json");
+          expect(optionsCreate.body).toContain(
+            encodeParam("createParameters", JSON.stringify(serviceDescription))
+          );
+          expect(optionsCreate.body).toContain("outputType=featureService");
+          expect(optionsCreate.body).toContain(
+            encodeParam("token", "fake-token")
+          );
+          expect(e.message).toEqual(
+            `A problem was encountered when trying to create the service.`
+          );
+          done();
         });
     });
 
-    it("should fail to create a feature service destined for a particular folder with HTTP 400", done => {
-      fetchMock.mock("end:createService", FeatureServiceFailResponse400, {});
+    it("should fail to create a feature service destined for a particular folder with success=false (for the move)", done => {
+      fetchMock.mock("end:createService", FeatureServiceResponse, {});
+      fetchMock.mock("end:move", { success: false });
       const folderId = "83216cba44bf4357bf06687ec88a847b";
 
       createFeatureService({
@@ -442,180 +327,51 @@ describe("create feature service", () => {
         folderId,
         ...MOCK_USER_REQOPTS
       })
-        .then(
-          () => {
-            fail(); // call is supposed to fail
-          },
-          response => {
-            expect(fetchMock.called("end:createService")).toEqual(true);
-            expect(fetchMock.called("end:move")).toEqual(false);
-
-            // Check create service call
-            const [urlCreate, optionsCreate]: [
-              string,
-              RequestInit
-            ] = fetchMock.lastCall("end:createService");
-            expect(urlCreate).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
-            );
-            expect(optionsCreate.method).toBe("POST");
-            expect(optionsCreate.body).toContain("f=json");
-            expect(optionsCreate.body).toContain(
-              encodeParam(
-                "createParameters",
-                JSON.stringify(serviceDescription)
-              )
-            );
-            expect(optionsCreate.body).toContain("outputType=featureService");
-            expect(optionsCreate.body).toContain(
-              encodeParam("token", "fake-token")
-            );
-
-            // Check response
-            expect(response).toEqual(FeatureServiceFailResponse);
-
-            done();
-          }
-        )
+        .then(() => fail())
         .catch(e => {
-          fail(e);
+          expect(fetchMock.called("end:createService")).toEqual(true);
+          expect(fetchMock.called("end:move")).toEqual(true);
+
+          // Check create service call
+          const [urlCreate, optionsCreate]: [
+            string,
+            RequestInit
+          ] = fetchMock.lastCall("end:createService");
+          expect(urlCreate).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
+          );
+          expect(optionsCreate.method).toBe("POST");
+          expect(optionsCreate.body).toContain("f=json");
+          expect(optionsCreate.body).toContain(
+            encodeParam("createParameters", JSON.stringify(serviceDescription))
+          );
+          expect(optionsCreate.body).toContain("outputType=featureService");
+          expect(optionsCreate.body).toContain(
+            encodeParam("token", "fake-token")
+          );
+
+          // Because the service is created in the root folder, the API follows it with a move call
+          const [urlMove, optionsMove]: [
+            string,
+            RequestInit
+          ] = fetchMock.lastCall("end:move");
+          expect(urlMove).toEqual(
+            `https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/${
+              FeatureServiceResponse.serviceItemId
+            }/move`
+          );
+          expect(optionsMove.method).toBe("POST");
+          expect(optionsMove.body).toContain("folder=" + folderId);
+          expect(optionsMove.body).toContain("f=json");
+          expect(optionsMove.body).toContain(
+            encodeParam("token", "fake-token")
+          );
+
+          expect(e.message).toEqual(
+            `A problem was encountered when trying to move the service to a different folder.`
+          );
+          done();
         });
     });
-
-    it("should create a feature service, but fail to move it to a particular folder with success=false", done => {
-      fetchMock
-        .mock("end:createService", FeatureServiceSuccessResponse, {})
-        .mock("end:move", MoveToFolderFailResponse, {});
-      const folderId = "83216cba44bf4357bf06687ec88a847b";
-
-      createFeatureService({
-        item: serviceDescription,
-        folderId,
-        ...MOCK_USER_REQOPTS
-      })
-        .then(
-          () => {
-            fail(); // call is supposed to fail
-          },
-          response => {
-            expect(fetchMock.called("end:createService")).toEqual(true);
-            expect(fetchMock.called("end:move")).toEqual(true);
-
-            // Check create service call
-            const [urlCreate, optionsCreate]: [
-              string,
-              RequestInit
-            ] = fetchMock.lastCall("end:createService");
-            expect(urlCreate).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
-            );
-            expect(optionsCreate.method).toBe("POST");
-            expect(optionsCreate.body).toContain("f=json");
-            expect(optionsCreate.body).toContain(
-              encodeParam(
-                "createParameters",
-                JSON.stringify(serviceDescription)
-              )
-            );
-            expect(optionsCreate.body).toContain("outputType=featureService");
-            expect(optionsCreate.body).toContain(
-              encodeParam("token", "fake-token")
-            );
-
-            // Because the service is created in the root folder, the API follows it with a move call
-            const [urlMove, optionsMove]: [
-              string,
-              RequestInit
-            ] = fetchMock.lastCall("end:move");
-            expect(urlMove).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/" +
-                FeatureServiceSuccessResponse.serviceItemId +
-                "/move"
-            );
-            expect(optionsMove.method).toBe("POST");
-            expect(optionsMove.body).toContain("folder=" + folderId);
-            expect(optionsMove.body).toContain("f=json");
-            expect(optionsMove.body).toContain(
-              encodeParam("token", "fake-token")
-            );
-
-            // Check response
-            expect(response).toEqual(FeatureServiceFailResponse);
-
-            done();
-          }
-        )
-        .catch(e => {
-          fail(e);
-        });
-    });
-
-    it("should create a feature service, but fail to move it to a particular folder with HTTP 400", done => {
-      fetchMock
-        .mock("end:createService", FeatureServiceSuccessResponse, {})
-        .mock("end:move", FeatureServiceFailResponse400, {});
-      const folderId = "83216cba44bf4357bf06687ec88a847b";
-
-      createFeatureService({
-        item: serviceDescription,
-        folderId,
-        ...MOCK_USER_REQOPTS
-      })
-        .then(
-          () => {
-            fail(); // call is supposed to fail
-          },
-          response => {
-            expect(fetchMock.called("end:createService")).toEqual(true);
-            expect(fetchMock.called("end:move")).toEqual(true);
-
-            // Check create service call
-            const [urlCreate, optionsCreate]: [
-              string,
-              RequestInit
-            ] = fetchMock.lastCall("end:createService");
-            expect(urlCreate).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
-            );
-            expect(optionsCreate.method).toBe("POST");
-            expect(optionsCreate.body).toContain("f=json");
-            expect(optionsCreate.body).toContain(
-              encodeParam(
-                "createParameters",
-                JSON.stringify(serviceDescription)
-              )
-            );
-            expect(optionsCreate.body).toContain("outputType=featureService");
-            expect(optionsCreate.body).toContain(
-              encodeParam("token", "fake-token")
-            );
-
-            // Because the service is created in the root folder, the API follows it with a move call
-            const [urlMove, optionsMove]: [
-              string,
-              RequestInit
-            ] = fetchMock.lastCall("end:move");
-            expect(urlMove).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/" +
-                FeatureServiceSuccessResponse.serviceItemId +
-                "/move"
-            );
-            expect(optionsMove.method).toBe("POST");
-            expect(optionsMove.body).toContain("folder=" + folderId);
-            expect(optionsMove.body).toContain("f=json");
-            expect(optionsMove.body).toContain(
-              encodeParam("token", "fake-token")
-            );
-
-            // Check response
-            expect(response).toEqual(FeatureServiceFailResponse);
-
-            done();
-          }
-        )
-        .catch(e => {
-          fail(e);
-        });
-    });
-  }); // auth requests
+  });
 });

--- a/packages/arcgis-rest-feature-service-admin/test/mocks/move.ts
+++ b/packages/arcgis-rest-feature-service-admin/test/mocks/move.ts
@@ -3,12 +3,9 @@
 
 import { IItemMoveResponse } from "@esri/arcgis-rest-items";
 
-export const MoveToFolderSuccessResponse: IItemMoveResponse = {
+export const MoveToFolderResponse: IItemMoveResponse = {
   folder: "83216cba44bf4357bf06687ec88a847b",
   itemId: "1b1a3c914ef94c49ae55ce223cac5754",
   owner: "casey",
   success: true
-};
-export const MoveToFolderFailResponse: any = {
-  success: false
 };

--- a/packages/arcgis-rest-feature-service-admin/test/mocks/service.ts
+++ b/packages/arcgis-rest-feature-service-admin/test/mocks/service.ts
@@ -67,9 +67,3 @@ export const AddToFeatureServiceError: any = {
     details: ["Object reference not set to an instance of an object."]
   }
 };
-
-export const AddToFeatureServiceBadRequest: any = {
-  code: "HTTP 400",
-  name: "ArcGISRequestError",
-  message: "HTTP 400: Bad Request"
-};

--- a/packages/arcgis-rest-feature-service-admin/test/mocks/service.ts
+++ b/packages/arcgis-rest-feature-service-admin/test/mocks/service.ts
@@ -20,6 +20,7 @@ export const FeatureServiceSuccessResponse: ICreateServiceResult = {
 export const FeatureServiceFailResponse: any = {
   success: false
 };
+export const FeatureServiceFailResponse400: any = 400;
 
 export const AddToFeatureServiceSuccessResponseFredAndGinger: IAddToServiceDefinitionResult = {
   layers: [
@@ -69,4 +70,10 @@ export const AddToFeatureServiceError: any = {
     message: "Unable to add feature service definition.",
     details: ["Object reference not set to an instance of an object."]
   }
+};
+
+export const AddToFeatureServiceBadRequest: any = {
+  code: "HTTP 400",
+  name: "ArcGISRequestError",
+  message: "HTTP 400: Bad Request"
 };

--- a/packages/arcgis-rest-feature-service-admin/test/mocks/service.ts
+++ b/packages/arcgis-rest-feature-service-admin/test/mocks/service.ts
@@ -4,7 +4,7 @@
 import { ICreateServiceResult } from "../../src/create";
 import { IAddToServiceDefinitionResult } from "../../src/addTo";
 
-export const FeatureServiceSuccessResponse: ICreateServiceResult = {
+export const FeatureServiceResponse: ICreateServiceResult = {
   encodedServiceURL:
     "https://services.arcgis.com/b6gLrKHqgkQb393u/arcgis/rest/services/EmptyServiceName/FeatureServer",
   isView: false,
@@ -17,10 +17,6 @@ export const FeatureServiceSuccessResponse: ICreateServiceResult = {
   success: true,
   type: "Feature Service"
 };
-export const FeatureServiceFailResponse: any = {
-  success: false
-};
-export const FeatureServiceFailResponse400: any = 400;
 
 export const AddToFeatureServiceSuccessResponseFredAndGinger: IAddToServiceDefinitionResult = {
   layers: [


### PR DESCRIPTION
If creating a feature service or adding layers &| tables to it fails with an HTTP 400 error, the createFeatureService function doesn't respond with a `resolve` or `reject`, preventing the calling program from resolving the Promise returned by the function.