### PR TITLE
refactor: remove the word Request from custom geocoding RequestOptions

### DIFF
--- a/packages/arcgis-rest-geocoding/src/bulk.ts
+++ b/packages/arcgis-rest-geocoding/src/bulk.ts
@@ -2,13 +2,9 @@
  * Apache-2.0 */
 
 import { request, cleanUrl } from "@esri/arcgis-rest-request";
-
 import { ISpatialReference, IPoint } from "@esri/arcgis-rest-types";
 
-import {
-  ARCGIS_ONLINE_GEOCODING_URL,
-  IEndpointRequestOptions
-} from "./helpers";
+import { ARCGIS_ONLINE_GEOCODING_URL, IEndpointOptions } from "./helpers";
 
 // it'd be better if doc didnt display these properties in alphabetical order
 export interface IAddressBulk {
@@ -31,7 +27,7 @@ export interface IAddressBulk {
   countryCode?: string;
 }
 
-export interface IBulkGeocodeRequestOptions extends IEndpointRequestOptions {
+export interface IBulkGeocodeOptions extends IEndpointOptions {
   addresses: IAddressBulk[];
 }
 
@@ -39,7 +35,7 @@ export interface IBulkGeocodeResponse {
   spatialReference: ISpatialReference;
   locations: Array<{
     address: string;
-    location: IPoint;
+    location?: IPoint; // candidates with a score of 0 wont include a location
     score: number;
     attributes: object;
   }>;
@@ -66,9 +62,9 @@ export interface IBulkGeocodeResponse {
  * @returns A Promise that will resolve with the data from the response. The spatial reference will be added to address locations unless `rawResponse: true` was passed.
  */
 export function bulkGeocode(
-  requestOptions: IBulkGeocodeRequestOptions // must POST, which is the default
-) {
-  const options: IBulkGeocodeRequestOptions = {
+  requestOptions: IBulkGeocodeOptions // must POST, which is the default
+): Promise<IBulkGeocodeResponse> {
+  const options: IBulkGeocodeOptions = {
     endpoint: ARCGIS_ONLINE_GEOCODING_URL,
     params: {
       forStorage: true,
@@ -107,7 +103,3 @@ export function bulkGeocode(
     return response;
   });
 }
-
-export default {
-  bulkGeocode
-};

--- a/packages/arcgis-rest-geocoding/src/geocode.ts
+++ b/packages/arcgis-rest-geocoding/src/geocode.ts
@@ -9,12 +9,9 @@ import {
 
 import { IExtent, ISpatialReference, IPoint } from "@esri/arcgis-rest-types";
 
-import {
-  ARCGIS_ONLINE_GEOCODING_URL,
-  IEndpointRequestOptions
-} from "./helpers";
+import { ARCGIS_ONLINE_GEOCODING_URL, IEndpointOptions } from "./helpers";
 
-export interface IGeocodeRequestOptions extends IEndpointRequestOptions {
+export interface IGeocodeOptions extends IEndpointOptions {
   /**
    * use this if all your address info is contained in a single string.
    */
@@ -82,9 +79,9 @@ export interface IGeocodeResponse {
  * @returns A Promise that will resolve with address candidates for the request. The spatial reference will be added to candidate locations and extents unless `rawResponse: true` was passed.
  */
 export function geocode(
-  address: string | IGeocodeRequestOptions
+  address: string | IGeocodeOptions
 ): Promise<IGeocodeResponse> {
-  let options: IGeocodeRequestOptions = {};
+  let options: IGeocodeOptions;
   let endpoint: string;
 
   if (typeof address === "string") {
@@ -92,7 +89,7 @@ export function geocode(
     endpoint = ARCGIS_ONLINE_GEOCODING_URL;
   } else {
     endpoint = address.endpoint || ARCGIS_ONLINE_GEOCODING_URL;
-    options = appendCustomParams<IGeocodeRequestOptions>(
+    options = appendCustomParams<IGeocodeOptions>(
       address,
       [
         "singleLine",

--- a/packages/arcgis-rest-geocoding/src/geocode.ts
+++ b/packages/arcgis-rest-geocoding/src/geocode.ts
@@ -81,7 +81,7 @@ export interface IGeocodeResponse {
 export function geocode(
   address: string | IGeocodeOptions
 ): Promise<IGeocodeResponse> {
-  let options: IGeocodeOptions;
+  let options: IGeocodeOptions = {};
   let endpoint: string;
 
   if (typeof address === "string") {

--- a/packages/arcgis-rest-geocoding/src/helpers.ts
+++ b/packages/arcgis-rest-geocoding/src/helpers.ts
@@ -8,7 +8,7 @@ export const ARCGIS_ONLINE_GEOCODING_URL =
   "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/";
 
 // nice to have: verify custom endpoints contain 'GeocodeServer' and end in a '/'
-export interface IEndpointRequestOptions extends IRequestOptions {
+export interface IEndpointOptions extends IRequestOptions {
   /**
    * Any ArcGIS Geocoding service (example: http://sampleserver6.arcgisonline.com/arcgis/rest/services/Locators/SanDiego/GeocodeServer )
    */
@@ -39,12 +39,12 @@ export interface IGetGeocodeServiceResponse {
  * @returns A Promise that will resolve with the data from the response.
  */
 export function getGeocodeService(
-  requestOptions?: IEndpointRequestOptions
+  requestOptions?: IEndpointOptions
 ): Promise<IGetGeocodeServiceResponse> {
   const url =
     (requestOptions && requestOptions.endpoint) || ARCGIS_ONLINE_GEOCODING_URL;
 
-  const options: IEndpointRequestOptions = {
+  const options: IEndpointOptions = {
     httpMethod: "GET",
     maxUrlLength: 2000,
     ...requestOptions

--- a/packages/arcgis-rest-geocoding/src/reverse.ts
+++ b/packages/arcgis-rest-geocoding/src/reverse.ts
@@ -5,10 +5,7 @@ import { request, cleanUrl } from "@esri/arcgis-rest-request";
 
 import { IPoint, ILocation } from "@esri/arcgis-rest-types";
 
-import {
-  ARCGIS_ONLINE_GEOCODING_URL,
-  IEndpointRequestOptions
-} from "./helpers";
+import { ARCGIS_ONLINE_GEOCODING_URL, IEndpointOptions } from "./helpers";
 
 export interface IReverseGeocodeResponse {
   address: {
@@ -57,9 +54,9 @@ function isLocation(
  */
 export function reverseGeocode(
   coords: IPoint | ILocation | [number, number],
-  requestOptions?: IEndpointRequestOptions
+  requestOptions?: IEndpointOptions
 ): Promise<IReverseGeocodeResponse> {
-  const options: IEndpointRequestOptions = {
+  const options: IEndpointOptions = {
     endpoint: ARCGIS_ONLINE_GEOCODING_URL,
     params: {},
     ...requestOptions

--- a/packages/arcgis-rest-geocoding/src/suggest.ts
+++ b/packages/arcgis-rest-geocoding/src/suggest.ts
@@ -3,10 +3,7 @@
 
 import { request, cleanUrl } from "@esri/arcgis-rest-request";
 
-import {
-  ARCGIS_ONLINE_GEOCODING_URL,
-  IEndpointRequestOptions
-} from "./helpers";
+import { ARCGIS_ONLINE_GEOCODING_URL, IEndpointOptions } from "./helpers";
 
 export interface ISuggestResponse {
   suggestions: Array<{
@@ -30,9 +27,9 @@ export interface ISuggestResponse {
  */
 export function suggest(
   partialText: string,
-  requestOptions?: IEndpointRequestOptions
+  requestOptions?: IEndpointOptions
 ): Promise<ISuggestResponse> {
-  const options: IEndpointRequestOptions = {
+  const options: IEndpointOptions = {
     endpoint: ARCGIS_ONLINE_GEOCODING_URL,
     params: {},
     ...requestOptions

--- a/packages/arcgis-rest-geocoding/test/mocks/responses.ts
+++ b/packages/arcgis-rest-geocoding/test/mocks/responses.ts
@@ -2,6 +2,9 @@
  * Apache-2.0 */
 
 import { IGeocodeResponse } from "../../src/geocode";
+import { ISuggestResponse } from "../../src/suggest";
+import { IReverseGeocodeResponse } from "../../src/reverse";
+import { IBulkGeocodeResponse } from "../../src/bulk";
 
 export const FindAddressCandidates: IGeocodeResponse = {
   spatialReference: {
@@ -93,7 +96,7 @@ export const FindAddressCandidatesNullExtent: IGeocodeResponse = {
   ]
 };
 
-export const Suggest = {
+export const Suggest: ISuggestResponse = {
   suggestions: [
     {
       text: "LAX, Los Angeles, CA, USA",
@@ -128,7 +131,7 @@ export const Suggest = {
   ]
 };
 
-export const ReverseGeocode = {
+export const ReverseGeocode: IReverseGeocodeResponse = {
   address: {
     Match_addr: "LA Airport",
     LongLabel: "LA Airport, Los Angeles, CA, USA",
@@ -161,7 +164,7 @@ export const ReverseGeocode = {
   }
 };
 
-export const GeocodeAddresses = {
+export const GeocodeAddresses: IBulkGeocodeResponse = {
   spatialReference: { wkid: 4326, latestWkid: 4326 },
   locations: [
     {
@@ -295,7 +298,7 @@ export const GeocodeAddresses = {
     {
       address: "foo bar baz",
       score: 0,
-      attributes: {}
+      attributes: {} as any
     }
   ]
 };

--- a/packages/arcgis-rest-routing/src/helpers.ts
+++ b/packages/arcgis-rest-routing/src/helpers.ts
@@ -8,7 +8,7 @@ export const ARCGIS_ONLINE_ROUTING_URL =
   "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World";
 
 // nice to have: verify custom endpoints contain 'NAServer' and end in a '/'
-export interface IEndpointRequestOptions extends IRequestOptions {
+export interface IEndpointOptions extends IRequestOptions {
   /**
    * Any ArcGIS Routing service (example: https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Network/USA/NAServer/Route/ ) to use for the routing service request.
    */

--- a/packages/arcgis-rest-routing/src/solveRoute.ts
+++ b/packages/arcgis-rest-routing/src/solveRoute.ts
@@ -10,9 +10,9 @@ import {
   IFeature
 } from "@esri/arcgis-rest-types";
 
-import { ARCGIS_ONLINE_ROUTING_URL, IEndpointRequestOptions } from "./helpers";
+import { ARCGIS_ONLINE_ROUTING_URL, IEndpointOptions } from "./helpers";
 
-export interface ISolveRouteRequestOptions extends IEndpointRequestOptions {
+export interface ISolveRouteRequestOptions extends IEndpointOptions {
   /**
    * Specify two or more locations between which the route is to be found.
    */


### PR DESCRIPTION
up until now, i wrote a `IBulkGeocodeResponse` interface, but never bothered to declare that `bulkGeocode()` returns it. whoops!

AFFECTS PACKAGES:
@esri/arcgis-rest-geocoding
@esri/arcgis-rest-routing

BREAKING CHANGE:
IGeocodeRequesttOptions is now IGeocodeOptions, IBulkGeocodingRequestOptions is now
IBulkGeocodeOptions