### PR TITLE
feat: new joinGroup and leaveGroup methods

### DIFF
--- a/packages/arcgis-rest-groups/src/helpers.ts
+++ b/packages/arcgis-rest-groups/src/helpers.ts
@@ -1,11 +1,11 @@
 /* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IRequestOptions } from "@esri/arcgis-rest-request";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 import { IItemUpdate, IGroupAdd, IGroup } from "@esri/arcgis-rest-common-types";
 
-export interface IGroupIdRequestOptions extends IRequestOptions {
+export interface IGroupIdRequestOptions extends IUserRequestOptions {
   id: string;
 }
 

--- a/packages/arcgis-rest-groups/src/index.ts
+++ b/packages/arcgis-rest-groups/src/index.ts
@@ -9,3 +9,4 @@ export * from "./protect";
 export * from "./remove";
 export * from "./search";
 export * from "./update";
+export * from "./join";

--- a/packages/arcgis-rest-groups/src/join.ts
+++ b/packages/arcgis-rest-groups/src/join.ts
@@ -7,25 +7,25 @@ import { IGroupIdRequestOptions } from "./helpers";
 
 /**
  * ```js
- * import { protectGroup } from '@esri/arcgis-rest-groups';
+ * import { joinGroup } from '@esri/arcgis-rest-groups';
  * //
- * protectGroup({
+ * joinGroup({
  *   id: groupId,
  *   authentication
  * })
  *   .then(response)
  * ```
- * Protect a group to avoid accidental deletion. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/protect-group.htm) for more information.
+ * Join a Group. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/join-group.htm) for more information.
  *
  * @param requestOptions - Options for the request
  * @returns A Promise that will resolve with the success/failure status of the request
  */
-export function protectGroup(
+export function joinGroup(
   requestOptions: IGroupIdRequestOptions
-): Promise<{ success: boolean }> {
+): Promise<{ success: boolean; groupId: string }> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
-  }/protect`;
+  }/join`;
   const options: IGroupIdRequestOptions = {
     ...requestOptions
   };
@@ -34,24 +34,25 @@ export function protectGroup(
 
 /**
  * ```js
- * import { unprotectGroup } from '@esri/arcgis-rest-groups';
+ * import { joinGroup } from '@esri/arcgis-rest-groups';
  * //
- * unprotectGroup({
+ * joinGroup({
  *   id: groupId,
  *   authentication
  * })
  *   .then(response)
  * ```
- * Unprotect a Group. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/unprotect-group.htm) for more information.
+ * Leave a Group. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/leave-group.htm) for more information.
+ *
  * @param requestOptions - Options for the request
  * @returns A Promise that will resolve with the success/failure status of the request
  */
-export function unprotectGroup(
+export function leaveGroup(
   requestOptions: IGroupIdRequestOptions
-): Promise<{ success: boolean }> {
+): Promise<{ success: boolean; groupId: string }> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
-  }/unprotect`;
+  }/leave`;
   const options: IGroupIdRequestOptions = {
     ...requestOptions
   };

--- a/packages/arcgis-rest-groups/src/join.ts
+++ b/packages/arcgis-rest-groups/src/join.ts
@@ -15,10 +15,10 @@ import { IGroupIdRequestOptions } from "./helpers";
  * })
  *   .then(response)
  * ```
- * Join a Group. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/join-group.htm) for more information.
+ * Make a request as the authenticated user to join a Group. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/join-group.htm) for more information.
  *
  * @param requestOptions - Options for the request
- * @returns A Promise that will resolve with the success/failure status of the request
+ * @returns A Promise that will resolve with the success/failure status of the request and the groupId.
  */
 export function joinGroup(
   requestOptions: IGroupIdRequestOptions
@@ -26,26 +26,24 @@ export function joinGroup(
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
   }/join`;
