### PR TITLE
refactor(feature responses): removes unneccessay feature layer respon…

### DIFF
--- a/packages/arcgis-rest-feature-layer/src/add.ts
+++ b/packages/arcgis-rest-feature-layer/src/add.ts
@@ -28,16 +28,6 @@ export interface IAddFeaturesRequestOptions
 }
 
 /**
- * Add features results.
- */
-export interface IAddFeaturesResult {
-  /**
-   * Array of JSON response Object(s) for each feature added.
-   */
-  addResults?: IEditFeatureResult[];
-}
-
-/**
  * ```js
  * import { addFeatures } from '@esri/arcgis-rest-feature-layer';
  * //
@@ -57,7 +47,7 @@ export interface IAddFeaturesResult {
  */
 export function addFeatures(
   requestOptions: IAddFeaturesRequestOptions
-): Promise<IAddFeaturesResult> {
+): Promise<{ addResults?: IEditFeatureResult[] }> {
   const url = `${cleanUrl(requestOptions.url)}/addFeatures`;
 
   // edit operations are POST only

--- a/packages/arcgis-rest-feature-layer/src/addAttachment.ts
+++ b/packages/arcgis-rest-feature-layer/src/addAttachment.ts
@@ -20,16 +20,6 @@ export interface IAddAttachmentOptions extends ILayerRequestOptions {
 }
 
 /**
- * `addAttachment()` request response.
- */
-export interface IAddAttachmentResponse {
-  /**
-   * Standard AGS add/update/edit result Object for the attachment.
-   */
-  addAttachmentResult: IEditFeatureResult;
-}
-
-/**
  * ```js
  * import { addAttachment } from '@esri/arcgis-rest-feature-layer';
  * //
@@ -47,7 +37,7 @@ export interface IAddAttachmentResponse {
  */
 export function addAttachment(
   requestOptions: IAddAttachmentOptions
-): Promise<IAddAttachmentResponse> {
+): Promise<{ addAttachmentResult: IEditFeatureResult }> {
   const options: IAddAttachmentOptions = {
     params: {},
     ...requestOptions

--- a/packages/arcgis-rest-feature-layer/src/delete.ts
+++ b/packages/arcgis-rest-feature-layer/src/delete.ts
@@ -28,16 +28,6 @@ export interface IDeleteFeaturesRequestOptions
 }
 
 /**
- * Delete features results.
- */
-export interface IDeleteFeaturesResult {
-  /**
-   * Array of JSON response Object(s) for each feature deleted.
-   */
-  deleteResults?: IEditFeatureResult[];
-}
-
-/**
  * ```js
  * import { deleteFeatures } from '@esri/arcgis-rest-feature-layer';
  * //
@@ -53,7 +43,7 @@ export interface IDeleteFeaturesResult {
  */
 export function deleteFeatures(
   requestOptions: IDeleteFeaturesRequestOptions
-): Promise<IDeleteFeaturesResult> {
+): Promise<{ deleteResults?: IEditFeatureResult[] }> {
   const url = `${cleanUrl(requestOptions.url)}/deleteFeatures`;
 
   // edit operations POST only

--- a/packages/arcgis-rest-feature-layer/src/deleteAttachments.ts
+++ b/packages/arcgis-rest-feature-layer/src/deleteAttachments.ts
@@ -20,16 +20,6 @@ export interface IDeleteAttachmentsOptions extends ILayerRequestOptions {
 }
 
 /**
- * `updateAttachment()` request response.
- */
-export interface IDeleteAttachmentsResponse {
-  /**
-   * Array of standard AGS add/update/edit result Object(s) for the attachment(s).
-   */
-  deleteAttachmentResults: IEditFeatureResult[];
-}
-
-/**
  * ```js
  * import { deleteAttachments } from '@esri/arcgis-rest-feature-layer';
  * //
@@ -46,7 +36,7 @@ export interface IDeleteAttachmentsResponse {
  */
 export function deleteAttachments(
   requestOptions: IDeleteAttachmentsOptions
-): Promise<IDeleteAttachmentsResponse> {
+): Promise<{ deleteAttachmentResults: IEditFeatureResult[] }> {
   const options: IDeleteAttachmentsOptions = {
     params: {},
     ...requestOptions

--- a/packages/arcgis-rest-feature-layer/src/getAttachments.ts
+++ b/packages/arcgis-rest-feature-layer/src/getAttachments.ts
@@ -26,16 +26,6 @@ export interface IAttachmentInfo {
 }
 
 /**
- * `getAttachments()` request response.
- */
-export interface IGetAttachmentsResponse {
-  /**
-   * Array of `attachmentInfo` Object(s) for each related attachment. Empty Array means no attachments.
-   */
-  attachmentInfos: IAttachmentInfo[];
-}
-
-/**
  * ```js
  * import { getAttachments } from '@esri/arcgis-rest-feature-layer';
  * //
@@ -51,7 +41,7 @@ export interface IGetAttachmentsResponse {
  */
 export function getAttachments(
   requestOptions: IGetAttachmentsOptions
-): Promise<IGetAttachmentsResponse> {
+): Promise<{ attachmentInfos: IAttachmentInfo[] }> {
   // pass through
   return request(
     `${cleanUrl(requestOptions.url)}/${requestOptions.featureId}/attachments`,

--- a/packages/arcgis-rest-feature-layer/src/update.ts
+++ b/packages/arcgis-rest-feature-layer/src/update.ts
@@ -28,16 +28,6 @@ export interface IUpdateFeaturesRequestOptions
 }
 
 /**
- * Update features results.
- */
-export interface IUpdateFeaturesResult {
-  /**
-   * Array of JSON response Object(s) for each feature updated.
-   */
-  updateResults?: IEditFeatureResult[];
-}
-
-/**
  *
  * ```js
  * import { updateFeatures } from '@esri/arcgis-rest-feature-layer';
@@ -57,7 +47,7 @@ export interface IUpdateFeaturesResult {
  */
 export function updateFeatures(
   requestOptions: IUpdateFeaturesRequestOptions
-): Promise<IUpdateFeaturesResult> {
+): Promise<{ updateResults?: IEditFeatureResult[] }> {
   const url = `${cleanUrl(requestOptions.url)}/updateFeatures`;
 
   // edit operations are POST only

--- a/packages/arcgis-rest-feature-layer/src/updateAttachment.ts
+++ b/packages/arcgis-rest-feature-layer/src/updateAttachment.ts
@@ -24,16 +24,6 @@ export interface IUpdateAttachmentOptions extends ILayerRequestOptions {
 }
 
 /**
- * `updateAttachment()` request response.
- */
-export interface IUpdateAttachmentResponse {
-  /**
-   * Standard AGS add/update/edit result Object for the attachment.
-   */
-  updateAttachmentResult: IEditFeatureResult;
-}
-
-/**
  *
  * ```js
  * import { updateAttachment } from '@esri/arcgis-rest-feature-layer';
@@ -52,7 +42,7 @@ export interface IUpdateAttachmentResponse {
  */
 export function updateAttachment(
   requestOptions: IUpdateAttachmentOptions
-): Promise<IUpdateAttachmentResponse> {
+): Promise<{ updateAttachmentResult: IEditFeatureResult }> {
   const options: IUpdateAttachmentOptions = {
     params: {},
     ...requestOptions


### PR DESCRIPTION
…se interfaces

AFFECTS PACKAGES:
@esri/arcgis-rest-feature-layer

BREAKING CHANGE:
removes IAddFeaturesResult, IAddAttachmentResponse, IDeleteFeaturesResult,
IDeleteAttachmentsResponse, IGetAttachmentsResponse, IUpdateFeaturesResult, &
IUpdateAttachmentResponse