### PR TITLE
fix: deprecate serializeGroup() and simplify SerializeItem()

### DIFF
--- a/packages/arcgis-rest-groups/src/create.ts
+++ b/packages/arcgis-rest-groups/src/create.ts
@@ -7,9 +7,9 @@ import {
   getPortalUrl
 } from "@esri/arcgis-rest-request";
 
-import { IGroupAdd } from "@esri/arcgis-rest-common-types";
+import { IGroupAdd, IGroup } from "@esri/arcgis-rest-common-types";
 
-import { serializeGroup } from "./helpers";
+// import { serializeGroup } from "./helpers";
 
 export interface IGroupAddRequestOptions extends IRequestOptions {
   group: IGroupAdd;
@@ -36,12 +36,12 @@ export interface IGroupAddRequestOptions extends IRequestOptions {
  */
 export function createGroup(
   requestOptions: IGroupAddRequestOptions
-): Promise<any> {
+): Promise<{ success: boolean; group: IGroup }> {
   const url = `${getPortalUrl(requestOptions)}/community/createGroup`;
   const options: IGroupAddRequestOptions = {
     ...requestOptions
   };
-  // serialize the group into something Portal will accept
-  options.params = serializeGroup(requestOptions.group);
+
+  options.params = requestOptions.group;
   return request(url, options);
 }

--- a/packages/arcgis-rest-groups/src/create.ts
+++ b/packages/arcgis-rest-groups/src/create.ts
@@ -36,10 +36,11 @@ export function createGroup(
   requestOptions: IGroupAddRequestOptions
 ): Promise<{ success: boolean; group: IGroup }> {
   const url = `${getPortalUrl(requestOptions)}/community/createGroup`;
-  const options: IGroupAddRequestOptions = {
-    ...requestOptions
+
+  requestOptions.params = {
+    ...requestOptions.params,
+    ...requestOptions.group
   };
 
-  options.params = requestOptions.group;
-  return request(url, options);
+  return request(url, requestOptions);
 }

--- a/packages/arcgis-rest-groups/src/create.ts
+++ b/packages/arcgis-rest-groups/src/create.ts
@@ -9,8 +9,6 @@ import {
 
 import { IGroupAdd, IGroup } from "@esri/arcgis-rest-common-types";
 
-// import { serializeGroup } from "./helpers";
-
 export interface IGroupAddRequestOptions extends IRequestOptions {
   group: IGroupAdd;
 }

--- a/packages/arcgis-rest-groups/src/helpers.ts
+++ b/packages/arcgis-rest-groups/src/helpers.ts
@@ -10,20 +10,16 @@ export interface IGroupIdRequestOptions extends IRequestOptions {
 }
 
 /**
- * Serialize a group into a json format accepted by the Portal API
+ * (Deprecated) Serialize a group into a json format accepted by the Portal API
  * for create and update operations.
- *
- * Deprecated. Will be removed in v2.0.0.
  *
  * @param group IGroup to be serialized
  * @returns a formatted JSON object to be sent to Portal
  * @private
  */
-/* istanbul ignore next - deprecated method */
+/* istanbul ignore next */
 export function serializeGroup(group: IGroupAdd | IItemUpdate | IGroup): any {
-  // create a clone so we're not messing with the original
   const clone = JSON.parse(JSON.stringify(group));
-  // join and tags...
   const { tags = [] } = group;
   clone.tags = tags.join(", ");
   return clone;

--- a/packages/arcgis-rest-groups/src/helpers.ts
+++ b/packages/arcgis-rest-groups/src/helpers.ts
@@ -11,12 +11,15 @@ export interface IGroupIdRequestOptions extends IRequestOptions {
 
 /**
  * Serialize a group into a json format accepted by the Portal API
- * for create and update operations
+ * for create and update operations.
+ *
+ * Deprecated. Will be removed in v2.0.0.
  *
  * @param group IGroup to be serialized
  * @returns a formatted JSON object to be sent to Portal
  * @private
  */
+/* istanbul ignore next - deprecated method */
 export function serializeGroup(group: IGroupAdd | IItemUpdate | IGroup): any {
   // create a clone so we're not messing with the original
   const clone = JSON.parse(JSON.stringify(group));

--- a/packages/arcgis-rest-groups/src/update.ts
+++ b/packages/arcgis-rest-groups/src/update.ts
@@ -9,8 +9,6 @@ import {
 
 import { IItemUpdate } from "@esri/arcgis-rest-common-types";
 
-import { serializeGroup } from "./helpers";
-
 export interface IGroupUpdateRequestOptions extends IRequestOptions {
   group: IItemUpdate;
 }
@@ -31,7 +29,7 @@ export interface IGroupUpdateRequestOptions extends IRequestOptions {
  */
 export function updateGroup(
   requestOptions: IGroupUpdateRequestOptions
-): Promise<any> {
+): Promise<{ success: boolean; groupId: string }> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.group.id
   }/update`;
@@ -39,7 +37,7 @@ export function updateGroup(
   const options: IGroupUpdateRequestOptions = {
     ...requestOptions
   };
-  // serialize the group into something Portal will accept
-  options.params = serializeGroup(requestOptions.group);
+
+  options.params = requestOptions.group;
   return request(url, options);
 }

--- a/packages/arcgis-rest-groups/src/update.ts
+++ b/packages/arcgis-rest-groups/src/update.ts
@@ -34,10 +34,10 @@ export function updateGroup(
     requestOptions.group.id
   }/update`;
 
-  const options: IGroupUpdateRequestOptions = {
-    ...requestOptions
+  requestOptions.params = {
+    ...requestOptions.params,
+    ...requestOptions.group
   };
 
-  options.params = requestOptions.group;
-  return request(url, options);
+  return request(url, requestOptions);
 }

--- a/packages/arcgis-rest-groups/test/crud.test.ts
+++ b/packages/arcgis-rest-groups/test/crud.test.ts
@@ -46,7 +46,7 @@ describe("groups", () => {
           expect(options.body).toContain(encodeParam("token", "fake-token"));
           expect(options.body).toContain(encodeParam("owner", "fakeUser"));
           // ensure the array props are serialized into strings
-          expect(options.body).toContain(encodeParam("tags", "foo, bar"));
+          expect(options.body).toContain(encodeParam("tags", "foo,bar"));
           expect(options.body).toContain(encodeParam("access", "public"));
           done();
         })
@@ -103,7 +103,7 @@ describe("groups", () => {
           expect(options.body).toContain(encodeParam("token", "fake-token"));
           expect(options.body).toContain(encodeParam("owner", "fakeUser"));
           // ensure the array props are serialized into strings
-          expect(options.body).toContain(encodeParam("tags", "foo, bar"));
+          expect(options.body).toContain(encodeParam("tags", "foo,bar"));
           done();
         })
         .catch(e => {

--- a/packages/arcgis-rest-groups/test/crud.test.ts
+++ b/packages/arcgis-rest-groups/test/crud.test.ts
@@ -111,6 +111,42 @@ describe("groups", () => {
         });
     });
 
+    it("should update a group with a custom param", done => {
+      fetchMock.once("*", GroupEditResponse);
+      const fakeGroup = {
+        id: "5bc",
+        title: "fake group",
+        owner: "fakeUser",
+        tags: ["foo", "bar"],
+        description: "my fake group"
+      };
+      updateGroup({
+        group: fakeGroup,
+        authentication: MOCK_AUTH,
+        params: {
+          clearEmptyFields: true
+        }
+      })
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/update"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain(encodeParam("f", "json"));
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          expect(options.body).toContain(encodeParam("owner", "fakeUser"));
+          // ensure the array props are serialized into strings
+          expect(options.body).toContain(encodeParam("tags", "foo,bar"));
+          expect(options.body).toContain(encodeParam("clearEmptyFields", true));
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
     it("should remove a group", done => {
       fetchMock.once("*", GroupEditResponse);
 

--- a/packages/arcgis-rest-items/src/helpers.ts
+++ b/packages/arcgis-rest-items/src/helpers.ts
@@ -33,25 +33,26 @@ export interface IFolderIdRequestOptions extends IUserRequestOptions {
   owner?: string;
 }
 
-export type ItemRelationshipType = "Map2Service" |
-"WMA2Code" |
-"Map2FeatureCollection" |
-"MobileApp2Code" |
-"Service2Data" |
-"Service2Service" |
-"Map2AppConfig" |
-"Item2Attachment" |
-"Item2Report" |
-"Listed2Provisioned" |
-"Style2Style" |
-"Service2Style" |
-"Survey2Service" |
-"Survey2Data" |
-"Service2Route" |
-"Area2Package" |
-"Map2Area" |
-"Service2Layer" |
-"Area2CustomPackage";
+export type ItemRelationshipType =
+  | "Map2Service"
+  | "WMA2Code"
+  | "Map2FeatureCollection"
+  | "MobileApp2Code"
+  | "Service2Data"
+  | "Service2Service"
+  | "Map2AppConfig"
+  | "Item2Attachment"
+  | "Item2Report"
+  | "Listed2Provisioned"
+  | "Style2Style"
+  | "Service2Style"
+  | "Survey2Service"
+  | "Survey2Data"
+  | "Service2Route"
+  | "Area2Package"
+  | "Map2Area"
+  | "Service2Layer"
+  | "Area2CustomPackage";
 
 export interface IItemRelationshipRequestOptions extends IRequestOptions {
   /**
@@ -61,14 +62,15 @@ export interface IItemRelationshipRequestOptions extends IRequestOptions {
   /**
    * The type of relationship between the two items.
    */
-  relationshipType: ItemRelationshipType | ItemRelationshipType[]
+  relationshipType: ItemRelationshipType | ItemRelationshipType[];
   /**
    * The direction of the relationship. Either forward (from origin -> destination) or reverse (from destination -> origin).
    */
   direction?: "forward" | "reverse";
 }
 
-export interface IManageItemRelationshipRequestOptions extends IUserRequestOptions {
+export interface IManageItemRelationshipRequestOptions
+  extends IUserRequestOptions {
   originItemId: string;
   destinationItemId: string;
   relationshipType: ItemRelationshipType;
@@ -159,8 +161,7 @@ export interface IItemMoveResponse {
 }
 
 /**
- * Serialize an item into a json format accepted by the Portal API
- * for create and update operations
+ * Serialize an item and its data into a json format accepted by the Portal API for create and update operations
  *
  * @param item Item to be serialized
  * @returns a formatted json object to be sent to Portal
@@ -168,19 +169,13 @@ export interface IItemMoveResponse {
 export function serializeItem(item: IItemAdd | IItemUpdate | IItem): any {
   // create a clone so we're not messing with the original
   const clone = JSON.parse(JSON.stringify(item));
-  // join keywords and tags...
-  const { typeKeywords = [], tags = [] } = item;
-  clone.typeKeywords = typeKeywords.join(", ");
-  clone.tags = tags.join(", ");
+
   // convert .data to .text
   if (clone.data) {
     clone.text = JSON.stringify(clone.data);
     delete clone.data;
   }
-  // Convert properties to a string
-  if (clone.properties) {
-    clone.properties = JSON.stringify(clone.properties);
-  }
+
   return clone;
 }
 

--- a/packages/arcgis-rest-items/test/create.test.ts
+++ b/packages/arcgis-rest-items/test/create.test.ts
@@ -69,10 +69,10 @@ describe("search", () => {
           expect(options.body).toContain("owner=dbouwman");
           // ensure the array props are serialized into strings
           expect(options.body).toContain(
-            encodeParam("typeKeywords", "fake, kwds")
+            encodeParam("typeKeywords", "fake,kwds")
           );
           expect(options.body).toContain(
-            encodeParam("tags", "fakey, mcfakepants")
+            encodeParam("tags", "fakey,mcfakepants")
           );
           expect(options.body).toContain(
             encodeParam("properties", JSON.stringify(fakeItem.properties))
@@ -115,10 +115,10 @@ describe("search", () => {
           expect(options.body).toContain("owner=dbouwman");
           // ensure the array props are serialized into strings
           expect(options.body).toContain(
-            encodeParam("typeKeywords", "fake, kwds")
+            encodeParam("typeKeywords", "fake,kwds")
           );
           expect(options.body).toContain(
-            encodeParam("tags", "fakey, mcfakepants")
+            encodeParam("tags", "fakey,mcfakepants")
           );
           expect(options.body).toContain(
             encodeParam("properties", JSON.stringify(fakeItem.properties))
@@ -161,10 +161,10 @@ describe("search", () => {
           // expect(options.body).toContain("owner=casey");
           // ensure the array props are serialized into strings
           expect(options.body).toContain(
-            encodeParam("typeKeywords", "fake, kwds")
+            encodeParam("typeKeywords", "fake,kwds")
           );
           expect(options.body).toContain(
-            encodeParam("tags", "fakey, mcfakepants")
+            encodeParam("tags", "fakey,mcfakepants")
           );
           expect(options.body).toContain(
             encodeParam("properties", JSON.stringify(fakeItem.properties))
@@ -245,10 +245,10 @@ describe("search", () => {
           expect(options.body).toContain("owner=dbouwman");
           // ensure the array props are serialized into strings
           expect(options.body).toContain(
-            encodeParam("typeKeywords", "fake, kwds")
+            encodeParam("typeKeywords", "fake,kwds")
           );
           expect(options.body).toContain(
-            encodeParam("tags", "fakey, mcfakepants")
+            encodeParam("tags", "fakey,mcfakepants")
           );
           done();
         })
@@ -290,10 +290,10 @@ describe("search", () => {
           expect(options.body).toContain("foo=bar");
           // ensure the array props are serialized into strings
           expect(options.body).toContain(
-            encodeParam("typeKeywords", "fake, kwds")
+            encodeParam("typeKeywords", "fake,kwds")
           );
           expect(options.body).toContain(
-            encodeParam("tags", "fakey, mcfakepants")
+            encodeParam("tags", "fakey,mcfakepants")
           );
           done();
         })
@@ -329,10 +329,10 @@ describe("search", () => {
           expect(options.body).toContain("owner=casey");
           // ensure the array props are serialized into strings
           expect(options.body).toContain(
-            encodeParam("typeKeywords", "fake, kwds")
+            encodeParam("typeKeywords", "fake,kwds")
           );
           expect(options.body).toContain(
-            encodeParam("tags", "fakey, mcfakepants")
+            encodeParam("tags", "fakey,mcfakepants")
           );
           done();
         })

--- a/packages/arcgis-rest-items/test/update.test.ts
+++ b/packages/arcgis-rest-items/test/update.test.ts
@@ -70,10 +70,10 @@ describe("search", () => {
           expect(options.body).toContain(encodeParam("owner", "dbouwman"));
           // ensure the array props are serialized into strings
           expect(options.body).toContain(
-            encodeParam("typeKeywords", "fake, kwds")
+            encodeParam("typeKeywords", "fake,kwds")
           );
           expect(options.body).toContain(
-            encodeParam("tags", "fakey, mcfakepants")
+            encodeParam("tags", "fakey,mcfakepants")
           );
           expect(options.body).toContain(
             encodeParam("text", JSON.stringify(fakeItem.data))
@@ -135,10 +135,10 @@ describe("search", () => {
           );
           // ensure the array props are serialized into strings
           expect(options.body).toContain(
-            encodeParam("typeKeywords", "fake, kwds")
+            encodeParam("typeKeywords", "fake,kwds")
           );
           expect(options.body).toContain(
-            encodeParam("tags", "fakey, mcfakepants")
+            encodeParam("tags", "fakey,mcfakepants")
           );
           expect(options.body).toContain(
             encodeParam("text", JSON.stringify(fakeItem.data))

--- a/packages/arcgis-rest-items/test/update.test.ts
+++ b/packages/arcgis-rest-items/test/update.test.ts
@@ -85,6 +85,61 @@ describe("search", () => {
         });
     });
 
+    it("should update an item with custom params", done => {
+      fetchMock.once("*", ItemSuccessResponse);
+      const fakeItem = {
+        id: "5bc",
+        owner: "dbouwman",
+        title: "my fake item",
+        description: "yep its fake",
+        snipped: "so very fake",
+        type: "Web Mapping Application",
+        typeKeywords: ["fake", "kwds"],
+        tags: ["fakey", "mcfakepants"],
+        properties: {
+          key: "somevalue"
+        },
+        data: {
+          values: {
+            key: "value"
+          }
+        }
+      };
+      updateItem({
+        item: fakeItem,
+        authentication: MOCK_USER_SESSION,
+        params: {
+          clearEmptyFields: true
+        }
+      })
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/5bc/update"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain(encodeParam("f", "json"));
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          expect(options.body).toContain(encodeParam("owner", "dbouwman"));
+          // ensure the array props are serialized into strings
+          expect(options.body).toContain(
+            encodeParam("typeKeywords", "fake,kwds")
+          );
+          expect(options.body).toContain(
+            encodeParam("tags", "fakey,mcfakepants")
+          );
+          expect(options.body).toContain(
+            encodeParam("text", JSON.stringify(fakeItem.data))
+          );
+          expect(options.body).toContain(encodeParam("clearEmptyFields", true));
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
     it("should update an item, including data and service proxy params", done => {
       fetchMock.once("*", ItemSuccessResponse);
       const fakeItem = {


### PR DESCRIPTION
it dawned on me when i submitted #474 that the custom logic we have for serializing groups and items isn't even needed.

the only thing going on in there thats worth keeping is stuffing `item.data` into a `text` parameter.

AFFECTS PACKAGES:
@esri/arcgis-rest-groups
@esri/arcgis-rest-items