### PR TITLE
fix: allow org admins to modify group sharing of public items outside the org

### DIFF
--- a/packages/arcgis-rest-sharing/src/group-sharing.ts
+++ b/packages/arcgis-rest-sharing/src/group-sharing.ts
@@ -82,14 +82,16 @@ function changeGroupSharing(
       requestOptions.action === "share" ? "notSharedWith" : "notUnsharedFrom";
     // check if the item has already been shared with the group...
     return isItemSharedWithGroup(requestOptions).then(result => {
-      // console.log(admin);
       // if we are sharing and result is true OR we are unsharing and result is false... short circuit
       if (
         (requestOptions.action === "share" && result === true) ||
         (requestOptions.action === "unshare" && result === false)
       ) {
-        // and send back the same response structure ArcGIS Online would
-        const response = { itemId: requestOptions.id, shortcut: true } as any;
+        // and send back the same response ArcGIS Online would
+        const response = {
+          itemId: requestOptions.id,
+          shortcut: true
+        } as ISharingResponse;
         response[resultProp] = [];
         return response;
       } else {
@@ -106,16 +108,16 @@ function changeGroupSharing(
                 }.`
               );
             } else {
-              // if orgAdmin or owner (and member of group) share using the owner url
-              if (owner === username || admin) {
+              // if owner (and member of group) share using the owner url
+              if (owner === username) {
                 return `${getPortalUrl(
                   requestOptions
                 )}/content/users/${owner}/items/${requestOptions.id}/${
                   requestOptions.action
                 }`;
               } else {
-                // if they are a group admin/owner, use the bare item url
-                if (membership === "admin" || membership === "owner") {
+                // if org admin, group admin/owner, use the bare item url
+                if (membership === "admin" || membership === "owner" || admin) {
                   return `${getPortalUrl(requestOptions)}/content/items/${
                     requestOptions.id
                   }/${requestOptions.action}`;

--- a/packages/arcgis-rest-sharing/test/group-sharing.test.ts
+++ b/packages/arcgis-rest-sharing/test/group-sharing.test.ts
@@ -199,7 +199,7 @@ describe("shareItemWithGroup() ::", () => {
     );
 
     fetchMock.once(
-      "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share",
+      "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
       SharingResponse
     );
 
@@ -214,10 +214,10 @@ describe("shareItemWithGroup() ::", () => {
           "All fetchMocks should have been called"
         );
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
+          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
         );
         expect(url).toBe(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
+          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
         );
         expect(options.method).toBe("POST");
         expect(response).toEqual(SharingResponse);
@@ -455,7 +455,7 @@ describe("unshareItemWithGroup() ::", () => {
     );
 
     fetchMock.once(
-      "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/a5b/unshare",
+      "https://myorg.maps.arcgis.com/sharing/rest/content/items/a5b/unshare",
       UnsharingResponse
     );
 
@@ -472,10 +472,10 @@ describe("unshareItemWithGroup() ::", () => {
     })
       .then(response => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/a5b/unshare"
+          "https://myorg.maps.arcgis.com/sharing/rest/content/items/a5b/unshare"
         );
         expect(url).toBe(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/a5b/unshare"
+          "https://myorg.maps.arcgis.com/sharing/rest/content/items/a5b/unshare"
         );
         expect(options.method).toBe("POST");
         expect(response).toEqual(UnsharingResponse);


### PR DESCRIPTION
org admins can indeed use [Share Item (as Group Admin)](https://developers.arcgis.com/rest/users-groups-and-items/share-item-as-group-admin-.htm) to share a public item _outside_ their organization with a private group _inside_ their org.

this is true even if they are not a group member/admin.

AFFECTS PACKAGES:
@esri/arcgis-rest-sharing

ISSUES CLOSED: #454