### PR TITLE
add new getUserUrl() method to auth package

### DIFF
--- a/packages/arcgis-rest-auth/src/get-user-url.ts
+++ b/packages/arcgis-rest-auth/src/get-user-url.ts
@@ -1,0 +1,17 @@
+/* Copyright (c) 2019 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { getPortalUrl } from "@esri/arcgis-rest-request";
+import { UserSession } from "./UserSession";
+
+/**
+ * Helper that returns the [user](https://developers.arcgis.com/rest/users-groups-and-items/user.htm) for a given portal.
+ *
+ * @param session
+ * @returns User url to be used in API requests.
+ */
+export function getUserUrl(session: UserSession): string {
+  return `${getPortalUrl(session)}/community/users/${encodeURIComponent(
+    session.username
+  )}`;
+}

--- a/packages/arcgis-rest-auth/src/index.ts
+++ b/packages/arcgis-rest-auth/src/index.ts
@@ -6,3 +6,4 @@ export * from "./UserSession";
 export * from "./fetch-token";
 export * from "./generate-token";
 export * from "./authenticated-request-options";
+export * from "./get-user-url";

--- a/packages/arcgis-rest-auth/test/getUserUrl.test.ts
+++ b/packages/arcgis-rest-auth/test/getUserUrl.test.ts
@@ -1,0 +1,38 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { UserSession, getUserUrl } from "../src/index";
+
+describe("getUserUrl", () => {
+  it("should encode special characters", () => {
+    const session = new UserSession({
+      username: "c@sey"
+    });
+
+    expect(getUserUrl(session)).toEqual(
+      "https://www.arcgis.com/sharing/rest/community/users/c%40sey"
+    );
+  });
+
+  it("should recognize an explicit ArcGIS Online organization", () => {
+    const session = new UserSession({
+      username: "c@sey",
+      portal: "https://custom.maps.arcgis.com/sharing/rest"
+    });
+
+    expect(getUserUrl(session)).toEqual(
+      "https://custom.maps.arcgis.com/sharing/rest/community/users/c%40sey"
+    );
+  });
+
+  it("should recognize ArcGIS Enterprise", () => {
+    const session = new UserSession({
+      username: "c@sey",
+      portal: "https://gis.city.gov/sharing/rest"
+    });
+
+    expect(getUserUrl(session)).toEqual(
+      "https://gis.city.gov/sharing/rest/community/users/c%40sey"
+    );
+  });
+});


### PR DESCRIPTION
when @tomwayson suggested this initially in https://github.com/Esri/hub.js/pull/144/files#r266006506 i should have known that he likely already considered the circular dependency my own idea would have involved.

this is of course a **perfect** opportunity to use an arrow function, but doing it that way causes two descriptions to be rendered in our doc for some reason.

```ts
export const getUserUrl = (session:UserSession) => `${getPortalUrl(session)}/community/users/${encodeURIComponent(session.username)}`;
```

![Screenshot 2019-03-20 18 07 07](https://user-images.githubusercontent.com/3011734/54728411-fd37f500-4b3a-11e9-946b-bace6fdbd5aa.png)


AFFECTS PACKAGES:
@esri/arcgis-rest-auth