### PR TITLE
refactor(interface names): removes "Request" from interface names in …

### DIFF
--- a/packages/arcgis-rest-routing/src/solveRoute.ts
+++ b/packages/arcgis-rest-routing/src/solveRoute.ts
@@ -12,7 +12,7 @@ import {
 
 import { ARCGIS_ONLINE_ROUTING_URL, IEndpointOptions } from "./helpers";
 
-export interface ISolveRouteRequestOptions extends IEndpointOptions {
+export interface ISolveRouteOptions extends IEndpointOptions {
   /**
    * Specify two or more locations between which the route is to be found.
    */
@@ -75,9 +75,9 @@ function isLocation(
  * @returns A Promise that will resolve with routes and directions for the request.
  */
 export function solveRoute(
-  requestOptions: ISolveRouteRequestOptions
+  requestOptions: ISolveRouteOptions
 ): Promise<ISolveRouteResponse> {
-  const options: ISolveRouteRequestOptions = {
+  const options: ISolveRouteOptions = {
     endpoint: requestOptions.endpoint || ARCGIS_ONLINE_ROUTING_URL,
     params: {},
     ...requestOptions

--- a/packages/arcgis-rest-service-admin/src/addTo.ts
+++ b/packages/arcgis-rest-service-admin/src/addTo.ts
@@ -5,8 +5,7 @@ import { request, cleanUrl } from "@esri/arcgis-rest-request";
 import { ILayer, ILayerDefinition, ITable } from "@esri/arcgis-rest-types";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
-export interface IAddToServiceDefinitionRequestOptions
-  extends IUserRequestOptions {
+export interface IAddToServiceDefinitionOptions extends IUserRequestOptions {
   /**
    * Layers to add
    */
@@ -47,7 +46,7 @@ export interface IAddToServiceDefinitionResult {
  */
 export function addToServiceDefinition(
   url: string,
-  requestOptions: IAddToServiceDefinitionRequestOptions
+  requestOptions: IAddToServiceDefinitionOptions
 ): Promise<IAddToServiceDefinitionResult> {
   const adminUrl = `${cleanUrl(url).replace(
     `/rest/services`,

--- a/packages/arcgis-rest-service-admin/src/create.ts
+++ b/packages/arcgis-rest-service-admin/src/create.ts
@@ -85,7 +85,7 @@ export interface ICreateServiceParams {
   };
 }
 
-export interface ICreateServiceRequestOptions extends IItemCrudRequestOptions {
+export interface ICreateServiceOptions extends IItemCrudRequestOptions {
   /**
    * A JSON object specifying the properties of the newly-created service. See the [REST
    * Documentation](https://developers.arcgis.com/rest/users-groups-and-items/working-with-users-groups-and-items.htm)
@@ -166,12 +166,12 @@ export interface ICreateServiceResult {
  * @returns A Promise that resolves with service details once the service has been created
  */
 export function createFeatureService(
-  requestOptions: ICreateServiceRequestOptions
+  requestOptions: ICreateServiceOptions
 ): Promise<ICreateServiceResult> {
   const owner = determineOwner(requestOptions);
   const baseUrl = `${getPortalUrl(requestOptions)}/content/users/${owner}`;
   const url = `${baseUrl}/createService`;
-  const options: ICreateServiceRequestOptions = {
+  const options: ICreateServiceOptions = {
     ...requestOptions,
     rawResponse: false
   };


### PR DESCRIPTION
…routing and service-admin

AFFECTS PACKAGES:
@esri/arcgis-rest-routing
@esri/arcgis-rest-service-admin

BREAKING CHANGE:
removed "Request" from interface names in routing and service-admin