### PR TITLE
fix(routing): Fix switched x and y

### DIFF
--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -149,8 +149,10 @@ export type SpatialRelationship =
 export interface IExtent {
   xmin: number;
   ymin: number;
+  zmin?: number;
   xmax: number;
   ymax: number;
+  zmax?: number;
   spatialReference?: ISpatialReference;
 }
 
@@ -272,6 +274,7 @@ export interface IPictureMarkerSymbol extends IMarkerSymbol, IPictureSourced {
 export interface IPoint extends IHasZM, IGeometry {
   x: number;
   y: number;
+  z?: number;
 }
 
 /**

--- a/packages/arcgis-rest-common/src/types/geometry.ts
+++ b/packages/arcgis-rest-common/src/types/geometry.ts
@@ -34,6 +34,7 @@ export interface IGeometry {
 export interface IPoint extends IHasZM, IGeometry {
   x: number;
   y: number;
+  z?: number;
 }
 
 /**
@@ -44,4 +45,5 @@ export interface ILocation {
   longitude?: number;
   lat?: number;
   long?: number;
+  z?: number;
 }

--- a/packages/arcgis-rest-common/src/util/location.ts
+++ b/packages/arcgis-rest-common/src/util/location.ts
@@ -4,13 +4,16 @@
 import { IPoint, ILocation } from "../types/geometry";
 
 export function isLocationArray(
-  coords: ILocation | IPoint | [number, number]
-): coords is [number, number] {
-  return (coords as [number, number]).length === 2;
+  coords: ILocation | IPoint | [number, number] | [number, number, number]
+): coords is [number, number] | [number, number, number] {
+  return (
+    (coords as [number, number]).length === 2 ||
+    (coords as [number, number, number]).length === 3
+  );
 }
 
 export function isLocation(
-  coords: ILocation | IPoint | [number, number]
+  coords: ILocation | IPoint | [number, number] | [number, number, number]
 ): coords is ILocation {
   return (
     (coords as ILocation).latitude !== undefined ||

--- a/packages/arcgis-rest-common/test/location.test.ts
+++ b/packages/arcgis-rest-common/test/location.test.ts
@@ -11,6 +11,11 @@ const stops: Array<[number, number]> = [
   [-117.918976, 33.812092]
 ];
 
+const stops3: Array<[number, number, number]> = [
+  [-117.195677, 34.056383, 10.11],
+  [-117.918976, 33.812092, 8.43]
+];
+
 const stopsObjectsLatLong: ILocation[] = [
   {
     lat: 34.056383,
@@ -19,6 +24,19 @@ const stopsObjectsLatLong: ILocation[] = [
   {
     lat: 33.812092,
     long: -117.918976
+  }
+];
+
+const stopsObjectsLatLong3: ILocation[] = [
+  {
+    lat: 34.056383,
+    long: -117.195677,
+    z: 10.11
+  },
+  {
+    lat: 33.812092,
+    long: -117.918976,
+    z: 8.43
   }
 ];
 
@@ -33,6 +51,19 @@ const stopsObjectsLatitudeLongitude: ILocation[] = [
   }
 ];
 
+const stopsObjectsLatitudeLongitude3: ILocation[] = [
+  {
+    latitude: 34.056383,
+    longitude: -117.195677,
+    z: 10.11
+  },
+  {
+    latitude: 33.812092,
+    longitude: -117.918976,
+    z: 8.43
+  }
+];
+
 const stopsObjectsPoint: IPoint[] = [
   {
     x: 34.056383,
@@ -44,13 +75,36 @@ const stopsObjectsPoint: IPoint[] = [
   }
 ];
 
+const stopsObjectsPoint3: IPoint[] = [
+  {
+    x: 34.056383,
+    y: -117.195677,
+    z: 10.11
+  },
+  {
+    x: 33.812092,
+    y: -117.918976,
+    z: 8.43
+  }
+];
+
 describe("location helpers", () => {
   it("should recognize a shorthand location", done => {
     expect(isLocation(stopsObjectsLatLong[0])).toEqual(true);
     done();
   });
 
+  it("should recognize a shorthand 3d location", done => {
+    expect(isLocation(stopsObjectsLatLong3[0])).toEqual(true);
+    done();
+  });
+
   it("should recognize a spelled out location", done => {
+    expect(isLocation(stopsObjectsLatitudeLongitude[0])).toEqual(true);
+    done();
+  });
+
+  it("should recognize a spelled out 3d location", done => {
     expect(isLocation(stopsObjectsLatitudeLongitude[0])).toEqual(true);
     done();
   });
@@ -60,14 +114,30 @@ describe("location helpers", () => {
     done();
   });
 
+  it("should recognize that a 3d point is not a location", done => {
+    expect(isLocation(stopsObjectsPoint3[0])).toEqual(false);
+    done();
+  });
+
   it("should recognize that raw coordinates are not a location", done => {
     expect(isLocation(stops[0])).toEqual(false);
+    done();
+  });
+
+  it("should recognize that raw 3d coordinates are not a location", done => {
+    expect(isLocation(stops3[0])).toEqual(false);
     done();
   });
 
   it("should recognize a location array", done => {
     expect(isLocationArray(stops[0])).toEqual(true);
     expect(isLocationArray(stops[1])).toEqual(true);
+    done();
+  });
+
+  it("should recognize a 3d location array", done => {
+    expect(isLocationArray(stops3[0])).toEqual(true);
+    expect(isLocationArray(stops3[1])).toEqual(true);
     done();
   });
 });

--- a/packages/arcgis-rest-routing/src/solveRoute.ts
+++ b/packages/arcgis-rest-routing/src/solveRoute.ts
@@ -85,7 +85,7 @@ export function solveRoute(
         return coords.longitude + "," + coords.latitude;
       }
     } else {
-      return coords.y + "," + coords.x;
+      return coords.x + "," + coords.y;
     }
   });
   options.params.stops = stops.join(";");

--- a/packages/arcgis-rest-routing/test/solveRoute.test.ts
+++ b/packages/arcgis-rest-routing/test/solveRoute.test.ts
@@ -38,12 +38,12 @@ const stopsObjectsLatitudeLongitude: ILocation[] = [
 
 const stopsObjectsPoint: IPoint[] = [
   {
-    x: 34.056383,
-    y: -117.195677
+    x: -117.195677,
+    y: 34.056383
   },
   {
-    x: 33.812092,
-    y: -117.918976
+    x: -117.918976,
+    y: 33.812092
   }
 ];
 


### PR DESCRIPTION
Fix switched x and y for point in solveRoute.
When providing point object with x,y, solveRoute switch their order to y,x.
The test case also had the switch.
To clarify the issue, x == long and y == latitude