### PR TITLE
deprecate passing raw params to fetchToken/generateToken

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -434,10 +434,12 @@ export class UserSession implements IAuthenticationManager {
     };
 
     return fetchToken(`${portal}/oauth2/token`, {
-      grant_type: "authorization_code",
-      client_id: clientId,
-      redirect_uri: redirectUri,
-      code: authorizationCode
+      params: {
+        grant_type: "authorization_code",
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        code: authorizationCode
+      }
     }).then(response => {
       return new UserSession({
         clientId,

--- a/packages/arcgis-rest-auth/src/fetch-token.ts
+++ b/packages/arcgis-rest-auth/src/fetch-token.ts
@@ -4,7 +4,6 @@
 import {
   request,
   IRequestOptions,
-  IFetchTokenParams,
   ITokenRequestOptions
 } from "@esri/arcgis-rest-request";
 
@@ -26,13 +25,9 @@ export interface IFetchTokenResponse {
 
 export function fetchToken(
   url: string,
-  requestOptions: IFetchTokenParams | ITokenRequestOptions
+  requestOptions: ITokenRequestOptions
 ): Promise<IFetchTokenResponse> {
-  // TODO: remove union type and type guard next breaking change and just expect IGenerateTokenRequestOptions
-  const options: IRequestOptions = (requestOptions as ITokenRequestOptions)
-    .params
-    ? (requestOptions as IRequestOptions)
-    : { params: requestOptions };
+  const options: IRequestOptions = requestOptions;
   // we generate a response, so we can't return the raw response
   options.rawResponse = false;
 

--- a/packages/arcgis-rest-auth/src/generate-token.ts
+++ b/packages/arcgis-rest-auth/src/generate-token.ts
@@ -4,7 +4,6 @@
 import {
   request,
   IRequestOptions,
-  IGenerateTokenParams,
   ITokenRequestOptions,
   NODEJS_DEFAULT_REFERER_HEADER
 } from "@esri/arcgis-rest-request";
@@ -17,13 +16,9 @@ export interface IGenerateTokenResponse {
 
 export function generateToken(
   url: string,
-  requestOptions: IGenerateTokenParams | ITokenRequestOptions
+  requestOptions: ITokenRequestOptions
 ): Promise<IGenerateTokenResponse> {
-  // TODO: remove union type and type guard next breaking change and just expect IGenerateTokenParams
-  const options: IRequestOptions = (requestOptions as ITokenRequestOptions)
-    .params
-    ? (requestOptions as IRequestOptions)
-    : { params: requestOptions };
+  const options: IRequestOptions = requestOptions;
 
   /* istanbul ignore else */
   if (

--- a/packages/arcgis-rest-auth/test/generateToken.test.ts
+++ b/packages/arcgis-rest-auth/test/generateToken.test.ts
@@ -10,35 +10,7 @@ const TOKEN_URL = "https://www.arcgis.com/sharing/rest/generateToken";
 describe("generateToken()", () => {
   afterEach(fetchMock.restore);
 
-  // to do: remove next time we have a breaking change
   it("should generate a token for a username and password", done => {
-    fetchMock.postOnce(TOKEN_URL, {
-      token: "token",
-      expires: TOMORROW.getTime()
-    });
-
-    generateToken(TOKEN_URL, {
-      username: "Casey",
-      password: "Jones"
-    })
-      .then(response => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
-          TOKEN_URL
-        );
-        expect(url).toEqual(TOKEN_URL);
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain("username=Casey");
-        expect(options.body).toContain("password=Jones");
-        expect(response.token).toEqual("token");
-        expect(response.expires).toEqual(TOMORROW.getTime());
-        done();
-      })
-      .catch(e => {
-        fail(e);
-      });
-  });
-
-  it("should generate a token for a username and password as params", done => {
     fetchMock.postOnce(TOKEN_URL, {
       token: "token",
       expires: TOMORROW.getTime()


### PR DESCRIPTION
see https://github.com/Esri/arcgis-rest-js/pull/264#discussion_r208381410 for more info.