### PR TITLE
preserve commit history of the documentation site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ script:
 deploy:
   provider: pages
   skip_cleanup: true
+  keep-history: true
   github_token: "$GITHUB_TOKEN"
   on:
     branch: master
   local-dir: docs/build/arcgis-rest-js
-  target_branch: gh-pages
 before_deploy:
 - npm run docs:build
 env:


### PR DESCRIPTION
right now we're force pushing on `gh-pages` every time a commit hits `master`.

https://docs.travis-ci.com/user/deployment/pages/