### PR TITLE
fix typo in code snippet

### DIFF
--- a/packages/arcgis-rest-request/src/utils/get-portal.ts
+++ b/packages/arcgis-rest-request/src/utils/get-portal.ts
@@ -22,12 +22,12 @@ export function getSelf(requestOptions?: IRequestOptions): Promise<IPortal> {
 }
 
 /**
- * * ```js
+ * ```js
  * import { getPortal } from "@esri/arcgis-rest-request";
  * //
  * getPortal()
- * getPortal("fe8") 
- * getPortal(null, { portal: "https://custom.maps.arcgis.com/sharing/rest/" }) 
+ * getPortal("fe8")
+ * getPortal(null, { portal: "https://custom.maps.arcgis.com/sharing/rest/" })
  * ```
  * Fetch information about the current portal by id. If no id is passed, portals/self will be called
  * @param id


### PR DESCRIPTION
the extra asterisk causes this:
<img width="730" alt="Screenshot 2019-03-26 11 24 09" src="https://user-images.githubusercontent.com/3011734/55023309-bc683200-4fb9-11e9-895f-f80c48539494.png">
