### PR TITLE
chore: miscellaneous doc improvements

### DIFF
--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -261,7 +261,7 @@
       {{ @propertyTableForId(id, "Available <code>requestOptions</code>", "Property", "Type")}}
     {% endif %}
 
-    {% if param.name == "requestOptions" and param.type.id %}
+    {% if param.name == "requestOptions" and param.type.type !== "reference" and param.type.id %}
       {{ @propertyTableForId(param.type.id, "Options", "Property", "Type")}}
     {% endif %}
   {% endfor %}

--- a/docs/src/api/_layout.html
+++ b/docs/src/api/_layout.html
@@ -25,7 +25,7 @@
             <button id="trigger{{loop.index}}" class="btn btn-transparent api-toggle-button">
               <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M7 4h5l12 12-12 12H7l12-12L7 4z"/></svg>
             </button>
-            {% link package.pageUrl, package.pkg.name, class="tsd-kind-icon" %}
+            {% link package.pageUrl, package.pkg.name.replace("@esri/arcgis-rest-",""), class="tsd-kind-icon" %}
             <ul id="list{{loop.index}}" class="api-package-content-list">
             {% for declaration in package.declarations %}
               <li class="{{ declaration.icon }} padding-left-1 padding-right-1 visually-hidden">{% link declaration.pageUrl, declaration.name, class="tsd-kind-icon padding-right-1" %}</li>

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -112,11 +112,6 @@ export interface IOauth2Options {
   refreshTokenTTL?: number;
 
   /**
-   * An unfederated ArcGIS Server instance that recognizes the supplied credentials.
-   */
-  server?: string;
-
-  /**
    * The locale assumed to render the login page.
    *
    * @browserOnly
@@ -204,7 +199,14 @@ export interface IUserSessionOptions {
   refreshTokenTTL?: number;
 
   /**
-   * An unfederated ArcGIS Server instance that recognizes the supplied credentials.
+   * An unfederated ArcGIS Server instance known to recognize credentials supplied manually.
+   * ```js
+   * {
+   *   server: "https://sampleserver6.arcgisonline.com/arcgis",
+   *   token: "SOSlV3v..",
+   *   tokenExpires: new Date(1545415669763)
+   * }
+   * ```
    */
   server?: string;
 }
@@ -213,16 +215,18 @@ export interface IUserSessionOptions {
  * ```js
  * import { UserSession } from '@esri/arcgis-rest-auth';
  * UserSession.beginOAuth2({
- *   // register a new app to create a unique clientId
+ *   // register an app of your own to create a unique clientId
  *   clientId: "abc123",
  *   redirectUri: 'https://yourapp.com/authenticate.html'
  * })
  *   .then(session)
  * // or
- * const session = new UserSession({
+ * new UserSession({
  *   username: "jsmith",
  *   password: "123456"
  * })
+ * // or
+ * UserSession.deserialize(cache)
  * ```
  * Used to authenticate both ArcGIS Online and ArcGIS Enterprise users. `UserSession` includes helper methods for [OAuth 2.0](/arcgis-rest-js/guides/browser-authentication/) in both browser and server applications.
  */
@@ -540,7 +544,14 @@ export class UserSession implements IAuthenticationManager {
   public readonly refreshTokenTTL: number;
 
   /**
-   * An unfederated ArcGIS Server instance that recognizes the supplied credentials.
+   * An unfederated ArcGIS Server instance known to recognize credentials supplied manually.
+   * ```js
+   * {
+   *   server: "https://sampleserver6.arcgisonline.com/arcgis",
+   *   token: "SOSlV3v..",
+   *   tokenExpires: new Date(1545415669763)
+   * }
+   * ```
    */
   public readonly server: string;
 


### PR DESCRIPTION
1. remove the redundant text from the API reference TOC
![toc](https://user-images.githubusercontent.com/3011734/54389465-5bf20000-465d-11e9-847b-8165f4d19066.png)
2. add code snippets to show how to rehydrate a UserSession and make use of its `server` constructor option less opaque.
3. remove the duplicate options tables.
4. remove `server` from [`IOauth2Options`](https://esri.github.io/arcgis-rest-js/api/auth/IOauth2Options/) entirely. i don't _think_ this is a breaking change because it is a nonsensical parameter for that interface that we weren't doing anything with.
