### PR TITLE
fix: catch err internally when getItemData doesnt find any

### DIFF
--- a/packages/arcgis-rest-items/src/get.ts
+++ b/packages/arcgis-rest-items/src/get.ts
@@ -75,7 +75,14 @@ export function getItemData(
     options.params.f = null;
   }
 
-  return request(url, options);
+  return request(url, options).catch(err => {
+    /*
+     * if the item doesn't include data, the response
+     * will be empty and the internal call to
+     * response.json() will fail with the error below
+     */
+    if (err.message === "Unexpected end of JSON input") return;
+  });
 }
 
 export interface IGetRelatedItemsResponse {

--- a/packages/arcgis-rest-items/src/get.ts
+++ b/packages/arcgis-rest-items/src/get.ts
@@ -76,13 +76,13 @@ export function getItemData(
   }
 
   return request(url, options).catch(err => {
+    /* if the item doesn't include data, the response will be empty
+       and the internal call to response.json() will fail */
+    const emptyResponseErr = RegExp(
+      /Unexpected end of (JSON input|data at line 1 column 1)/i
+    );
     /* istanbul ignore else */
-    if (err.message.indexOf("Unexpected end of JSON input") > -1) {
-      /*
-       * if the item doesn't include data, the response
-       * will be empty and the internal call to
-       * response.json() will fail with the error below
-       */
+    if (emptyResponseErr.test(err.message)) {
       return null;
     } else throw err;
   });

--- a/packages/arcgis-rest-items/src/get.ts
+++ b/packages/arcgis-rest-items/src/get.ts
@@ -83,7 +83,7 @@ export function getItemData(
     );
     /* istanbul ignore else */
     if (emptyResponseErr.test(err.message)) {
-      return null;
+      return;
     } else throw err;
   });
 }

--- a/packages/arcgis-rest-items/src/get.ts
+++ b/packages/arcgis-rest-items/src/get.ts
@@ -55,7 +55,7 @@ export function getItem(
  * getItemData("ae7", { authentication })
  *   .then(response)
  * ```
- * Get the /data for an item. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/item-data.htm) for more information.
+ * Get the /data for an item. If no data exists, returns `undefined`. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/item-data.htm) for more information.
  * @param id - Item Id
  * @param requestOptions - Options for the request
  * @returns A Promise that will resolve with the json data for the item.

--- a/packages/arcgis-rest-items/src/get.ts
+++ b/packages/arcgis-rest-items/src/get.ts
@@ -76,12 +76,15 @@ export function getItemData(
   }
 
   return request(url, options).catch(err => {
-    /*
-     * if the item doesn't include data, the response
-     * will be empty and the internal call to
-     * response.json() will fail with the error below
-     */
-    if (err.message === "Unexpected end of JSON input") return;
+    /* istanbul ignore else */
+    if (err.message === "Unexpected end of JSON input") {
+      /*
+       * if the item doesn't include data, the response
+       * will be empty and the internal call to
+       * response.json() will fail with the error below
+       */
+      return null;
+    } else throw err;
   });
 }
 

--- a/packages/arcgis-rest-items/src/get.ts
+++ b/packages/arcgis-rest-items/src/get.ts
@@ -77,7 +77,7 @@ export function getItemData(
 
   return request(url, options).catch(err => {
     /* istanbul ignore else */
-    if (err.message === "Unexpected end of JSON input") {
+    if (err.message.indexOf("Unexpected end of JSON input") > -1) {
       /*
        * if the item doesn't include data, the response
        * will be empty and the internal call to

--- a/packages/arcgis-rest-items/test/get.test.ts
+++ b/packages/arcgis-rest-items/test/get.test.ts
@@ -94,7 +94,7 @@ describe("get", () => {
     fetchMock.once("*", {
       sendAsJson: false,
       headers: { "Content-Type": "text/plain;charset=utf-8" },
-      body: null
+      body: ""
     });
 
     getItemData("3ef")
@@ -105,7 +105,7 @@ describe("get", () => {
           "https://www.arcgis.com/sharing/rest/content/items/3ef/data?f=json"
         );
         expect(options.method).toBe("GET");
-        expect(response).toBe(undefined);
+        expect(response).toBe(null);
         done();
       })
       .catch(e => {

--- a/packages/arcgis-rest-items/test/get.test.ts
+++ b/packages/arcgis-rest-items/test/get.test.ts
@@ -105,7 +105,7 @@ describe("get", () => {
           "https://www.arcgis.com/sharing/rest/content/items/3ef/data?f=json"
         );
         expect(options.method).toBe("GET");
-        expect(response).toBe(null);
+        expect(response).toBe(undefined);
         done();
       })
       .catch(e => {

--- a/packages/arcgis-rest-items/test/get.test.ts
+++ b/packages/arcgis-rest-items/test/get.test.ts
@@ -30,7 +30,7 @@ describe("get", () => {
     fetchMock.once("*", ItemResponse);
 
     getItem("3ef")
-      .then(response => {
+      .then(() => {
         expect(fetchMock.called()).toEqual(true);
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
         expect(url).toEqual(
@@ -88,6 +88,29 @@ describe("get", () => {
     } else {
       done();
     }
+  });
+
+  it("should return a valid response even when no data is retrieved", done => {
+    fetchMock.once("*", {
+      sendAsJson: false,
+      headers: { "Content-Type": "text/plain;charset=utf-8" },
+      body: null
+    });
+
+    getItemData("3ef")
+      .then(response => {
+        expect(fetchMock.called()).toEqual(true);
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          "https://www.arcgis.com/sharing/rest/content/items/3ef/data?f=json"
+        );
+        expect(options.method).toBe("GET");
+        expect(response).toBe(undefined);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
   });
 
   it("should return related items", done => {


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-items

ISSUES CLOSED: #504