### PR TITLE
re-export IGeocodeParams (until v2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### @esri/arcgis-rest-geocoder
 
-* Removed
-   * the (unused) `IGeocodeParams` interface has been removed. [`fb2ba9a`](https://github.com/Esri/arcgis-rest-js/commit/fb2ba9ac2ccaf6ed17e02ecb170009b68f638b00) [#459](https://github.com/Esri/arcgis-rest-js/issues/459)
-
 * Fixes
    * remove `magicKey` from `suggest()` [`fb2ba9a`](https://github.com/Esri/arcgis-rest-js/commit/fb2ba9ac2ccaf6ed17e02ecb170009b68f638b00) [#459](https://github.com/Esri/arcgis-rest-js/issues/459)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### @esri/arcgis-rest-geocoder
 
+* Removed
+   * the (unused) `IGeocodeParams` interface has been removed. [`fb2ba9a`](https://github.com/Esri/arcgis-rest-js/commit/fb2ba9ac2ccaf6ed17e02ecb170009b68f638b00) [#459](https://github.com/Esri/arcgis-rest-js/issues/459)
+
 * Fixes
    * remove `magicKey` from `suggest()` [`fb2ba9a`](https://github.com/Esri/arcgis-rest-js/commit/fb2ba9ac2ccaf6ed17e02ecb170009b68f638b00) [#459](https://github.com/Esri/arcgis-rest-js/issues/459)
 

--- a/packages/arcgis-rest-auth/README.md
+++ b/packages/arcgis-rest-auth/README.md
@@ -54,7 +54,7 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ### License
 
-Copyright &copy; 2017-2018 Esri
+Copyright &copy; 2017-2019 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -50,5 +50,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-common-types/README.md
+++ b/packages/arcgis-rest-common-types/README.md
@@ -49,7 +49,7 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ### License
 
-Copyright &copy; 2017-2018 Esri
+Copyright &copy; 2017-2019 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/arcgis-rest-common-types/package.json
+++ b/packages/arcgis-rest-common-types/package.json
@@ -36,5 +36,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-common/package.json
+++ b/packages/arcgis-rest-common/package.json
@@ -37,5 +37,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-feature-service-admin/package.json
+++ b/packages/arcgis-rest-feature-service-admin/package.json
@@ -52,5 +52,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-feature-service/README.md
+++ b/packages/arcgis-rest-feature-service/README.md
@@ -60,7 +60,7 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ### License
 
-Copyright &copy; 2017-2018 Esri
+Copyright &copy; 2017-2019 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -49,5 +49,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-geocoder/README.md
+++ b/packages/arcgis-rest-geocoder/README.md
@@ -70,7 +70,7 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ### License
 
-Copyright &copy; 2017-2018 Esri
+Copyright &copy; 2017-2019 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/arcgis-rest-geocoder/package.json
+++ b/packages/arcgis-rest-geocoder/package.json
@@ -51,5 +51,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-geocoder/src/geocode.ts
+++ b/packages/arcgis-rest-geocoder/src/geocode.ts
@@ -4,7 +4,8 @@
 import {
   request,
   appendCustomParams,
-  cleanUrl
+  cleanUrl,
+  IParams
 } from "@esri/arcgis-rest-request";
 
 import {
@@ -14,6 +15,24 @@ import {
 } from "@esri/arcgis-rest-common-types";
 
 import { worldGeocoder, IEndpointRequestOptions } from "./helpers";
+
+// unused, will be removed in v2.0.0
+export interface IGeocodeParams extends IParams {
+  /**
+   * You can create an autocomplete experience by making a call to suggest with partial text and then passing through the magicKey and complete address that are returned to geocode.
+   * ```js
+   * import { suggest, geocode } from '@esri/arcgis-rest-geocoder';
+   * suggest("LAX")
+   *   .then((response) => {
+   *     geocode({
+   *       singleLine: response.suggestions[1].text,
+   *       magicKey: response.suggestions[0].magicKey
+   *     })
+   *   })
+   * ```
+   */
+  magicKey?: string;
+}
 
 export interface IGeocodeRequestOptions extends IEndpointRequestOptions {
   /**

--- a/packages/arcgis-rest-groups/README.md
+++ b/packages/arcgis-rest-groups/README.md
@@ -54,7 +54,7 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ### License
 
-Copyright &copy; 2017-2018 Esri
+Copyright &copy; 2017-2019 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/arcgis-rest-groups/package.json
+++ b/packages/arcgis-rest-groups/package.json
@@ -51,5 +51,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-items/README.md
+++ b/packages/arcgis-rest-items/README.md
@@ -56,7 +56,7 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ### License
 
-Copyright &copy; 2017-2018 Esri
+Copyright &copy; 2017-2019 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/arcgis-rest-items/package.json
+++ b/packages/arcgis-rest-items/package.json
@@ -51,5 +51,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-request/README.md
+++ b/packages/arcgis-rest-request/README.md
@@ -55,7 +55,7 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ### License
 
-Copyright &copy; 2017-2018 Esri
+Copyright &copy; 2017-2019 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -41,5 +41,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-routing/package.json
+++ b/packages/arcgis-rest-routing/package.json
@@ -50,5 +50,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-sharing/package.json
+++ b/packages/arcgis-rest-sharing/package.json
@@ -56,5 +56,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }

--- a/packages/arcgis-rest-users/package.json
+++ b/packages/arcgis-rest-users/package.json
@@ -50,5 +50,13 @@
   "bugs": {
     "url": "https://github.com/Esri/arcgis-rest-js/issues"
   },
-  "homepage": "https://github.com/Esri/arcgis-rest-js#readme"
+  "homepage": "https://github.com/Esri/arcgis-rest-js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ]
 }


### PR DESCRIPTION
@skitterm aptly pointed out that i removed `IGeocodeParams` in `v1.17.0`.

https://github.com/Esri/arcgis-rest-js/commit/fb2ba9ac2ccaf6ed17e02ecb170009b68f638b00#diff-094efe5f622403522c0543b08434e397

just because we weren't actually utilizing the interface in any of the geocoding methods doesn't mean other developers weren't using it.

whoops!

this PR just adds a note to the CHANGELOG as breadcrumb. while i was in there i bumped the copyright year and added keywords to our package.json files to fix this 😢 	

![screenshot 2019-02-25 16 21 18](https://user-images.githubusercontent.com/3011734/53378137-6a2fe480-3919-11e9-972f-ffeeb2a0ff34.png)
