### PR TITLE
fix(add resource): make resource an optional parameter

### DIFF
--- a/packages/arcgis-rest-items/src/add.ts
+++ b/packages/arcgis-rest-items/src/add.ts
@@ -23,6 +23,9 @@ export interface IItemDataAddRequestOptions extends IItemIdRequestOptions {
   data: any;
 }
 
+/**
+ * Deprecated. Please use `IItemResourceRequestOptions` instead.
+ */
 export interface IItemResourceAddRequestOptions
   extends IItemResourceRequestOptions {
   /**
@@ -136,11 +139,21 @@ export function addItemRelationship(
 /**
  * ```js
  * import { addItemResource } from '@esri/arcgis-rest-items';
- * //
+ *
+ * // Add a file resource
  * addItemResource({
  *   id: '3ef',
  *   resource: file,
  *   name: 'bigkahuna.jpg',
+ *   authentication
+ * })
+ *   .then(response)
+ *
+ * // Add a text resource
+ * addItemResource({
+ *   id: '4fg',
+ *   content: "Text content",
+ *   name: 'bigkahuna.txt',
  *   authentication
  * })
  *   .then(response)
@@ -151,7 +164,7 @@ export function addItemRelationship(
  * @returns A Promise to add item resources.
  */
 export function addItemResource(
-  requestOptions: IItemResourceAddRequestOptions
+  requestOptions: IItemResourceRequestOptions
 ): Promise<IItemResourceResponse> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${

--- a/packages/arcgis-rest-items/src/helpers.ts
+++ b/packages/arcgis-rest-items/src/helpers.ts
@@ -89,6 +89,9 @@ export interface IItemResourceRequestOptions extends IItemIdRequestOptions {
    * Controls whether access to the file resource is restricted to the owner or inherited from the sharing permissions set for the associated item.
    */
   private?: boolean;
+  /**
+   * Object to store
+   */
   resource?: any;
 }
 

--- a/packages/arcgis-rest-items/test/add.test.ts
+++ b/packages/arcgis-rest-items/test/add.test.ts
@@ -286,5 +286,35 @@ describe("search", () => {
           fail(e);
         });
     });
+
+    it("should add a text resource", done => {
+      fetchMock.once("*", {
+        success: true
+      });
+
+      addItemResource({
+        id: "3ef",
+        content: "Text content",
+        name: "thebigkahuna.txt",
+        ...MOCK_USER_REQOPTS
+      })
+        .then(() => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/addResources"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain("f=json");
+          expect(options.body).toContain("text=Text%20content");
+          expect(options.body).toContain("fileName=thebigkahuna");
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
   }); // auth requests
 });


### PR DESCRIPTION
Resources can be added with just text content, so the resource parameter should be optional.

AFFECTS PACKAGES:
@esri/arcgis-rest-items

@jgravois Making `resource` optional means that `IItemResourceAddRequestOptions` is not necessary, so I marked it as deprecated. Let me know if that makes sense. 