### PR TITLE
fix: dont stringify values in item calls

### DIFF
--- a/packages/arcgis-rest-items/src/add.ts
+++ b/packages/arcgis-rest-items/src/add.ts
@@ -1,7 +1,11 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, getPortalUrl, appendCustomParams } from "@esri/arcgis-rest-request";
+import {
+  request,
+  getPortalUrl,
+  appendCustomParams
+} from "@esri/arcgis-rest-request";
 
 import {
   IItemIdRequestOptions,
@@ -56,7 +60,7 @@ export function addItemJsonData(
   // a `text` form field. It can also be sent with the `.create` call by sending
   // a `.data` property.
   requestOptions.params = {
-    text: JSON.stringify(requestOptions.data),
+    text: requestOptions.data,
     ...requestOptions.params
   };
 
@@ -117,11 +121,13 @@ export function addItemData(
  */
 export function addItemRelationship(
   requestOptions: IManageItemRelationshipRequestOptions
-): Promise<{ "success": boolean }> {
+): Promise<{ success: boolean }> {
   const owner = determineOwner(requestOptions);
-  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/addRelationship`;
+  const url = `${getPortalUrl(
+    requestOptions
+  )}/content/users/${owner}/addRelationship`;
 
-  const options = { params: {}, ...requestOptions }
+  const options = { params: {}, ...requestOptions };
   appendCustomParams(requestOptions, options);
 
   return request(url, options);

--- a/packages/arcgis-rest-items/src/helpers.ts
+++ b/packages/arcgis-rest-items/src/helpers.ts
@@ -172,7 +172,7 @@ export function serializeItem(item: IItemAdd | IItemUpdate | IItem): any {
 
   // convert .data to .text
   if (clone.data) {
-    clone.text = JSON.stringify(clone.data);
+    clone.text = clone.data;
     delete clone.data;
   }
 

--- a/packages/arcgis-rest-items/test/add.test.ts
+++ b/packages/arcgis-rest-items/test/add.test.ts
@@ -5,7 +5,7 @@ import * as fetchMock from "fetch-mock";
 
 import { attachmentFile } from "../../arcgis-rest-feature-service/test/attachments.test";
 
-import { 
+import {
   addItemJsonData,
   addItemData,
   addItemResource,
@@ -16,7 +16,7 @@ import { ItemSuccessResponse } from "./mocks/item";
 
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { TOMORROW } from "@esri/arcgis-rest-auth/test/utils";
-import { encodeParam, appendCustomParams } from "@esri/arcgis-rest-request";
+import { encodeParam } from "@esri/arcgis-rest-request";
 
 describe("search", () => {
   afterEach(fetchMock.restore);
@@ -183,7 +183,7 @@ describe("search", () => {
 
     it("should add a relationship to an item", done => {
       fetchMock.once("*", { success: true });
-      
+
       addItemRelationship({
         originItemId: "3ef",
         destinationItemId: "ae7",

--- a/packages/arcgis-rest-items/test/update.test.ts
+++ b/packages/arcgis-rest-items/test/update.test.ts
@@ -58,7 +58,7 @@ describe("search", () => {
         }
       };
       updateItem({ item: fakeItem, ...MOCK_USER_REQOPTS })
-        .then(response => {
+        .then(() => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(


### PR DESCRIPTION
this PR can be considered an amendment to #475.

there's no need for item methods to stringify parameters, `request()` handles this internally.

AFFECTS PACKAGES:
@esri/arcgis-rest-items