### PR TITLE
fix: loosen peerDependencies to document the oldest compatible package

### DIFF
--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -20,8 +20,8 @@
     "@esri/arcgis-rest-request": "^1.19.2"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.19.2",
-    "@esri/arcgis-rest-request": "^1.19.2"
+    "@esri/arcgis-rest-common-types": "^1.1.2",
+    "@esri/arcgis-rest-request": "^1.0.0"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-feature-service-admin/package.json
+++ b/packages/arcgis-rest-feature-service-admin/package.json
@@ -22,10 +22,10 @@
     "@esri/arcgis-rest-request": "^1.19.2"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.19.2",
-    "@esri/arcgis-rest-common-types": "^1.19.2",
-    "@esri/arcgis-rest-items": "^1.19.2",
-    "@esri/arcgis-rest-request": "^1.19.2"
+    "@esri/arcgis-rest-auth": "^1.0.3",
+    "@esri/arcgis-rest-common-types": "^1.3.0",
+    "@esri/arcgis-rest-items": "^1.10.0",
+    "@esri/arcgis-rest-request": "^1.14.2"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -20,8 +20,8 @@
     "@esri/arcgis-rest-request": "^1.19.2"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-common-types": "^1.19.2",
-    "@esri/arcgis-rest-request": "^1.19.2"
+    "@esri/arcgis-rest-common-types": "^1.1.0",
+    "@esri/arcgis-rest-request": "^1.14.2"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-geocoder/package.json
+++ b/packages/arcgis-rest-geocoder/package.json
@@ -16,14 +16,12 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.19.2",
     "@esri/arcgis-rest-common-types": "^1.19.2",
     "@esri/arcgis-rest-request": "^1.19.2"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.19.2",
-    "@esri/arcgis-rest-common-types": "^1.19.2",
-    "@esri/arcgis-rest-request": "^1.19.2"
+    "@esri/arcgis-rest-common-types": "^1.0.0",
+    "@esri/arcgis-rest-request": "^1.14.2"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-groups/package.json
+++ b/packages/arcgis-rest-groups/package.json
@@ -21,9 +21,9 @@
     "@esri/arcgis-rest-request": "^1.19.2"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.19.2",
-    "@esri/arcgis-rest-common-types": "^1.19.2",
-    "@esri/arcgis-rest-request": "^1.19.2"
+    "@esri/arcgis-rest-auth": "^1.0.3",
+    "@esri/arcgis-rest-common-types": "^1.6.0",
+    "@esri/arcgis-rest-request": "^1.0.0"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-items/package.json
+++ b/packages/arcgis-rest-items/package.json
@@ -21,9 +21,9 @@
     "@esri/arcgis-rest-request": "^1.19.2"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.19.2",
-    "@esri/arcgis-rest-common-types": "^1.19.2",
-    "@esri/arcgis-rest-request": "^1.19.2"
+    "@esri/arcgis-rest-auth": "^1.0.3",
+    "@esri/arcgis-rest-common-types": "^1.6.0",
+    "@esri/arcgis-rest-request": "^1.13.1"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-routing/package.json
+++ b/packages/arcgis-rest-routing/package.json
@@ -16,14 +16,12 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-auth": "^1.19.2",
     "@esri/arcgis-rest-common": "^1.19.2",
     "@esri/arcgis-rest-request": "^1.19.2"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.19.2",
-    "@esri/arcgis-rest-common": "^1.19.2",
-    "@esri/arcgis-rest-request": "^1.19.2"
+    "@esri/arcgis-rest-common": "^1.14.0",
+    "@esri/arcgis-rest-request": "^1.14.2"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/packages/arcgis-rest-sharing/package.json
+++ b/packages/arcgis-rest-sharing/package.json
@@ -19,10 +19,10 @@
     "@esri/arcgis-rest-request": "^1.19.2"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.19.2",
-    "@esri/arcgis-rest-common-types": "^1.19.2",
-    "@esri/arcgis-rest-groups": "^1.19.2",
-    "@esri/arcgis-rest-request": "^1.19.2"
+    "@esri/arcgis-rest-auth": "^1.0.0",
+    "@esri/arcgis-rest-common-types": "^1.9.0",
+    "@esri/arcgis-rest-groups": "^1.0.0",
+    "@esri/arcgis-rest-request": "^1.0.0"
   },
   "files": [
     "dist/**"

--- a/packages/arcgis-rest-users/package.json
+++ b/packages/arcgis-rest-users/package.json
@@ -21,9 +21,9 @@
     "@esri/arcgis-rest-request": "^1.19.2"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-auth": "^1.19.2",
-    "@esri/arcgis-rest-common-types": "^1.19.2",
-    "@esri/arcgis-rest-request": "^1.19.2"
+    "@esri/arcgis-rest-auth": "^1.0.3",
+    "@esri/arcgis-rest-common-types": "^1.1.2",
+    "@esri/arcgis-rest-request": "^1.0.0"
   },
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION
### tl:dr

it has been an error on my part to sync the `peerDependencies` manually with the `devDependencies` that lerna bumps automatically. we should be advertising the _lowest_ compatible version, not the most recent.

---

@jPurush shared a thread with me the other day that made me realize:

* lerna is making a conscious choice not to bump the `peerDependencies` for each package 
* if it _is_ necessary to bump a `peerDependency` to exclude a previously compatible version, its likely that a breaking change is being introduced.

for example, we should have tagged `v2.0.0` when we landed #400 because we introduced a dependency on a new `cleanUrl()` method inside the request package in existing functions in _other_ packages.

folks even reported uncaught errors to me when `cleanUrl()` wasn't found in their own projects that were resolved by upgrading `request`. i knew enough about what was going on to recommend the fix to people but not enough to realize that we'd broken our contract.

getting in here and trying to figure out exactly what the minimum requirements were for our packages actually made the relationships _more_ clear to me.

besides that, going forward we'll benefit from the lack of rote manual version bumping.

reference:
* https://github.com/lerna/lerna/issues/1575#issuecomment-420380754
* https://github.com/lerna/lerna/issues/1018
* example in [babel](https://github.com/babel/babel/blob/282129ea66dcdbfc9093eb8ff2278bed1127c861/packages/babel-plugin-proposal-do-expressions/package.json)

AFFECTS PACKAGES:
@esri/arcgis-rest-auth
@esri/arcgis-rest-feature-service-admin
@esri/arcgis-rest-feature-service
@esri/arcgis-rest-geocoder
@esri/arcgis-rest-groups
@esri/arcgis-rest-items
@esri/arcgis-rest-routing
@esri/arcgis-rest-sharing
@esri/arcgis-rest-users