### PR TITLE
Switch polyfill.io to v3

### DIFF
--- a/demos/attachments/index.html
+++ b/demos/attachments/index.html
@@ -4,7 +4,7 @@
 
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
-<script src="https://cdn.polyfill.io/v2/polyfill.js?features=es5,Promise,fetch"></script>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Cfetch%2CPromise"></script>
 
 <div class="container-fluid">
   <div class="row">

--- a/demos/attachments/index.html
+++ b/demos/attachments/index.html
@@ -4,7 +4,7 @@
 
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
-<script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Cfetch%2CPromise"></script>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
 
 <div class="container-fluid">
   <div class="row">

--- a/demos/oauth2-browser-retry/index.html
+++ b/demos/oauth2-browser-retry/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>ArcGIS REST JS Browser OAuth2 - retry</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <script src="https://cdn.polyfill.io/v2/polyfill.js?features=es5,Promise,fetch"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Cfetch%2CPromise"></script>
   </head>
   <body>
     <div id="app-wrapper">

--- a/demos/oauth2-browser-retry/index.html
+++ b/demos/oauth2-browser-retry/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>ArcGIS REST JS Browser OAuth2 - retry</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Cfetch%2CPromise"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
   </head>
   <body>
     <div id="app-wrapper">

--- a/demos/oauth2-browser/index.html
+++ b/demos/oauth2-browser/index.html
@@ -5,7 +5,7 @@
     <title>ArcGIS REST JS Browser OAuth2</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="./style.css">
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Cfetch%2CPromise"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
   </head>
   <body>
     <div id="app-wrapper">

--- a/demos/oauth2-browser/index.html
+++ b/demos/oauth2-browser/index.html
@@ -5,7 +5,7 @@
     <title>ArcGIS REST JS Browser OAuth2</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="./style.css">
-    <script src="https://cdn.polyfill.io/v2/polyfill.js?features=es5,Promise,fetch"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Cfetch%2CPromise"></script>
   </head>
   <body>
     <div id="app-wrapper">

--- a/docs/src/guides/amd-requirejs-dojo.md
+++ b/docs/src/guides/amd-requirejs-dojo.md
@@ -20,7 +20,7 @@ group: 1-get-started
   Open your console to see the demo.
 </body>
   <!-- require polyfills for fetch and Promise from https://polyfill.io -->
-  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=es5,Promise,fetch"></script>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Cfetch%2CPromise"></script>
   <script>
     dojoConfig = {
         paths: {

--- a/docs/src/guides/amd-requirejs-dojo.md
+++ b/docs/src/guides/amd-requirejs-dojo.md
@@ -20,7 +20,7 @@ group: 1-get-started
   Open your console to see the demo.
 </body>
   <!-- require polyfills for fetch and Promise from https://polyfill.io -->
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Cfetch%2CPromise"></script>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
   <script>
     dojoConfig = {
         paths: {

--- a/docs/src/guides/from-a-cdn.md
+++ b/docs/src/guides/from-a-cdn.md
@@ -22,7 +22,7 @@ ArcGIS REST JS is hosted on [unpkg](https://unpkg.com/). You can find URLs for i
   Open your console to see the demo.
 </body>
   <!-- require polyfills for fetch and Promise from https://polyfill.io -->
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Cfetch%2CPromise"></script>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
 
   <!-- require ArcGIS REST JS libraries from https://unpkg.com -->
   <script src="{% cdnUrl data.typedoc | findPackage('@esri/arcgis-rest-request') %}.js"></script>

--- a/docs/src/guides/from-a-cdn.md
+++ b/docs/src/guides/from-a-cdn.md
@@ -22,7 +22,7 @@ ArcGIS REST JS is hosted on [unpkg](https://unpkg.com/). You can find URLs for i
   Open your console to see the demo.
 </body>
   <!-- require polyfills for fetch and Promise from https://polyfill.io -->
-  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=es5,Promise,fetch"></script>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2Cfetch%2CPromise"></script>
 
   <!-- require ArcGIS REST JS libraries from https://unpkg.com -->
   <script src="{% cdnUrl data.typedoc | findPackage('@esri/arcgis-rest-request') %}.js"></script>


### PR DESCRIPTION
polyfill.io v2 is depreciated. And the v2 docs and bundle builder aren't even available anymore. The v2 cdn still works but if a dev wants to add other features or just check out pollyfill.io they'll most likely switch anyway.

The `es5` feature doesn't exist in v3. I believe this what is now the `default` feature.