### PR TITLE
docs: resolve inline redirect sample error

### DIFF
--- a/demos/oauth2-browser-retry/authenticate.html
+++ b/demos/oauth2-browser-retry/authenticate.html
@@ -5,6 +5,7 @@
     <title>ArcGIS Rest JS Vanilla JS - redirect</title>
   </head>
   <body>
+    <script src="node_modules/@esri/arcgis-rest-request/dist/umd/request.umd.js"></script>
     <script src="https://unpkg.com/@esri/arcgis-rest-auth"></script>
     <script>
       // arcgis-rest-js ensures the clientId is associated with the state parameter by default.

--- a/demos/oauth2-browser/authenticate.html
+++ b/demos/oauth2-browser/authenticate.html
@@ -5,6 +5,7 @@
     <title>ArcGIS Rest JS OAuth redirect</title>
   </head>
   <body>
+    <script src="node_modules/@esri/arcgis-rest-request/dist/umd/request.umd.js"></script>
     <script src="node_modules/@esri/arcgis-rest-auth/dist/umd/auth.umd.js"></script>
     <script>
       /* in a production app, clientId could be hardcoded. here we're using a regex to extract it from the state parameter in the OAuth2 server response to make the demo more interchangeable.


### PR DESCRIPTION
an astute developer from the Netherlands pointed out this morning that our browser OAuth demo throws an error when you choose an inline redirect.

this was because the `cleanUrl()` utility function lives inside the request package.

![clean_url](https://user-images.githubusercontent.com/3011734/53983869-fc2fae00-40cc-11e9-81b8-3a0f40797a0a.png)

AFFECTS PACKAGES:
@esri/arcgis-rest-demo-vanilla