### PR TITLE
WIP: add a IRequestOptionsBase for fns that don't support rawResponse

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -16,6 +16,7 @@ import * as http from "http";
 import {
   request,
   IRequestOptions,
+  IRequestOptionsBase,
   ArcGISAuthError,
   IAuthenticationManager,
   ITokenRequestOptions,
@@ -662,10 +663,10 @@ export class UserSession implements IAuthenticationManager {
    *   })
    * ```
    *
-   * @param requestOptions - Options for the request. NOTE: `rawResponse` is not supported by this operation.
+   * @param requestOptions - Options for the request.
    * @returns A Promise that will resolve with the data from the response.
    */
-  public getUser(requestOptions?: IRequestOptions): Promise<IUser> {
+  public getUser(requestOptions?: IRequestOptionsBase): Promise<IUser> {
     if (this._user && this._user.username === this.username) {
       return Promise.resolve(this._user);
     } else {

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -32,7 +32,17 @@ export interface IAuthenticationManager {
 /**
  * Options for the `request()` method.
  */
-export interface IRequestOptions {
+export interface IRequestOptions extends IRequestOptionsBase {
+  /**
+   * Return the raw [response](https://developer.mozilla.org/en-US/docs/Web/API/Response)
+   */
+  rawResponse?: boolean;
+}
+
+/**
+ * Base options for the `request()` method. Does not include an option for returning the raw response.
+ */
+export interface IRequestOptionsBase {
   /**
    * Additional parameters to pass in the request.
    */
@@ -42,11 +52,6 @@ export interface IRequestOptions {
    * The HTTP method to send the request with.
    */
   httpMethod?: HTTPMethods;
-
-  /**
-   * Return the raw [response](https://developer.mozilla.org/en-US/docs/Web/API/Response)
-   */
-  rawResponse?: boolean;
 
   /**
    * The instance of `IAuthenticationManager` to use to authenticate this request.


### PR DESCRIPTION
TODO: how to keep rawResponse out of some interfaces that don't extend directly from IRequestOptions

See: https://github.com/Esri/arcgis-rest-js/pull/463#discussion_r257432175
and: https://github.com/Esri/arcgis-rest-js/pull/463#discussion_r257432692