-  const options: IGroupIdRequestOptions = {
-    ...requestOptions
-  };
-  return request(url, options);
+
+  return request(url, requestOptions);
 }
 
 /**
  * ```js
- * import { joinGroup } from '@esri/arcgis-rest-groups';
+ * import { leaveGroup } from '@esri/arcgis-rest-groups';
  * //
- * joinGroup({
+ * leaveGroup({
  *   id: groupId,
  *   authentication
  * })
  *   .then(response)
  * ```
- * Leave a Group. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/leave-group.htm) for more information.
+ * Make a request as the authenticated user to leave a Group. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/leave-group.htm) for more information.
  *
  * @param requestOptions - Options for the request
- * @returns A Promise that will resolve with the success/failure status of the request
+ * @returns A Promise that will resolve with the success/failure status of the request and the groupId.
  */
 export function leaveGroup(
   requestOptions: IGroupIdRequestOptions
@@ -53,8 +51,6 @@ export function leaveGroup(
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
   }/leave`;
-  const options: IGroupIdRequestOptions = {
-    ...requestOptions
-  };
-  return request(url, options);
+
+  return request(url, requestOptions);
 }

--- a/packages/arcgis-rest-groups/src/protect.ts
+++ b/packages/arcgis-rest-groups/src/protect.ts
@@ -26,10 +26,8 @@ export function protectGroup(
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
   }/protect`;
-  const options: IGroupIdRequestOptions = {
-    ...requestOptions
-  };
-  return request(url, options);
+
+  return request(url, requestOptions);
 }
 
 /**
@@ -52,8 +50,6 @@ export function unprotectGroup(
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
   }/unprotect`;
-  const options: IGroupIdRequestOptions = {
-    ...requestOptions
-  };
-  return request(url, options);
+
+  return request(url, requestOptions);
 }

--- a/packages/arcgis-rest-groups/test/crud.test.ts
+++ b/packages/arcgis-rest-groups/test/crud.test.ts
@@ -8,6 +8,8 @@ import { removeGroup } from "../src/remove";
 import { GroupEditResponse } from "./mocks/responses";
 
 import { encodeParam } from "@esri/arcgis-rest-request";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { TOMORROW } from "@esri/arcgis-rest-auth/test/utils";
 import { IGroupAdd } from "@esri/arcgis-rest-common-types";
 import * as fetchMock from "fetch-mock";
 
@@ -15,12 +17,19 @@ describe("groups", () => {
   afterEach(fetchMock.restore);
 
   describe("authenticted methods", () => {
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
+    const MOCK_AUTH = new UserSession({
+      clientId: "clientId",
+      redirectUri: "https://example-app.com/redirect-uri",
+      token: "fake-token",
+      tokenExpires: TOMORROW,
+      refreshToken: "refreshToken",
+      refreshTokenExpires: TOMORROW,
+      refreshTokenTTL: 1440,
+      username: "casey",
+      password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
+    });
+
     const MOCK_REQOPTS = {
       authentication: MOCK_AUTH
     };

--- a/packages/arcgis-rest-groups/test/join.test.ts
+++ b/packages/arcgis-rest-groups/test/join.test.ts
@@ -6,20 +6,28 @@ import { joinGroup, leaveGroup } from "../src/join";
 import { GroupEditResponse } from "./mocks/responses";
 
 import { encodeParam } from "@esri/arcgis-rest-request";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { TOMORROW } from "@esri/arcgis-rest-auth/test/utils";
+
 import * as fetchMock from "fetch-mock";
 
 describe("groups", () => {
   afterEach(fetchMock.restore);
 
   describe("authenticted methods", () => {
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
-      portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
     const MOCK_REQOPTS = {
-      authentication: MOCK_AUTH
+      authentication: new UserSession({
+        clientId: "clientId",
+        redirectUri: "https://example-app.com/redirect-uri",
+        token: "fake-token",
+        tokenExpires: TOMORROW,
+        refreshToken: "refreshToken",
+        refreshTokenExpires: TOMORROW,
+        refreshTokenTTL: 1440,
+        username: "casey",
+        password: "123456",
+        portal: "https://myorg.maps.arcgis.com/sharing/rest"
+      })
     };
 
     it("should help a user join a group", done => {

--- a/packages/arcgis-rest-groups/test/join.test.ts
+++ b/packages/arcgis-rest-groups/test/join.test.ts
@@ -1,0 +1,64 @@
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { joinGroup, leaveGroup } from "../src/join";
+
+import { GroupEditResponse } from "./mocks/responses";
+
+import { encodeParam } from "@esri/arcgis-rest-request";
+import * as fetchMock from "fetch-mock";
+
+describe("groups", () => {
+  afterEach(fetchMock.restore);
+
+  describe("authenticted methods", () => {
+    const MOCK_AUTH = {
+      getToken() {
+        return Promise.resolve("fake-token");
+      },
+      portal: "https://myorg.maps.arcgis.com/sharing/rest"
+    };
+    const MOCK_REQOPTS = {
+      authentication: MOCK_AUTH
+    };
+
+    it("should help a user join a group", done => {
+      fetchMock.once("*", GroupEditResponse);
+
+      joinGroup({ id: "5bc", ...MOCK_REQOPTS })
+        .then(() => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/join"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain(encodeParam("f", "json"));
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+    it("should help a user leave a group", done => {
+      fetchMock.once("*", GroupEditResponse);
+
+      leaveGroup({ id: "5bc", ...MOCK_REQOPTS })
+        .then(() => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/leave"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain(encodeParam("f", "json"));
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+  });
+});

--- a/packages/arcgis-rest-groups/test/notification.test.ts
+++ b/packages/arcgis-rest-groups/test/notification.test.ts
@@ -1,4 +1,7 @@
 import { encodeParam } from "@esri/arcgis-rest-request";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { TOMORROW } from "@esri/arcgis-rest-auth/test/utils";
+
 import * as fetchMock from "fetch-mock";
 
 import { createGroupNotification } from "../src/notification";
@@ -9,12 +12,19 @@ describe("groups", () => {
   afterEach(fetchMock.restore);
 
   describe("createGroupNotification", () => {
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
+    const MOCK_AUTH = new UserSession({
+      clientId: "clientId",
+      redirectUri: "https://example-app.com/redirect-uri",
+      token: "fake-token",
+      tokenExpires: TOMORROW,
+      refreshToken: "refreshToken",
+      refreshTokenExpires: TOMORROW,
+      refreshTokenTTL: 1440,
+      username: "casey",
+      password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
+    });
+
     const MOCK_REQOPTS = {
       authentication: MOCK_AUTH
     };

--- a/packages/arcgis-rest-groups/test/protect.test.ts
+++ b/packages/arcgis-rest-groups/test/protect.test.ts
@@ -6,27 +6,35 @@ import { protectGroup, unprotectGroup } from "../src/protect";
 import { GroupEditResponse } from "./mocks/responses";
 
 import { encodeParam } from "@esri/arcgis-rest-request";
+import { UserSession } from "@esri/arcgis-rest-auth";
+import { TOMORROW } from "@esri/arcgis-rest-auth/test/utils";
+
 import * as fetchMock from "fetch-mock";
 
 describe("groups", () => {
   afterEach(fetchMock.restore);
 
   describe("authenticted methods", () => {
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
-      portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
     const MOCK_REQOPTS = {
-      authentication: MOCK_AUTH
+      authentication: new UserSession({
+        clientId: "clientId",
+        redirectUri: "https://example-app.com/redirect-uri",
+        token: "fake-token",
+        tokenExpires: TOMORROW,
+        refreshToken: "refreshToken",
+        refreshTokenExpires: TOMORROW,
+        refreshTokenTTL: 1440,
+        username: "casey",
+        password: "123456",
+        portal: "https://myorg.maps.arcgis.com/sharing/rest"
+      })
     };
 
     it("should protect a group", done => {
       fetchMock.once("*", GroupEditResponse);
 
       protectGroup({ id: "5bc", ...MOCK_REQOPTS })
-        .then(response => {
+        .then(() => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(
@@ -45,7 +53,7 @@ describe("groups", () => {
       fetchMock.once("*", GroupEditResponse);
 
       unprotectGroup({ id: "5bc", ...MOCK_REQOPTS })
-        .then(response => {
+        .then(() => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(


### PR DESCRIPTION
made some tweaks to simplify protect/unprotect and make it more evident to TypeScript users that passing authentication is mandatory.

AFFECTS PACKAGES:
@esri/arcgis-rest-groups