### PR TITLE
make it possible for retry() to strip an invalid session

### DIFF
--- a/demos/vue/src/components/App.vue
+++ b/demos/vue/src/components/App.vue
@@ -222,9 +222,7 @@ export default {
             // session.
             this.$store.dispatch("updateSession", session);
           })
-          .catch(error => {
-            console.error(error);
-          });
+          .catch(error);
       }
     },
     // The signup with an inline redirect workflow. In this case the user is just redirected to
@@ -270,7 +268,6 @@ export default {
         })
         .catch(error => {
           this.searching = false;
-          console.error(error);
         });
     }
   }

--- a/demos/webmap-checker-sapper/package.json
+++ b/demos/webmap-checker-sapper/package.json
@@ -5,7 +5,7 @@
   "version": "1.19.1",
   "scripts": {
     "dev": "sapper dev",
-    "build": "sapper build --legacy",
+    "build:legacy": "sapper build --legacy",
     "export": "sapper export --legacy",
     "start": "node __sapper__/build",
     "cy:run": "cypress run",

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -151,13 +151,18 @@ export function request(
 
   const fetchOptions: RequestInit = {
     method: httpMethod,
-    // ensures behavior mimics XMLHttpRequest. needed to support sending IWA cookies
+    /* ensures behavior mimics XMLHttpRequest.
+    needed to support sending IWA cookies */
     credentials: "same-origin"
   };
 
   return (authentication
-    ? authentication.getToken(url, {
-        fetch: options.fetch
+    ? authentication.getToken(url, { fetch: options.fetch }).catch(err => {
+        /* if necessary, append original request url and
+         requestOptions to the error thrown by getToken() */
+        err.url = url;
+        err.options = options;
+        throw err;
       })
     : Promise.resolve("")
   )

--- a/packages/arcgis-rest-request/test/utils/ArcGISAuthError.test.ts
+++ b/packages/arcgis-rest-request/test/utils/ArcGISAuthError.test.ts
@@ -7,9 +7,8 @@ import {
   ArcGISOnlineError,
   GenerateTokenError
 } from "./../mocks/errors";
+import { request } from "../../src/request";
 import * as fetchMock from "fetch-mock";
-import { request } from "https";
-import { request as esriRequest } from "../../src/request";
 
 describe("ArcGISRequestError", () => {
   afterEach(fetchMock.restore);
@@ -176,7 +175,7 @@ describe("ArcGISRequestError", () => {
     it("should throw an authentication error for invalid credentials", done => {
       fetchMock.post("*", GenerateTokenError);
 
-      esriRequest("https://www.arcgis.com/sharing/rest/generateToken", {
+      request("https://www.arcgis.com/sharing/rest/generateToken", {
         params: {
           username: "correct",
           password: "incorrect",


### PR DESCRIPTION
tl:dr: _super_ edge case fix.

---
in Hub land we started encountering errors when passing a valid (www.arcgis.com) authentication session to _public_ services hosted by unfederated instances of ArcGIS Server.

because of this currently we're sending a whole lot of anonymous requests _after_ users authenticate and using retry() to tack on a session we had the whole time whenever we encounter an `ArcGISAuthError` (see https://github.com/Esri/ember-arcgis-server-services/pull/46 for more info).

it'd be a whole lot nicer to invert the flow and pass through the authentication we have consistently and `catch` the ones that are public, but unfederated.

this PR would allow us to do that, by ensuring that the original `url` and `options` are passed through.

```js
const url = `https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer`;
request(url, {
    authentication,
    params: {
      foo: 'bar'
    }
  })
    .catch(err => {
      if (err.name === 'ArcGISAuthError') {
        // instead of supplying auth, strip it 
        err.retry(() => Promise.resolve(undefined))
          .then(response)
      }
    })
```