### PR TITLE
refactor(interfaces): removes "Request" from option interface names

### DIFF
--- a/packages/arcgis-rest-feature-layer/src/add.ts
+++ b/packages/arcgis-rest-feature-layer/src/add.ts
@@ -15,7 +15,7 @@ import { ISharedEditOptions, IEditFeatureResult } from "./helpers";
  * Add features request options. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/add-features.htm) for more information.
  *
  */
-export interface IAddFeaturesRequestOptions extends ISharedEditOptions {
+export interface IAddFeaturesOptions extends ISharedEditOptions {
   /**
    * Array of JSON features to add.
    */
@@ -41,12 +41,12 @@ export interface IAddFeaturesRequestOptions extends ISharedEditOptions {
  * @returns A Promise that will resolve with the addFeatures response.
  */
 export function addFeatures(
-  requestOptions: IAddFeaturesRequestOptions
+  requestOptions: IAddFeaturesOptions
 ): Promise<{ addResults?: IEditFeatureResult[] }> {
   const url = `${cleanUrl(requestOptions.url)}/addFeatures`;
 
   // edit operations are POST only
-  const options = appendCustomParams<IAddFeaturesRequestOptions>(
+  const options = appendCustomParams<IAddFeaturesOptions>(
     requestOptions,
     ["features", "gdbVersion", "returnEditMoment", "rollbackOnFailure"],
     { params: { ...requestOptions.params } }

--- a/packages/arcgis-rest-feature-layer/src/addAttachment.ts
+++ b/packages/arcgis-rest-feature-layer/src/addAttachment.ts
@@ -2,13 +2,13 @@
  * Apache-2.0 */
 
 import { request, cleanUrl } from "@esri/arcgis-rest-request";
-import { ILayerRequestOptions, IEditFeatureResult } from "./helpers";
+import { IGetLayerOptions, IEditFeatureResult } from "./helpers";
 
 /**
  * Request options for adding a related attachment to a feature by id. See [Add Attachment](https://developers.arcgis.com/rest/services-reference/add-attachment.htm) for more information.
  *
  */
-export interface IAddAttachmentOptions extends ILayerRequestOptions {
+export interface IAddAttachmentOptions extends IGetLayerOptions {
   /**
    * Unique identifier of feature to add related attachment.
    */

--- a/packages/arcgis-rest-feature-layer/src/decodeValues.ts
+++ b/packages/arcgis-rest-feature-layer/src/decodeValues.ts
@@ -10,7 +10,7 @@ import { getLayer } from "./getLayer";
 /**
  * Request options to fetch a feature by id.
  */
-export interface IDecodeValuesRequestOptions extends IRequestOptions {
+export interface IDecodeValuesOptions extends IRequestOptions {
   /**
    * Layer service url.
    */
@@ -58,7 +58,7 @@ export interface IDecodeValuesRequestOptions extends IRequestOptions {
  * @returns A Promise that will resolve with the addFeatures response.
  */
 export function decodeValues(
-  requestOptions: IDecodeValuesRequestOptions
+  requestOptions: IDecodeValuesOptions
 ): Promise<IQueryFeaturesResponse> {
   return new Promise(resolve => {
     if (!requestOptions.fields) {

--- a/packages/arcgis-rest-feature-layer/src/delete.ts
+++ b/packages/arcgis-rest-feature-layer/src/delete.ts
@@ -16,7 +16,7 @@ import {
  * Delete features request options. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/delete-features.htm) for more information.
  *
  */
-export interface IDeleteFeaturesRequestOptions
+export interface IDeleteFeaturesOptions
   extends ISharedEditOptions,
     ISharedQueryOptions {
   /**
@@ -40,12 +40,12 @@ export interface IDeleteFeaturesRequestOptions
  * @returns A Promise that will resolve with the deleteFeatures response.
  */
 export function deleteFeatures(
-  requestOptions: IDeleteFeaturesRequestOptions
+  requestOptions: IDeleteFeaturesOptions
 ): Promise<{ deleteResults?: IEditFeatureResult[] }> {
   const url = `${cleanUrl(requestOptions.url)}/deleteFeatures`;
 
   // edit operations POST only
-  const options = appendCustomParams<IDeleteFeaturesRequestOptions>(
+  const options = appendCustomParams<IDeleteFeaturesOptions>(
     requestOptions,
     [
       "where",

--- a/packages/arcgis-rest-feature-layer/src/deleteAttachments.ts
+++ b/packages/arcgis-rest-feature-layer/src/deleteAttachments.ts
@@ -2,13 +2,13 @@
  * Apache-2.0 */
 
 import { request, cleanUrl } from "@esri/arcgis-rest-request";
-import { ILayerRequestOptions, IEditFeatureResult } from "./helpers";
+import { IGetLayerOptions, IEditFeatureResult } from "./helpers";
 
 /**
  * Request options to for deleting related attachments of a feature by id. See [Delete Attachments](https://developers.arcgis.com/rest/services-reference/delete-attachments.htm) for more information.
  *
  */
-export interface IDeleteAttachmentsOptions extends ILayerRequestOptions {
+export interface IDeleteAttachmentsOptions extends IGetLayerOptions {
   /**
    * Unique identifier of feature to delete related attachment(s).
    */

--- a/packages/arcgis-rest-feature-layer/src/getAttachments.ts
+++ b/packages/arcgis-rest-feature-layer/src/getAttachments.ts
@@ -2,13 +2,13 @@
  * Apache-2.0 */
 
 import { request, cleanUrl } from "@esri/arcgis-rest-request";
-import { ILayerRequestOptions } from "./helpers";
+import { IGetLayerOptions } from "./helpers";
 
 /**
  * Request options to fetch `attachmentInfos` of a feature by id. See [Attachment Infos](https://developers.arcgis.com/rest/services-reference/attachment-infos-feature-service-.htm) for more information.
  *
  */
-export interface IGetAttachmentsOptions extends ILayerRequestOptions {
+export interface IGetAttachmentsOptions extends IGetLayerOptions {
   /**
    * Unique identifier of feature to request related `attachmentInfos`.
    */

--- a/packages/arcgis-rest-feature-layer/src/getLayer.ts
+++ b/packages/arcgis-rest-feature-layer/src/getLayer.ts
@@ -2,8 +2,8 @@
  * Apache-2.0 */
 
 import { request, cleanUrl } from "@esri/arcgis-rest-request";
-import { ILayerRequestOptions } from "./helpers";
 import { ILayerDefinition } from "@esri/arcgis-rest-types";
+import { IGetLayerOptions } from "./helpers";
 
 /**
  * ```js
@@ -19,8 +19,6 @@ import { ILayerDefinition } from "@esri/arcgis-rest-types";
  * @param options - Options for the request.
  * @returns A Promise that will resolve with the addFeatures response.
  */
-export function getLayer(
-  options: ILayerRequestOptions
-): Promise<ILayerDefinition> {
+export function getLayer(options: IGetLayerOptions): Promise<ILayerDefinition> {
   return request(cleanUrl(options.url), options);
 }

--- a/packages/arcgis-rest-feature-layer/src/helpers.ts
+++ b/packages/arcgis-rest-feature-layer/src/helpers.ts
@@ -11,14 +11,14 @@ import {
 /**
  * Base options for making requests against feature layers
  */
-export interface ILayerRequestOptions extends IRequestOptions {
+export interface IGetLayerOptions extends IRequestOptions {
   /**
    * Layer service url.
    */
   url: string;
 }
 
-export interface ISharedQueryOptions extends ILayerRequestOptions {
+export interface ISharedQueryOptions extends IGetLayerOptions {
   where?: string;
   geometry?: IGeometry;
   geometryType?: GeometryType;
@@ -39,7 +39,7 @@ export interface IEditFeatureResult {
 /**
  * Common add, update, and delete features options.
  */
-export interface ISharedEditOptions extends ILayerRequestOptions {
+export interface ISharedEditOptions extends IGetLayerOptions {
   /**
    * The geodatabase version to apply the edits.
    */

--- a/packages/arcgis-rest-feature-layer/src/query.ts
+++ b/packages/arcgis-rest-feature-layer/src/query.ts
@@ -15,12 +15,12 @@ import {
   IExtent
 } from "@esri/arcgis-rest-types";
 
-import { ILayerRequestOptions, ISharedQueryOptions } from "./helpers";
+import { IGetLayerOptions, ISharedQueryOptions } from "./helpers";
 
 /**
  * Request options to fetch a feature by id.
  */
-export interface IFeatureRequestOptions extends ILayerRequestOptions {
+export interface IGetFeatureOptions extends IGetLayerOptions {
   /**
    * Unique identifier of the feature.
    */
@@ -45,7 +45,7 @@ export interface IStatisticDefinition {
 /**
  * feature query request options. See [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-feature-service-layer-.htm) for more information.
  */
-export interface IQueryFeaturesRequestOptions extends ISharedQueryOptions {
+export interface IQueryFeaturesOptions extends ISharedQueryOptions {
   objectIds?: number[];
   relationParam?: string;
   // NOTE: either time=1199145600000 or time=1199145600000, 1230768000000
@@ -118,12 +118,12 @@ export interface IQueryResponse {
  * @returns A Promise that will resolve with the feature or the [response](https://developer.mozilla.org/en-US/docs/Web/API/Response) itself if `rawResponse: true` was passed in.
  */
 export function getFeature(
-  requestOptions: IFeatureRequestOptions
+  requestOptions: IGetFeatureOptions
 ): Promise<IFeature> {
   const url = `${cleanUrl(requestOptions.url)}/${requestOptions.id}`;
 
   // default to a GET request
-  const options: IFeatureRequestOptions = {
+  const options: IGetFeatureOptions = {
     ...{ httpMethod: "GET" },
     ...requestOptions
   };
@@ -151,9 +151,9 @@ export function getFeature(
  * @returns A Promise that will resolve with the query response.
  */
 export function queryFeatures(
-  requestOptions: IQueryFeaturesRequestOptions
+  requestOptions: IQueryFeaturesOptions
 ): Promise<IQueryFeaturesResponse | IQueryResponse> {
-  const queryOptions = appendCustomParams<IQueryFeaturesRequestOptions>(
+  const queryOptions = appendCustomParams<IQueryFeaturesOptions>(
     requestOptions,
     [
       "where",

--- a/packages/arcgis-rest-feature-layer/src/queryRelated.ts
+++ b/packages/arcgis-rest-feature-layer/src/queryRelated.ts
@@ -15,12 +15,12 @@ import {
   IField
 } from "@esri/arcgis-rest-types";
 
-import { ILayerRequestOptions } from "./helpers";
+import { IGetLayerOptions } from "./helpers";
 
 /**
- * Related record query request options. Additional arguments can be passed via the [params](/arcgis-rest-js/api/feature-service/IQueryRelatedRequestOptions/#params) property. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-feature-service-.htm) for more information and a full list of parameters.
+ * Related record query request options. Additional arguments can be passed via the [params](/arcgis-rest-js/api/feature-service/IQueryRelatedOptions/#params) property. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-feature-service-.htm) for more information and a full list of parameters.
  */
-export interface IQueryRelatedRequestOptions extends ILayerRequestOptions {
+export interface IQueryRelatedOptions extends IGetLayerOptions {
   relationshipId?: number;
   objectIds?: number[];
   outFields?: "*" | string[];
@@ -65,9 +65,9 @@ export interface IQueryRelatedResponse extends IHasZM {
  * @returns A Promise that will resolve with the query response
  */
 export function queryRelated(
-  requestOptions: IQueryRelatedRequestOptions
+  requestOptions: IQueryRelatedOptions
 ): Promise<IQueryRelatedResponse> {
-  const options = appendCustomParams<IQueryRelatedRequestOptions>(
+  const options = appendCustomParams<IQueryRelatedOptions>(
     requestOptions,
     ["objectIds", "relationshipId", "definitionExpression", "outFields"],
     {

--- a/packages/arcgis-rest-feature-layer/src/update.ts
+++ b/packages/arcgis-rest-feature-layer/src/update.ts
@@ -15,7 +15,7 @@ import { ISharedEditOptions, IEditFeatureResult } from "./helpers";
  * Update features request options. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/update-features.htm) for more information.
  *
  */
-export interface IUpdateFeaturesRequestOptions extends ISharedEditOptions {
+export interface IUpdateFeaturesOptions extends ISharedEditOptions {
   /**
    * Array of JSON features to update.
    */
@@ -41,12 +41,12 @@ export interface IUpdateFeaturesRequestOptions extends ISharedEditOptions {
  * @returns A Promise that will resolve with the updateFeatures response.
  */
 export function updateFeatures(
-  requestOptions: IUpdateFeaturesRequestOptions
+  requestOptions: IUpdateFeaturesOptions
 ): Promise<{ updateResults?: IEditFeatureResult[] }> {
   const url = `${cleanUrl(requestOptions.url)}/updateFeatures`;
 
   // edit operations are POST only
-  const options = appendCustomParams<IUpdateFeaturesRequestOptions>(
+  const options = appendCustomParams<IUpdateFeaturesOptions>(
     requestOptions,
     ["features", "gdbVersion", "returnEditMoment", "rollbackOnFailure"],
     { params: { ...requestOptions.params } }

--- a/packages/arcgis-rest-feature-layer/src/updateAttachment.ts
+++ b/packages/arcgis-rest-feature-layer/src/updateAttachment.ts
@@ -2,13 +2,13 @@
  * Apache-2.0 */
 
 import { request, cleanUrl } from "@esri/arcgis-rest-request";
-import { ILayerRequestOptions, IEditFeatureResult } from "./helpers";
+import { IGetLayerOptions, IEditFeatureResult } from "./helpers";
 
 /**
  * Request options to for updating a related attachment to a feature by id. See [Update Attachment](https://developers.arcgis.com/rest/services-reference/update-attachment.htm) for more information.
  *
  */
-export interface IUpdateAttachmentOptions extends ILayerRequestOptions {
+export interface IUpdateAttachmentOptions extends IGetLayerOptions {
   /**
    * Unique identifier of feature to update related attachment.
    */

--- a/packages/arcgis-rest-feature-layer/test/crud.test.ts
+++ b/packages/arcgis-rest-feature-layer/test/crud.test.ts
@@ -5,8 +5,8 @@ import {
   addFeatures,
   updateFeatures,
   deleteFeatures,
-  IDeleteFeaturesRequestOptions,
-  IUpdateFeaturesRequestOptions
+  IDeleteFeaturesOptions,
+  IUpdateFeaturesOptions
 } from "../src/index";
 
 import * as fetchMock from "fetch-mock";
@@ -79,7 +79,7 @@ describe("feature", () => {
         }
       ],
       rollbackOnFailure: false
-    } as IUpdateFeaturesRequestOptions;
+    } as IUpdateFeaturesOptions;
     fetchMock.once("*", updateFeaturesResponse);
     updateFeatures(requestOptions)
       .then(response => {
@@ -107,7 +107,7 @@ describe("feature", () => {
       url: serviceUrl,
       objectIds: [1001],
       where: "1=1"
-    } as IDeleteFeaturesRequestOptions;
+    } as IDeleteFeaturesOptions;
     fetchMock.once("*", deleteFeaturesResponse);
     deleteFeatures(requestOptions)
       .then(response => {

--- a/packages/arcgis-rest-feature-layer/test/query.test.ts
+++ b/packages/arcgis-rest-feature-layer/test/query.test.ts
@@ -5,8 +5,8 @@ import {
   getFeature,
   queryFeatures,
   queryRelated,
-  IQueryFeaturesRequestOptions,
-  IQueryRelatedRequestOptions
+  IQueryFeaturesOptions,
+  IQueryRelatedOptions
 } from "../src/index";
 
 import * as fetchMock from "fetch-mock";
@@ -65,7 +65,7 @@ describe("getFeature() and queryFeatures()", () => {
   });
 
   it("should supply default query parameters", done => {
-    const requestOptions: IQueryFeaturesRequestOptions = {
+    const requestOptions: IQueryFeaturesOptions = {
       url: serviceUrl
     };
     fetchMock.once("*", queryResponse);
@@ -85,7 +85,7 @@ describe("getFeature() and queryFeatures()", () => {
   });
 
   it("should use passed in query parameters", done => {
-    const requestOptions: IQueryFeaturesRequestOptions = {
+    const requestOptions: IQueryFeaturesOptions = {
       url: serviceUrl,
       where: "Condition='Poor'",
       outFields: ["FID", "Tree_ID", "Cmn_Name", "Condition"]
@@ -110,7 +110,7 @@ describe("getFeature() and queryFeatures()", () => {
   });
 
   it("should supply default query related parameters", done => {
-    const requestOptions: IQueryRelatedRequestOptions = {
+    const requestOptions: IQueryRelatedOptions = {
       url: serviceUrl
     };
     fetchMock.once("*", queryRelatedResponse);
@@ -132,7 +132,7 @@ describe("getFeature() and queryFeatures()", () => {
   });
 
   it("should use passed in query related parameters", done => {
-    const requestOptions: IQueryRelatedRequestOptions = {
+    const requestOptions: IQueryRelatedOptions = {
       url: serviceUrl,
       relationshipId: 1,
       definitionExpression: "APPROXACRE<10000",


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-feature-layer

BREAKING CHANGE:
Options interfaces in @esri/arcgis-rest-feature-layer have been renamed