### PR TITLE
fix: ensure an empty array request parameter is stringified and passed through

### DIFF
--- a/packages/arcgis-rest-request/src/utils/process-params.ts
+++ b/packages/arcgis-rest-request/src/utils/process-params.ts
@@ -65,12 +65,12 @@ export function processParams(params: any): any {
     // null, undefined, function are excluded. If you want to send an empty key you need to send an empty string "".
     switch (type) {
       case "Array":
-        // Based on the first element of the array, classify array as an array of objects to be stringified
-        // or an array of non-objects to be comma-separated
+        // classify array as empty or use the first element to determine whether it contains objects to be stringified or non-objects to be comma-separated
         value =
-          param[0] &&
-          param[0].constructor &&
-          param[0].constructor.name === "Object"
+          param.length === 0 ||
+          (param[0] &&
+            param[0].constructor &&
+            param[0].constructor.name === "Object")
             ? JSON.stringify(param)
             : param.join(",");
         break;

--- a/packages/arcgis-rest-request/test/utils/process-params.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-params.test.ts
@@ -94,15 +94,17 @@ describe("processParams", () => {
     expect(processParams(params)).toEqual(expected);
   });
 
-  it("should exclude null and undefined, but not a zero", () => {
+  it("should exclude null and undefined, but not a zero or an empty array", () => {
     const params: any = {
       foo: null,
       bar: undefined,
-      baz: 0
+      baz: 0,
+      qux: []
     };
 
     const expected = {
-      baz: 0
+      baz: 0,
+      qux: "[]"
     };
 
     expect(processParams(params)).toEqual(expected);


### PR DESCRIPTION
i'm working on a [web component](https://github.com/esridc/hub-components) that updates user tags and noticed this afternoon that we currently don't pass a value at all when an empty array is provided as a request parameter.

```ts
request(updateUserUrl, {
  params: { tags: [] }, 
  authentication
});
```
![no tags](https://user-images.githubusercontent.com/3011734/53601026-f895a780-3b5f-11e9-9587-e6980d0ad621.png)

ArcGIS Online's (understandable) reaction to this call is to make _no_ edits to the user's current tags, when in actuality I want to remove them all.

AFFECTS PACKAGES:
@esri/arcgis-rest-request