### PR TITLE
2.0.0 doc improvements

### DIFF
--- a/docs/acetate.config.js
+++ b/docs/acetate.config.js
@@ -217,22 +217,28 @@ module.exports = function(acetate) {
 
   // <code> friendly script tag string
   acetate.helper("scriptTag", function(context, package) {
-    return `&lt;script src="https://unpkg.com/${
-      package.name
-    }@${package.version}/dist/umd/${package.name.replace("@esri/arcgis-rest-", "")}.umd.min.js"&gt;&lt;/script&gt;`;
+    return acetate.nunjucks.renderString(
+      `{% highlight "html" %}<script src="https://unpkg.com/${package.name}@${
+        package.version
+      }/dist/umd/${package.name.replace(
+        "@esri/arcgis-rest-",
+        ""
+      )}.umd.min.js>{% endhighlight %}`
+    );
   });
 
   // CDN with SRI only if hash exists
   acetate.helper("scriptTagSRI", function(context, package) {
     const hash = srihashes.packages[package.name];
     if (hash) {
-      return `<h2 class="font-size--1 trailer-half">CDN with SRI:</h2>
-      <pre><code>&lt;script src="https://unpkg.com/${package.name}@${
+      return acetate.nunjucks.renderString(`
+        {%highlight "html" %}
+        <script src="https://unpkg.com/${package.name}@${
         package.version
       }/dist/umd/${package.name.replace(
         "@esri/arcgis-rest-",
         ""
-      )}.umd.min.js" integrity="${hash}" crossorigin="anonymous"&gt;&lt;/script&gt;</code></pre>`;
+      )}.umd.min.js" integrity="${hash}" crossorigin="anonymous"></script>{% endhighlight %}`);
     } else {
       return "";
     }

--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -136,7 +136,6 @@ const md = new MarkdownIt();
     .then(declarations => {
       const blacklist = [
         "genericSearch",
-        "DEFAULT_ARCGIS_REQUEST_OPTIONS",
         "appendCustomParams",
         "requiresFormData",
         "processParams",

--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -19,7 +19,6 @@ const md = new MarkdownIt();
         OUTPUT,
         "--exclude",
         "**/*test.ts",
-        "--excludeNotExported",
         "--ignoreCompilerErrors",
         "--module",
         "common",
@@ -114,6 +113,10 @@ const md = new MarkdownIt();
        * into a giant array of all declarations in all packages.
        */
       return children.reduce((allChildren, child) => {
+        if (!child.children) {
+          console.log(child);
+          return allChildren;
+        }
         return allChildren.concat(
           child.children.map(c => {
             c.package = child.package;
@@ -128,6 +131,15 @@ const md = new MarkdownIt();
        */
       return declarations.filter(
         declaration => declaration.flags && declaration.flags.isExported
+      );
+    })
+    .then(declarations => {
+      const blacklist = ["genericSearch", "DEFAULT_ARCGIS_REQUEST_OPTIONS"];
+      /**
+       * Next we remove any declarations we want to blacklist from the API ref
+       */
+      return declarations.filter(
+        declaration => !blacklist.includes(declaration.name)
       );
     })
     .then(declarations => {

--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -134,7 +134,22 @@ const md = new MarkdownIt();
       );
     })
     .then(declarations => {
-      const blacklist = ["genericSearch", "DEFAULT_ARCGIS_REQUEST_OPTIONS"];
+      const blacklist = [
+        "genericSearch",
+        "DEFAULT_ARCGIS_REQUEST_OPTIONS",
+        "appendCustomParams",
+        "requiresFormData",
+        "processParams",
+        "encodeParam",
+        "encodeQueryString",
+        "encodeFormData",
+        "warn",
+        "cleanUrl",
+        "checkForErrors",
+        "determineOwner",
+        "isItemOwner",
+        "isOrgAdmin"
+      ];
       /**
        * Next we remove any declarations we want to blacklist from the API ref
        */
@@ -409,10 +424,10 @@ function rankChild(child) {
   if (isStatic) {
     score -= 15;
   }
-  if (!isOptional) {
+  if (!isInherited) {
     score -= 5;
   }
-  if (!isInherited) {
+  if (!isOptional) {
     score -= 15;
   }
   return score;

--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -11,303 +11,397 @@ const MarkdownIt = require("markdown-it");
 const md = new MarkdownIt();
 
 (function generateTypeDoc() {
-  return (
-    new Promise((resolve, reject) => {
-      const typedoc = spawn(
-        "typedoc",
-        [
-          "-json",
-          OUTPUT,
-          "--exclude",
-          "**/*test.ts",
-          "--ignoreCompilerErrors",
-          "--module",
-          "common",
-          "--tsconfig",
-          "./tsconfig.json"
-        ],
-        {
-          stdio: "inherit"
-        }
-      );
+  return new Promise((resolve, reject) => {
+    const typedoc = spawn(
+      "typedoc",
+      [
+        "-json",
+        OUTPUT,
+        "--exclude",
+        "**/*test.ts",
+        "--excludeNotExported",
+        "--ignoreCompilerErrors",
+        "--module",
+        "common",
+        "--tsconfig",
+        "./tsconfig.json"
+      ],
+      {
+        stdio: "inherit"
+      }
+    );
 
-      typedoc.on("close", code => {
-        if (code !== 0) {
-          reject(code);
+    typedoc.on("close", code => {
+      if (code !== 0) {
+        reject(code);
+        return;
+      }
+
+      readFile(OUTPUT, (error, content) => {
+        if (error) {
+          reject(error);
           return;
         }
 
-        readFile(OUTPUT, (error, content) => {
-          if (error) {
-            reject(error);
-            return;
-          }
+        resolve(JSON.parse(content.toString()));
+      });
+    });
+  })
+    .then(json => {
+      /**
+       * `json.children` will be a list of all TypeScript files in our project.
+       * We dont care about the files, we just need all their children so we reduce
+       * to a single list of everything in the entire project.
+       */
+      return json.children.reduce(
+        (allChildren, fileChildren) => allChildren.concat(fileChildren),
+        []
+      );
+    })
+    .then(children => {
+      /**
+       * We dont want TypeScript files that have been symlinked into `node_modules`
+       * folders by Lerna so ignore any child whose source file has `node_modules`
+       * in its `fileName`
+       */
+      return children.filter(
+        c => !minimatch(c.sources[0].fileName, "**/node_modules/**")
+      );
+    })
+    .then(children => {
+      /**
+       * We now only want children that are actual source files, not tests, so
+       * filter out all children without `src` in their path.
+       */
+      return children.filter(c =>
+        minimatch(c.sources[0].fileName, "**/src/**/*.ts")
+      );
+    })
+    .then(children => {
+      /**
+       * Some children might be empty so there is nothing to document in them.
+       * For example most `index.ts` files don't have anything besides `import`
+       * or `export` so we can safely filter these children out.
+       */
+      return children.filter(c => !!c.children);
+    })
+    .then(children => {
+      /**
+       * The `name` of each child is wrapped in extra quote marks remove these
+       * quote marks and add `.ts` back to the end of the `name`,
+       */
+      return children.map(child => {
+        child.name = child.name.replace(/\"/g, "") + ".ts";
+        return child;
+      });
+    })
+    .then(children => {
+      /**
+       * Now determine which `package` each of our children belongs to based on
+       * its name.
+       */
+      return children.map(child => {
+        child.name = _.first(child.name.split("/"));
+        child.package = child.name;
+        return child;
+      });
+    })
+    .then(children => {
+      /**
+       * `children` is currently a list of all TypeScript source files in
+       * `packages`. `children.children` is an array of all declarations in that
+       * source file. We need to concat all `children.children` arrays together
+       * into a giant array of all declarations in all packages.
+       */
+      return children.reduce((allChildren, child) => {
+        return allChildren.concat(
+          child.children.map(c => {
+            c.package = child.package;
+            return c;
+          })
+        );
+      }, []);
+    })
+    .then(declarations => {
+      /**
+       * Next we remove all children that are not exported out of their files.
+       */
+      return declarations.filter(
+        declaration => declaration.flags && declaration.flags.isExported
+      );
+    })
+    .then(declarations => {
+      /**
+       * Now that we have a list of all declarations across the entire project
+       * we can begin to generate additional information about each declaration.
+       * For example we can now determine the `src` of the page that will
+       * be generated for this declaration. Each `declaration` will also have
+       * `children` which we can generate and define an `icon` property for. These
+       * additional properties, `src`, `pageUrl`, `icon` and `children` are then
+       * merged into the `declaration`. This also adds a `title`, `description`
+       * and `titleSegments` to each page which are used in the template for SEO.
+       */
+      return declarations.map(declaration => {
+        const abbreviatedPackageName = declaration.package.replace(
+          "arcgis-rest-",
+          ""
+        );
+        const src = `arcgis-rest-js/api/${abbreviatedPackageName}/${
+          declaration.name
+        }.html`;
+        let children;
 
-          resolve(JSON.parse(content.toString()));
+        if (declaration.children) {
+          children = declaration.children.map(child => {
+            child.icon = `tsd-kind-${slug(
+              child.kindString
+            ).toLowerCase()} tsd-parent-kind-${slug(
+              declaration.kindString
+            ).toLowerCase()}`;
+
+            if (child.flags.isPrivate) {
+              child.icon += ` tsd-is-private`;
+            }
+
+            if (child.flags.isProtected) {
+              child.icon += ` tsd-is-protected`;
+            }
+
+            if (child.flags.isStatic) {
+              child.icon += ` tsd-is-static`;
+            }
+
+            if (child.signatures) {
+              child.signatures = child.signatures.map(sig => {
+                sig.icon = child.icon;
+                return sig;
+              });
+            }
+
+            return child;
+          });
+        }
+
+        declaration.title = declaration.name;
+        declaration.titleSegments = ["API Reference"];
+        declaration.description =
+          declaration.comment && declaration.comment.shortText
+            ? cheerio
+                .load(md.render(declaration.comment.shortText))
+                .text()
+                .replace("\n", "")
+            : "API Reference documentation for ${child.name}, part of ${declaration.package}.";
+
+        return Object.assign(declaration, {
+          src,
+          pageUrl: prettyifyUrl(src),
+          icon: `tsd-kind-${slug(declaration.kindString).toLowerCase()}`,
+          children
         });
       });
     })
-      .then(json => {
-        /**
-         * `json.children` will be a list of all TypeScript files in our project.
-         * We dont care about the files, we just need all their children so we reduce
-         * to a single list of everything in the entire project.
-         */
-        return json.children.reduce(
-          (allChildren, fileChildren) => allChildren.concat(fileChildren),
-          []
-        );
-      })
-      .then(children => {
-        /**
-         * We dont want TypeScript files that have been symlinked into `node_modules`
-         * folders by Lerna so ignore any child whose source file has `node_modules`
-         * in its `fileName`
-         */
-        return children.filter(
-          c => !minimatch(c.sources[0].fileName, "**/node_modules/**")
-        );
-      })
-      .then(children => {
-        /**
-         * We now only want children that are actual source files, not tests, so
-         * filter out all children without `src` in their path.
-         */
-        return children.filter(c =>
-          minimatch(c.sources[0].fileName, "**/src/**/*.ts")
-        );
-      })
-      .then(children => {
-        /**
-         * Some children might be empty so there is nothing to document in them.
-         * For example most `index.ts` files don't have anything besides `import`
-         * or `export` so we can safely filter these children out.
-         */
-        return children.filter(c => !!c.children);
-      })
-      .then(children => {
-        /**
-         * The `name` of each child is wrapped in extra quote marks remove these
-         * quote marks and add `.ts` back to the end of the `name`,
-         */
-        return children.map(child => {
-          child.name = child.name.replace(/\"/g, "") + ".ts";
-          return child;
-        });
-      })
-      .then(children => {
-        /**
-         * Now determine which `package` each of our children belongs to based on
-         * its name.
-         */
-        return children.map(child => {
-          child.name = _.first(child.name.split("/"));
-          child.package = child.name;
-          return child;
-        });
-      })
-      .then(children => {
-        /**
-         * `children` is currently a list of all TypeScript source files in
-         * `packages`. `children.children` is an array of all declarations in that
-         * source file. We need to concat all `children.children` arrays together
-         * into a giant array of all declarations in all packages.
-         */
-        return children.reduce((allChildren, child) => {
-          return allChildren.concat(
-            child.children.map(c => {
-              c.package = child.package;
-              return c;
-            })
-          );
-        }, []);
-      })
-      // .then(children => {
-      //   /**
-      //    * Next we remove all children that are not exported out of their files.
-      //    */
-      //   return children.filter(c => c.flags && c.flags.isExported);
-      // })
-      .then(declarations => {
-        /**
-         * Now that we have a list of all declarations across the entire project
-         * we can begin to generate additional information about each declaration.
-         * For example we can now determine the `src` of the page that will
-         * be generated for this declaration. Each `declaration` will also have
-         * `children` which we can generate and define an `icon` property for. These
-         * additional properties, `src`, `pageUrl`, `icon` and `children` are then
-         * merged into the `declaration`. This also adds a `title`, `description`
-         * and `titleSegments` to each page which are used in the template for SEO.
-         */
-        return declarations.map(declaration => {
-          const abbreviatedPackageName = declaration.package.replace(
-            "arcgis-rest-",
-            ""
-          );
-          const src = `arcgis-rest-js/api/${abbreviatedPackageName}/${
-            declaration.name
-          }.html`;
-          let children;
+    .then(declarations => {
+      /**
+       * We now have a list of `declarations` that will be used to generate the
+       * individual API reference pages, but we still need to generate a landing
+       * page for each `package`. Return a new object with our `declarations` and
+       * a new property `packages` which is an array of every `package` with a
+       * page `src`, a `pageUrl`, an `icon` and a list of `declarations`. This
+       * also adds a `title`, `description` and `titleSegments` to each page
+       * which are used in the template for SEO.
+       */
+      return {
+        declarations,
+        packages: _(declarations)
+          .map(d => d.package)
+          .uniq()
+          .reduce((packages, package) => {
+            const abbreviatedPackageName = package.replace("arcgis-rest-", "");
+            const src = `arcgis-rest-js/api/${abbreviatedPackageName}.html`;
+            const pkg = require(`${process.cwd()}/packages/${package}/package.json`);
 
-          if (declaration.children) {
-            children = declaration.children.map(child => {
-              child.icon = `tsd-kind-${slug(
-                child.kindString
-              ).toLowerCase()} tsd-parent-kind-${slug(
-                declaration.kindString
-              ).toLowerCase()}`;
+            packages.push({
+              package,
+              pkg,
+              title: package,
+              description: pkg.description,
+              titleSegments: ["API Reference"],
+              name: package,
+              declarations: declarations
+                .filter(d => d.package === package)
+                .sort((da, db) => {
+                  const types = [
+                    "Class",
+                    "Function",
+                    "Object literal",
+                    "Variable",
+                    "Enumeration",
+                    "Type alias",
+                    "Interface"
+                  ];
 
-              if (child.flags.isPrivate) {
-                child.icon += ` tsd-is-private`;
-              }
+                  const aIndex = types.findIndex(t => da.kindString === t);
+                  const bIndex = types.findIndex(t => db.kindString === t);
 
-              if (child.flags.isProtected) {
-                child.icon += ` tsd-is-protected`;
-              }
-
-              if (child.flags.isStatic) {
-                child.icon += ` tsd-is-static`;
-              }
-
-              if (child.signatures) {
-                child.signatures = child.signatures.map(sig => {
-                  sig.icon = child.icon;
-                  return sig;
-                });
-              }
-
-              return child;
+                  if (aIndex > bIndex) {
+                    return 1;
+                  } else if (aIndex < bIndex) {
+                    return -1;
+                  } else {
+                    return 0;
+                  }
+                }),
+              icon: "tsd-kind-module",
+              src,
+              pageUrl: prettyifyUrl(src)
             });
+            return packages;
+          }, [])
+      };
+    })
+    .then(api => {
+      /**
+       * Since we generated the TypeDoc for the entire project at once each
+       * `declaration` has a unique numerical `id` property. We occasionally
+       * need to lookup a declaration by its `id` so we can prebuild an index of
+       * them here.
+       */
+      api.index = api.declarations.reduce((index, declaration) => {
+        index[declaration.id] = declaration;
+        return index;
+      }, {});
+
+      return api;
+    })
+    .then(api => {
+      /**
+       * In order to power the API reference quick search we can build an array
+       * of all declarations and child items
+       */
+      api.quickSearchIndex = api.declarations.reduce(
+        (quickSearchIndex, declaration) => {
+          if (declaration.children) {
+            quickSearchIndex = quickSearchIndex.concat(
+              declaration.children.map(child => {
+                return {
+                  title: `${declaration.name}.${child.name}`,
+                  url: `${declaration.pageUrl}#${child.name}`,
+                  icon: child.icon
+                };
+              })
+            );
           }
 
-          declaration.title = declaration.name;
-          declaration.titleSegments = ["API Reference"];
-          declaration.description =
-            declaration.comment && declaration.comment.shortText
-              ? cheerio
-                  .load(md.render(declaration.comment.shortText))
-                  .text()
-                  .replace("\n", "")
-              : "API Reference documentation for ${child.name}, part of ${declaration.package}.";
+          return quickSearchIndex.concat([
+            {
+              title: declaration.name,
+              url: declaration.pageUrl,
+              icon: declaration.icon
+            }
+          ]);
+        },
+        []
+      );
 
-          return Object.assign(declaration, {
-            src,
-            pageUrl: prettyifyUrl(src),
-            icon: `tsd-kind-${slug(declaration.kindString).toLowerCase()}`,
-            children
+      return api;
+    })
+    .then(api => {
+      /**
+       * Next we can sort the children of each declaration to sort by required/optional/inherited
+       */
+      api.declarations = api.declarations.map(declaration => {
+        if (declaration.children) {
+          declaration.children.sort((ca, cb) => {
+            const aIndex = rankChild(ca);
+            const bIndex = rankChild(cb);
+
+            if (aIndex > bIndex) {
+              return 1; // sort a below b
+            } else if (aIndex < bIndex) {
+              return -1; // sort a above b
+            } else {
+              return 0;
+            }
+            return 0;
           });
-        });
-      })
-      .then(declarations => {
-        /**
-         * We now have a list of `declarations` that will be used to generate the
-         * individual API reference pages, but we still need to generate a landing
-         * page for each `package`. Return a new object with our `declarations` and
-         * a new property `packages` which is an array of every `package` with a
-         * page `src`, a `pageUrl`, an `icon` and a list of `declarations`. This
-         * also adds a `title`, `description` and `titleSegments` to each page
-         * which are used in the template for SEO.
-         */
-        return {
-          declarations,
-          packages: _(declarations)
-            .map(d => d.package)
-            .uniq()
-            .reduce((packages, package) => {
-              const abbreviatedPackageName = package.replace(
-                "arcgis-rest-",
-                ""
-              );
-              const src = `arcgis-rest-js/api/${abbreviatedPackageName}.html`;
-              const pkg = require(`${process.cwd()}/packages/${package}/package.json`);
+        }
 
-              packages.push({
-                package,
-                pkg,
-                title: package,
-                description: pkg.description,
-                titleSegments: ["API Reference"],
-                name: package,
-                declarations: declarations.filter(d => d.package === package),
-                icon: "tsd-kind-module",
-                src,
-                pageUrl: prettyifyUrl(src)
+        if (declaration.groups) {
+          declaration.groups.forEach(group => {
+            if (group.children) {
+              group.children.sort((ca, cb) => {
+                const childA = declaration.children.find(c => c.id === ca);
+                const childB = declaration.children.find(c => c.id === cb);
+
+                const aIndex = rankChild(childA);
+                const bIndex = rankChild(childB);
+
+                if (aIndex > bIndex) {
+                  return 1;
+                } else if (aIndex < bIndex) {
+                  return -1;
+                } else {
+                  return 0;
+                }
+                return 0;
               });
-              return packages;
-            }, [])
-        };
-      })
-      .then(api => {
-        /**
-         * Since we generated the TypeDoc for the entire project at once each
-         * `declaration` has a unique numerical `id` property. We occasionally
-         * need to lookup a declaration by its `id` so we can prebuild an index of
-         * them here.
-         */
-        api.index = api.declarations.reduce((index, declaration) => {
-          index[declaration.id] = declaration;
-          return index;
-        }, {});
-
-        return api;
-      })
-      .then(api => {
-        /**
-         * In order to power the API reference quick search we can build an array
-         * of all declarations and child items
-         */
-        api.quickSearchIndex = api.declarations.reduce(
-          (quickSearchIndex, declaration) => {
-            if (declaration.children) {
-              quickSearchIndex = quickSearchIndex.concat(
-                declaration.children.map(child => {
-                  return {
-                    title: `${declaration.name}.${child.name}`,
-                    url: `${declaration.pageUrl}#${child.name}`,
-                    icon: child.icon
-                  };
-                })
-              );
             }
-
-            return quickSearchIndex.concat([
-              {
-                title: declaration.name,
-                url: declaration.pageUrl,
-                icon: declaration.icon
-              }
-            ]);
-          },
-          []
-        );
-
-        return api;
-      })
-      .then(api => {
-        /**
-         * Our final object looks like this:
-         *
-         * {
-         *   packages: [Array of packages.],
-         *   declarations: [Array of each exported declaration accross all source files.]
-         *   index: { Object mapping each declaration.id as a key with the declaration as its value}
-         * }
-         *
-         * We now export this to the Acetate source directory.
-         */
-        return new Promise((resolve, reject) => {
-          writeFile(OUTPUT, JSON.stringify(api, null, 2), e => {
-            if (e) {
-              reject(e);
-              return;
-            }
-
-            resolve(api);
           });
+        }
+
+        return declaration;
+      });
+
+      return api;
+    })
+    .then(api => {
+      /**
+       * Our final object looks like this:
+       *
+       * {
+       *   packages: [Array of packages.],
+       *   declarations: [Array of each exported declaration accross all source files.]
+       *   index: { Object mapping each declaration.id as a key with the declaration as its value}
+       * }
+       *
+       * We now export this to the Acetate source directory.
+       */
+      return new Promise((resolve, reject) => {
+        writeFile(OUTPUT, JSON.stringify(api, null, 2), e => {
+          if (e) {
+            reject(e);
+            return;
+          }
+
+          resolve(api);
         });
-      })
-      .catch(e => {
-        console.error(e);
-      })
-  );
+      });
+    })
+    .catch(e => {
+      console.error(e);
+    });
 })();
+
+function rankChild(child) {
+  const { isPrivate, isPublic, isOptional, isStatic } = child
+    ? child.flags
+    : {};
+
+  const isInherited = child.inheritedFrom ? true : false;
+
+  let score = 0;
+
+  if (isPrivate) {
+    score += 30;
+  }
+  if (isStatic) {
+    score -= 15;
+  }
+  if (!isOptional) {
+    score -= 5;
+  }
+  if (!isInherited) {
+    score -= 15;
+  }
+  return score;
+}

--- a/docs/src/_layout.html
+++ b/docs/src/_layout.html
@@ -64,11 +64,13 @@
       </main>
     </div>
 
-    <footer class="footer leader-1">
+    <footer class="footer">
       {% block footer %}{% endblock %}
-      <div class="grid-container">
-        <div class="column-24 trailer-half">
-          <a href="https://github.com/Esri/arcgis-rest-js" class="font-size--1">Fork this project on GitHub</a>
+      <div class="panel panel-white">
+        <div class="grid-container">
+          <div class="column-24">
+            <a href="https://github.com/Esri/arcgis-rest-js" class="font-size--2">Fork this project on GitHub</a>
+          </div>
         </div>
       </div>
     </footer>

--- a/docs/src/_layout.html
+++ b/docs/src/_layout.html
@@ -20,7 +20,7 @@
           <h2 class="side-nav-title">ArcGIS REST JS</h2>
           {% link "/arcgis-rest-js/guides/", "Guides", class="side-nav-link" %}
           {% link "/arcgis-rest-js/api/", "API Reference", class="side-nav-link"%}
-          {% link "https://github.com/Esri/arcgis-rest-js", "GitHub", class="top-nav-link" %}
+          {% link "https://github.com/Esri/arcgis-rest-js", "GitHub", class="side-nav-link" %}
         </aside>
       </nav>
     </div>
@@ -69,13 +69,13 @@
       <div class="panel panel-white">
         <div class="grid-container">
           <div class="column-24">
-            <a href="https://github.com/Esri/arcgis-rest-js" class="font-size--2">Fork this project on GitHub</a>
+            <a href="https://github.com/Esri/arcgis-rest-js" class="font-size--2">Fork this project</a>
           </div>
         </div>
       </div>
     </footer>
 
-    <script src="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.0.0-rc.7/js/calcite-web.min.js"></script>
+    <script src="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.2.5/js/calcite-web.min.js"></script>
 
     <script>
        calcite.init()

--- a/docs/src/_layout.html
+++ b/docs/src/_layout.html
@@ -8,7 +8,7 @@
     {% if description %}
     <meta name="description" content="A modular, high quality toolkit for working with the ArcGIS REST API.">
     {% endif %}
-    <link rel="stylesheet" href="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.0.0-rc.7/css/calcite-web.min.css">
+    <link rel="stylesheet" href="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.2.5/css/calcite-web.min.css">
     <link rel="stylesheet" href="/arcgis-rest-js/css/style.css">
     {% block css %}{% endblock %}
   </head>
@@ -20,6 +20,7 @@
           <h2 class="side-nav-title">ArcGIS REST JS</h2>
           {% link "/arcgis-rest-js/guides/", "Guides", class="side-nav-link" %}
           {% link "/arcgis-rest-js/api/", "API Reference", class="side-nav-link"%}
+          {% link "https://github.com/Esri/arcgis-rest-js", "GitHub", class="top-nav-link" %}
         </aside>
       </nav>
     </div>
@@ -37,6 +38,7 @@
               <nav class="top-nav-list" role="navigation" aria-labelledby="topnav">
                 {% link "/arcgis-rest-js/guides/", "Guides", class="top-nav-link" %}
                 {% link "/arcgis-rest-js/api/", "API Reference", class="top-nav-link"%}
+                {% link "https://github.com/Esri/arcgis-rest-js", "GitHub", class="top-nav-link" %}
               </nav>
             </div>
 

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -566,11 +566,20 @@
 
 <hr class="leader-half trailer-half">
 
+{% if signatures[0].comment.tags %}
+  {% for tag in signatures[0].comment.tags %}
+    {% if tag.tag === "restlink" %}
+      <small class="font-size--2">REST API documentation for <code>{{name}}()</code> at <a href="{{tag.text}}">{{tag.text}}</a></small>
+      <br>
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
 <small class="font-size--2">{{kindString}} defined in <a href="https://github.com/Esri/arcgis-rest-js/blob/master/packages/{{sources[0].fileName}}#L{{sources[0].line}}">packages/{{sources[0].fileName}}:{{sources[0].line}}</a></small>
 
 {% if isDev %}
   <details class="leader-1">
     <summary>Debug Info</summary>
-    <pre><code>{{signatures[0].parameters | inspect}}</code></pre>
+    <pre><code>{{signatures[0].comment.tags | inspect}}</code></pre>
   </details>
 {% endif %}

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -1,4 +1,4 @@
-{% macro @type(type) -%}
+{% macro @type(type, isArray) -%}
   {%- if type.type === 'stringLiteral' -%}
     <span class="text-green">"{{type.value}}"</span>
   {%- endif -%}
@@ -11,9 +11,11 @@
     </dl>}
   {%- endif -%}
 
-  {% if type.type === 'array' %}
+  {%- if type.type === 'array' and (type.elementType.type === "union" or (type.elementType.type === "typeParameter" and type.elementType.constraint.type === "union")) -%}
+    <i class="no-wrap">{{ @type(type.elementType, true) }}</i>
+  {%- elif  type.type === 'array'  -%}
     <i class="no-wrap">{{ @type(type.elementType) }}<span class="text-light-gray">{{ '[]' }}</span></i>
-  {% endif %}
+  {%- endif -%}
 
   {%- if type.type === 'intrinsic' -%}
     <i class="text-purple">{{type.name}}</i>
@@ -42,7 +44,7 @@
 
   {%- if type.type === 'union' -%}
     <i>{%- for t in type.types -%}
-      {{ @type(t) }}
+      {{ @type(t) }}{% if isArray %}<span class="text-light-gray">{{ '[]' }}</span>{% endif %}
 
       {%- if (loop.last === false) -%}
         <span class="text-light-gray">{{ ' | ' }}</span>
@@ -63,6 +65,10 @@
         <span class="text-light-gray">{{ ']' }}</span>
       {%- endif -%}
     {%- endfor -%}</i>
+  {%- endif -%}
+
+  {%- if type.type === 'typeParameter' and type.constraint -%}
+    {{ @type(type.constraint, isArray) }}
   {%- endif -%}
 
   {%- if type.typeArguments -%}

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -1,4 +1,8 @@
 {% macro @type(type) -%}
+  {%- if type.type === 'stringLiteral' -%}
+    <span class="text-green">"{{type.value}}"</span>
+  {%- endif -%}
+
   {%- if type.declaration and type.declaration.children -%}
     {<dl class="type-child-list clearfix">
     {%- for child in type.declaration.children -%}
@@ -38,11 +42,7 @@
 
   {%- if type.type === 'union' -%}
     <i>{%- for t in type.types -%}
-      {%- if t.type === 'stringLiteral' -%}
-        <span class="text-green">"{{t.value}}"</span>
-      {%- else -%}
-        {{ @type(t) }}
-      {%- endif -%}
+      {{ @type(t) }}
 
       {%- if (loop.last === false) -%}
         <span class="text-light-gray">{{ ' | ' }}</span>
@@ -507,8 +507,8 @@
 {% endif %}
 
 {% if type %}
-  Value(s):<br>
-  <pre>{{@type(type)}}</pre>
+  Value(s):
+  <pre style="display: inline;">{{@type(type)}}</pre>
 {% endif %}
 
 {% if groups %}

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -310,8 +310,6 @@
               {% for signature in child.signatures -%}
                 <li class="code-face tsd-signature tsd-kind-icon">
                   <a href="#{{signature.name}}">{{ signature.name }}</a><span class="text-light-gray">(</span>{{ @signatureParams(signature.parameters) }}<span class="text-light-gray">)</span>
-                  {{ @flags(child.flags) }}
-                  {{ @inherited(child.inheritedFrom) }}
                 </li>
               {%- endfor %}
             </ul>

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -569,7 +569,7 @@
 {% if signatures[0].comment.tags %}
   {% for tag in signatures[0].comment.tags %}
     {% if tag.tag === "restlink" %}
-      <small class="font-size--2">REST API documentation for <code>{{name}}()</code> at <a href="{{tag.text}}">{{tag.text}}</a></small>
+      <small class="font-size--2">REST API documentation for <code>{{name}}()</code> available at <a href="{{tag.text}}">{{tag.text}}</a></small>
       <br>
     {% endif %}
   {% endfor %}

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -448,7 +448,7 @@
         {%- endfor %}
       </tbody>
     </table>
-  <div>
+  </div>
 {% endmacro %}
 
 <div class="clearfix trailer-half">

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -83,7 +83,7 @@
 {%- endmacro %}
 
 {% macro @signature(signature) -%}
-  <li class="code-face tsd-signature tsd-kind-icon">{{ signature.name }}<span class="text-light-gray">(</span>{{ @signatureParams(signature.parameters) }}<span class="text-light-gray">) : </span>{{@type(signature.type)}}</li>
+  <li class="code-face tsd-signature tsd-kind-icon trailer-0 leader-0">{{ signature.name }}<span class="text-light-gray">(</span>{{ @signatureParams(signature.parameters) }}<span class="text-light-gray">) : </span>{{@type(signature.type)}}</li>
 {%- endmacro %}
 
 {% macro @inherited(inheritedFrom) -%}
@@ -96,7 +96,7 @@
   {% if header %}
     <h2 class="font-size-1 trailer-half">{{header | safe}}</h2>
   {% endif %}
-  <table>
+  <table class="table">
     <thead>
       <tr>
         <th>{{column1Header}}</th>
@@ -137,7 +137,7 @@
 {% endmacro %}
 
 {% macro @properties (group, children) %}
-  <table>
+  <table class="table">
     <thead>
       <tr>
         <th>{{ API_TOOLS.findChildById(group.children[0], children).kindString }}</th>
@@ -179,7 +179,7 @@
 {% endmacro %}
 
 {% macro @indexSignature (signatures, parentKind) %}
-  <table>
+  <table class="table">
     <thead>
       <tr>
         <th>Key Type</th>
@@ -244,11 +244,13 @@
     {{ signatures[0].comment.shortText | safe }}
   {%- endmarkdown %}
 
-  <ul class="list-plain tsd-signatures {{icon}} trailer-half">
-    {% for signature in signatures %}
-      {{ @signature(signature) }}
-    {% endfor %}
-  </ul>
+  <div class="panel padding-leader-half padding-trailer-half padding-right-quarter padding-left-half trailer-half">
+    <ul class="list-plain tsd-signatures {{icon}} trailer-0 leader-0">
+      {% for signature in signatures %}
+        {{ @signature(signature) }}
+      {% endfor %}
+    </ul>
+  </div>
 
   {% if signatures[0].parameters %}
     <h2 class="font-size-1 trailer-half">Parameters</h2>
@@ -269,8 +271,12 @@
   <h2 class="font-size-1 trailer-half">Returns</h2>
 
   {%- markdown -%}
-    <code>{{@type(signatures[0].type)}}</code>{{" - " if signatures[0].comment.returns}}{{ signatures[0].comment.returns | safe }}
+    {{ signatures[0].comment.returns | safe }}
   {%- endmarkdown %}
+
+  <div class="fonts-size--1 panel padding-leader-half padding-trailer-half padding-right-half padding-left-half trailer-half">
+  {{@type(signatures[0].type)}}
+  </div>
 
   {% if signatures[0].comment.text %}
     <hr class="leader-half trailer-half">
@@ -290,7 +296,7 @@
 {% endmacro %}
 
 {% macro @methodsTable(group, children) %}
-  <table>
+  <table class="table">
     <thead>
     <tr>
       <th>Method</th>
@@ -395,7 +401,7 @@
 {% endmacro %}
 
 {% macro @parametersTable(parameters, fnName) %}
-  <table>
+  <table class="table">
     <thead>
       <tr>
         <th class="font-size--2">Parameter</th>
@@ -441,7 +447,7 @@
   <small class="{{icon}} font-size--2 right"><span class="tsd-kind-icon">{{kindString}}</span></small>
 </div>
 
-<hr class="leader-half trailer-1">
+<hr class="leader-half trailer-half">
 
 {% if comment %}
   {% markdown -%}

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -96,125 +96,131 @@
   {% if header %}
     <h2 class="font-size-1 trailer-half">{{header | safe}}</h2>
   {% endif %}
-  <table class="table">
-    <thead>
-      <tr>
-        <th>{{column1Header}}</th>
-        <th>{{column2Header}}</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for child in API_TOOLS.findById(data.typedoc, id).children %}
-        <tr id="{{child.name}}">
-          <td class="code-face {{child.icon}} no-wrap">
-            <a href="#{{child.name}}" class="table-link">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M28.633 17.945l-4.118-4.426c.076 1.131-.034 2.262-.355 3.241l2.83 2.827a5.281 5.281 0 0 1 0 7.459 5.223 5.223 0 0 1-3.723 1.54 5.227 5.227 0 0 1-3.728-1.542l-5.459-5.459a5.276 5.276 0 0 1 0-7.452c.607-.609 1.361-1.048 2.1-1.229a1.833 1.833 0 0 0-.279-.414l-1.344-1.461c-.845.404-1.54.881-2.12 1.461a7.554 7.554 0 0 0-2.223 5.371c0 2.027.791 3.934 2.223 5.366l5.459 5.459a7.544 7.544 0 0 0 5.371 2.225 7.55 7.55 0 0 0 5.366-2.223c2.962-2.962 2.962-7.782 0-10.745zM8.711 3.497a5.23 5.23 0 0 1 3.726 1.54l5.459 5.457a5.279 5.279 0 0 1 0 7.454c-.605.605-1.356 1.043-2.105 1.222.086.154.166.301.287.421l1.422 1.422c.808-.394 1.476-.862 2.039-1.422 2.96-2.962 2.96-7.777 0-10.74L14.08 3.394c-1.434-1.435-3.342-2.225-5.369-2.225s-3.934.791-5.369 2.225C1.908 4.828 1.117 6.736 1.117 8.763s.791 3.934 2.225 5.369L7.46 18.56c-.076-1.131.034-2.262.355-3.239l-2.83-2.833c-.994-.991-1.542-2.316-1.542-3.726s.548-2.732 1.542-3.726a5.23 5.23 0 0 1 3.726-1.54z"/></svg>
-            </a>
-            <span class="tsd-kind-icon">{{child.name}}</span>
-            {{ @flags(child.flags) }}
-            {{ @inherited(child.inheritedFrom) }}
-          </td>
-          <td class="code-face">
-            {% if child.defaultValue %}
-              {{ child.defaultValue }}
-            {% elif child.getSignature %}
-              {{ @type(child.getSignature[0].type) }}
-            {% else %}
-              {{ @type(child.type) }}
-            {% endif %}
-          </td>
-          <td class="body-face api-param-comment">
-            {% markdown -%}
-              {{ child.comment.shortText | safe | trim }}
-            {%- endmarkdown %}
-          </td>
+  <div class="overflow-auto trailer-1">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>{{column1Header}}</th>
+          <th>{{column2Header}}</th>
+          <th>Notes</th>
         </tr>
-      {% endfor %}
+      </thead>
+      <tbody>
+        {% for child in API_TOOLS.findById(data.typedoc, id).children %}
+          <tr id="{{child.name}}">
+            <td class="code-face {{child.icon}} no-wrap">
+              <a href="#{{child.name}}" class="table-link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M28.633 17.945l-4.118-4.426c.076 1.131-.034 2.262-.355 3.241l2.83 2.827a5.281 5.281 0 0 1 0 7.459 5.223 5.223 0 0 1-3.723 1.54 5.227 5.227 0 0 1-3.728-1.542l-5.459-5.459a5.276 5.276 0 0 1 0-7.452c.607-.609 1.361-1.048 2.1-1.229a1.833 1.833 0 0 0-.279-.414l-1.344-1.461c-.845.404-1.54.881-2.12 1.461a7.554 7.554 0 0 0-2.223 5.371c0 2.027.791 3.934 2.223 5.366l5.459 5.459a7.544 7.544 0 0 0 5.371 2.225 7.55 7.55 0 0 0 5.366-2.223c2.962-2.962 2.962-7.782 0-10.745zM8.711 3.497a5.23 5.23 0 0 1 3.726 1.54l5.459 5.457a5.279 5.279 0 0 1 0 7.454c-.605.605-1.356 1.043-2.105 1.222.086.154.166.301.287.421l1.422 1.422c.808-.394 1.476-.862 2.039-1.422 2.96-2.962 2.96-7.777 0-10.74L14.08 3.394c-1.434-1.435-3.342-2.225-5.369-2.225s-3.934.791-5.369 2.225C1.908 4.828 1.117 6.736 1.117 8.763s.791 3.934 2.225 5.369L7.46 18.56c-.076-1.131.034-2.262.355-3.239l-2.83-2.833c-.994-.991-1.542-2.316-1.542-3.726s.548-2.732 1.542-3.726a5.23 5.23 0 0 1 3.726-1.54z"/></svg>
+              </a>
+              <span class="tsd-kind-icon">{{child.name}}</span>
+              {{ @flags(child.flags) }}
+              {{ @inherited(child.inheritedFrom) }}
+            </td>
+            <td class="code-face">
+              {% if child.defaultValue %}
+                {{ child.defaultValue }}
+              {% elif child.getSignature %}
+                {{ @type(child.getSignature[0].type) }}
+              {% else %}
+                {{ @type(child.type) }}
+              {% endif %}
+            </td>
+            <td class="body-face api-param-comment">
+              {% markdown -%}
+                {{ child.comment.shortText | safe | trim }}
+              {%- endmarkdown %}
+            </td>
+          </tr>
+        {% endfor %}
 
-    </tbody>
-  </table>
+      </tbody>
+    </table>
+  </div>
 {% endmacro %}
 
 {% macro @properties (group, children) %}
-  <table class="table">
-    <thead>
-      <tr>
-        <th>{{ API_TOOLS.findChildById(group.children[0], children).kindString }}</th>
-        <th>{{ 'Value' if API_TOOLS.findChildById(group.children[0], children).defaultValue else 'Type' }}</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for id in group.children %}
-        {% set child = API_TOOLS.findChildById(id, children) %}
-        <tr id="{{child.name}}">
-          <td class="code-face {{child.icon}} no-wrap">
-            <a href="#{{child.name}}" class="table-link">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M28.633 17.945l-4.118-4.426c.076 1.131-.034 2.262-.355 3.241l2.83 2.827a5.281 5.281 0 0 1 0 7.459 5.223 5.223 0 0 1-3.723 1.54 5.227 5.227 0 0 1-3.728-1.542l-5.459-5.459a5.276 5.276 0 0 1 0-7.452c.607-.609 1.361-1.048 2.1-1.229a1.833 1.833 0 0 0-.279-.414l-1.344-1.461c-.845.404-1.54.881-2.12 1.461a7.554 7.554 0 0 0-2.223 5.371c0 2.027.791 3.934 2.223 5.366l5.459 5.459a7.544 7.544 0 0 0 5.371 2.225 7.55 7.55 0 0 0 5.366-2.223c2.962-2.962 2.962-7.782 0-10.745zM8.711 3.497a5.23 5.23 0 0 1 3.726 1.54l5.459 5.457a5.279 5.279 0 0 1 0 7.454c-.605.605-1.356 1.043-2.105 1.222.086.154.166.301.287.421l1.422 1.422c.808-.394 1.476-.862 2.039-1.422 2.96-2.962 2.96-7.777 0-10.74L14.08 3.394c-1.434-1.435-3.342-2.225-5.369-2.225s-3.934.791-5.369 2.225C1.908 4.828 1.117 6.736 1.117 8.763s.791 3.934 2.225 5.369L7.46 18.56c-.076-1.131.034-2.262.355-3.239l-2.83-2.833c-.994-.991-1.542-2.316-1.542-3.726s.548-2.732 1.542-3.726a5.23 5.23 0 0 1 3.726-1.54z"/></svg>
-            </a>
-            <span class="tsd-kind-icon">{{child.name}}</span>
-            {{ @flags(child.flags) }}
-            {{ @inherited(child.inheritedFrom) }}
-          </td>
-          <td class="code-face">
-            {% if child.defaultValue %}
-              {{ child.defaultValue }}
-            {% elif child.getSignature %}
-              {{ @type(child.getSignature[0].type) }}
-            {% else %}
-              {{ @type(child.type) }}
-            {% endif %}
-          </td>
-          <td class="body-face api-param-comment">
-            {% markdown -%}
-              {{ child.comment.shortText | safe | trim }}
-            {%- endmarkdown %}
-          </td>
+  <div class="overflow-auto trailer-1">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>{{ API_TOOLS.findChildById(group.children[0], children).kindString }}</th>
+          <th>{{ 'Value' if API_TOOLS.findChildById(group.children[0], children).defaultValue else 'Type' }}</th>
+          <th>Notes</th>
         </tr>
-      {% endfor %}
+      </thead>
+      <tbody>
+        {% for id in group.children %}
+          {% set child = API_TOOLS.findChildById(id, children) %}
+          <tr id="{{child.name}}">
+            <td class="code-face {{child.icon}} no-wrap">
+              <a href="#{{child.name}}" class="table-link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M28.633 17.945l-4.118-4.426c.076 1.131-.034 2.262-.355 3.241l2.83 2.827a5.281 5.281 0 0 1 0 7.459 5.223 5.223 0 0 1-3.723 1.54 5.227 5.227 0 0 1-3.728-1.542l-5.459-5.459a5.276 5.276 0 0 1 0-7.452c.607-.609 1.361-1.048 2.1-1.229a1.833 1.833 0 0 0-.279-.414l-1.344-1.461c-.845.404-1.54.881-2.12 1.461a7.554 7.554 0 0 0-2.223 5.371c0 2.027.791 3.934 2.223 5.366l5.459 5.459a7.544 7.544 0 0 0 5.371 2.225 7.55 7.55 0 0 0 5.366-2.223c2.962-2.962 2.962-7.782 0-10.745zM8.711 3.497a5.23 5.23 0 0 1 3.726 1.54l5.459 5.457a5.279 5.279 0 0 1 0 7.454c-.605.605-1.356 1.043-2.105 1.222.086.154.166.301.287.421l1.422 1.422c.808-.394 1.476-.862 2.039-1.422 2.96-2.962 2.96-7.777 0-10.74L14.08 3.394c-1.434-1.435-3.342-2.225-5.369-2.225s-3.934.791-5.369 2.225C1.908 4.828 1.117 6.736 1.117 8.763s.791 3.934 2.225 5.369L7.46 18.56c-.076-1.131.034-2.262.355-3.239l-2.83-2.833c-.994-.991-1.542-2.316-1.542-3.726s.548-2.732 1.542-3.726a5.23 5.23 0 0 1 3.726-1.54z"/></svg>
+              </a>
+              <span class="tsd-kind-icon">{{child.name}}</span>
+              {{ @flags(child.flags) }}
+              {{ @inherited(child.inheritedFrom) }}
+            </td>
+            <td class="code-face">
+              {% if child.defaultValue %}
+                {{ child.defaultValue }}
+              {% elif child.getSignature %}
+                {{ @type(child.getSignature[0].type) }}
+              {% else %}
+                {{ @type(child.type) }}
+              {% endif %}
+            </td>
+            <td class="body-face api-param-comment">
+              {% markdown -%}
+                {{ child.comment.shortText | safe | trim }}
+              {%- endmarkdown %}
+            </td>
+          </tr>
+        {% endfor %}
 
-    </tbody>
-  </table>
+      </tbody>
+    </table>
+  </div>
 {% endmacro %}
 
 {% macro @indexSignature (signatures, parentKind) %}
-  <table class="table">
-    <thead>
-      <tr>
-        <th>Key Type</th>
-        <th>Value Type</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for child in signatures %}
-        <tr id="{{child.parameters[0].id}}">
-          <td class="code-face tsd-kind-index-signature tsd-parent-kind-{{parentKind | lower}} no-wrap">
-            <a href="#{{child.parameters[0].id}}" class="table-link">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M28.633 17.945l-4.118-4.426c.076 1.131-.034 2.262-.355 3.241l2.83 2.827a5.281 5.281 0 0 1 0 7.459 5.223 5.223 0 0 1-3.723 1.54 5.227 5.227 0 0 1-3.728-1.542l-5.459-5.459a5.276 5.276 0 0 1 0-7.452c.607-.609 1.361-1.048 2.1-1.229a1.833 1.833 0 0 0-.279-.414l-1.344-1.461c-.845.404-1.54.881-2.12 1.461a7.554 7.554 0 0 0-2.223 5.371c0 2.027.791 3.934 2.223 5.366l5.459 5.459a7.544 7.544 0 0 0 5.371 2.225 7.55 7.55 0 0 0 5.366-2.223c2.962-2.962 2.962-7.782 0-10.745zM8.711 3.497a5.23 5.23 0 0 1 3.726 1.54l5.459 5.457a5.279 5.279 0 0 1 0 7.454c-.605.605-1.356 1.043-2.105 1.222.086.154.166.301.287.421l1.422 1.422c.808-.394 1.476-.862 2.039-1.422 2.96-2.962 2.96-7.777 0-10.74L14.08 3.394c-1.434-1.435-3.342-2.225-5.369-2.225s-3.934.791-5.369 2.225C1.908 4.828 1.117 6.736 1.117 8.763s.791 3.934 2.225 5.369L7.46 18.56c-.076-1.131.034-2.262.355-3.239l-2.83-2.833c-.994-.991-1.542-2.316-1.542-3.726s.548-2.732 1.542-3.726a5.23 5.23 0 0 1 3.726-1.54z"/></svg>
-            </a>
-            <span class="tsd-kind-icon">{{ @type(child.parameters[0].type) }}</span>
-          </td>
-          <td class="code-face">
-            {% if child.defaultValue %}
-              {{ child.defaultValue }}
-            {% elif child.getSignature %}
-              {{ @type(child.getSignature[0].type) }}
-            {% else %}
-              {{ @type(child.type) }}
-            {% endif %}
-          </td>
-          <td class="body-face api-param-comment">
-            {% markdown -%}
-              {{ child.comment.shortText | safe | trim }}
-            {%- endmarkdown %}
-          </td>
+  <div class="overflow-auto trailer-1">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Key Type</th>
+          <th>Value Type</th>
+          <th>Notes</th>
         </tr>
-      {% endfor %}
+      </thead>
+      <tbody>
+        {% for child in signatures %}
+          <tr id="{{child.parameters[0].id}}">
+            <td class="code-face tsd-kind-index-signature tsd-parent-kind-{{parentKind | lower}} no-wrap">
+              <a href="#{{child.parameters[0].id}}" class="table-link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M28.633 17.945l-4.118-4.426c.076 1.131-.034 2.262-.355 3.241l2.83 2.827a5.281 5.281 0 0 1 0 7.459 5.223 5.223 0 0 1-3.723 1.54 5.227 5.227 0 0 1-3.728-1.542l-5.459-5.459a5.276 5.276 0 0 1 0-7.452c.607-.609 1.361-1.048 2.1-1.229a1.833 1.833 0 0 0-.279-.414l-1.344-1.461c-.845.404-1.54.881-2.12 1.461a7.554 7.554 0 0 0-2.223 5.371c0 2.027.791 3.934 2.223 5.366l5.459 5.459a7.544 7.544 0 0 0 5.371 2.225 7.55 7.55 0 0 0 5.366-2.223c2.962-2.962 2.962-7.782 0-10.745zM8.711 3.497a5.23 5.23 0 0 1 3.726 1.54l5.459 5.457a5.279 5.279 0 0 1 0 7.454c-.605.605-1.356 1.043-2.105 1.222.086.154.166.301.287.421l1.422 1.422c.808-.394 1.476-.862 2.039-1.422 2.96-2.962 2.96-7.777 0-10.74L14.08 3.394c-1.434-1.435-3.342-2.225-5.369-2.225s-3.934.791-5.369 2.225C1.908 4.828 1.117 6.736 1.117 8.763s.791 3.934 2.225 5.369L7.46 18.56c-.076-1.131.034-2.262.355-3.239l-2.83-2.833c-.994-.991-1.542-2.316-1.542-3.726s.548-2.732 1.542-3.726a5.23 5.23 0 0 1 3.726-1.54z"/></svg>
+              </a>
+              <span class="tsd-kind-icon">{{ @type(child.parameters[0].type) }}</span>
+            </td>
+            <td class="code-face">
+              {% if child.defaultValue %}
+                {{ child.defaultValue }}
+              {% elif child.getSignature %}
+                {{ @type(child.getSignature[0].type) }}
+              {% else %}
+                {{ @type(child.type) }}
+              {% endif %}
+            </td>
+            <td class="body-face api-param-comment">
+              {% markdown -%}
+                {{ child.comment.shortText | safe | trim }}
+              {%- endmarkdown %}
+            </td>
+          </tr>
+        {% endfor %}
 
-    </tbody>
-  </table>
+      </tbody>
+    </table>
+  </div>
 {% endmacro %}
 
 {% macro @flags(flags) %}
@@ -296,44 +302,45 @@
 {% endmacro %}
 
 {% macro @methodsTable(group, children) %}
-  <table class="table">
-    <thead>
-    <tr>
-      <th>Method</th>
-      <th>Returns</th>
-      <th>Notes</th>
-    </tr>
-    </thead>
-    <tbody>
-      {% for childId in group.children %}
-        {% set child = API_TOOLS.findChildById(childId, children) %}
-        <tr id="{{child.signatures[0].name}}-summary">
-          <td>
-            <a href="#{{child.signatures[0].name}}-summary" class="table-link">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M28.633 17.945l-4.118-4.426c.076 1.131-.034 2.262-.355 3.241l2.83 2.827a5.281 5.281 0 0 1 0 7.459 5.223 5.223 0 0 1-3.723 1.54 5.227 5.227 0 0 1-3.728-1.542l-5.459-5.459a5.276 5.276 0 0 1 0-7.452c.607-.609 1.361-1.048 2.1-1.229a1.833 1.833 0 0 0-.279-.414l-1.344-1.461c-.845.404-1.54.881-2.12 1.461a7.554 7.554 0 0 0-2.223 5.371c0 2.027.791 3.934 2.223 5.366l5.459 5.459a7.544 7.544 0 0 0 5.371 2.225 7.55 7.55 0 0 0 5.366-2.223c2.962-2.962 2.962-7.782 0-10.745zM8.711 3.497a5.23 5.23 0 0 1 3.726 1.54l5.459 5.457a5.279 5.279 0 0 1 0 7.454c-.605.605-1.356 1.043-2.105 1.222.086.154.166.301.287.421l1.422 1.422c.808-.394 1.476-.862 2.039-1.422 2.96-2.962 2.96-7.777 0-10.74L14.08 3.394c-1.434-1.435-3.342-2.225-5.369-2.225s-3.934.791-5.369 2.225C1.908 4.828 1.117 6.736 1.117 8.763s.791 3.934 2.225 5.369L7.46 18.56c-.076-1.131.034-2.262.355-3.239l-2.83-2.833c-.994-.991-1.542-2.316-1.542-3.726s.548-2.732 1.542-3.726a5.23 5.23 0 0 1 3.726-1.54z"/></svg>
-            </a>
-            <ul class="method-table-signatures {{child.signatures[0].icon}}">
-              {% for signature in child.signatures -%}
-                <li class="code-face tsd-signature tsd-kind-icon">
-                  <a href="#{{signature.name}}">{{ signature.name }}</a><span class="text-light-gray">(</span>{{ @signatureParams(signature.parameters) }}<span class="text-light-gray">)</span>
-                </li>
-              {%- endfor %}
-            </ul>
-          </td>
-          <td class="code-face">{{@type(child.signatures[0].type)}}</td>
-          <td class="body-face api-param-comment">
-            {% markdown -%}
-              {{ child.signatures[0].comment.shortText | safe | trim }}
-            {%- endmarkdown %}
-            {% markdown -%}
-              {{ child.signatures[0].comment.text | safe | trim }}
-            {%- endmarkdown %}
-          </td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-
+  <div class="overflow-auto trailer-1">
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Method</th>
+        <th>Returns</th>
+        <th>Notes</th>
+      </tr>
+      </thead>
+      <tbody>
+        {% for childId in group.children %}
+          {% set child = API_TOOLS.findChildById(childId, children) %}
+          <tr id="{{child.signatures[0].name}}-summary">
+            <td>
+              <a href="#{{child.signatures[0].name}}-summary" class="table-link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M28.633 17.945l-4.118-4.426c.076 1.131-.034 2.262-.355 3.241l2.83 2.827a5.281 5.281 0 0 1 0 7.459 5.223 5.223 0 0 1-3.723 1.54 5.227 5.227 0 0 1-3.728-1.542l-5.459-5.459a5.276 5.276 0 0 1 0-7.452c.607-.609 1.361-1.048 2.1-1.229a1.833 1.833 0 0 0-.279-.414l-1.344-1.461c-.845.404-1.54.881-2.12 1.461a7.554 7.554 0 0 0-2.223 5.371c0 2.027.791 3.934 2.223 5.366l5.459 5.459a7.544 7.544 0 0 0 5.371 2.225 7.55 7.55 0 0 0 5.366-2.223c2.962-2.962 2.962-7.782 0-10.745zM8.711 3.497a5.23 5.23 0 0 1 3.726 1.54l5.459 5.457a5.279 5.279 0 0 1 0 7.454c-.605.605-1.356 1.043-2.105 1.222.086.154.166.301.287.421l1.422 1.422c.808-.394 1.476-.862 2.039-1.422 2.96-2.962 2.96-7.777 0-10.74L14.08 3.394c-1.434-1.435-3.342-2.225-5.369-2.225s-3.934.791-5.369 2.225C1.908 4.828 1.117 6.736 1.117 8.763s.791 3.934 2.225 5.369L7.46 18.56c-.076-1.131.034-2.262.355-3.239l-2.83-2.833c-.994-.991-1.542-2.316-1.542-3.726s.548-2.732 1.542-3.726a5.23 5.23 0 0 1 3.726-1.54z"/></svg>
+              </a>
+              <ul class="method-table-signatures {{child.signatures[0].icon}}">
+                {% for signature in child.signatures -%}
+                  <li class="code-face tsd-signature tsd-kind-icon">
+                    <a href="#{{signature.name}}">{{ signature.name }}</a><span class="text-light-gray">(</span>{{ @signatureParams(signature.parameters) }}<span class="text-light-gray">)</span>
+                  </li>
+                {%- endfor %}
+              </ul>
+            </td>
+            <td class="code-face">{{@type(child.signatures[0].type)}}</td>
+            <td class="body-face api-param-comment">
+              {% markdown -%}
+                {{ child.signatures[0].comment.shortText | safe | trim }}
+              {%- endmarkdown %}
+              {% markdown -%}
+                {{ child.signatures[0].comment.text | safe | trim }}
+              {%- endmarkdown %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
   {% for childId in group.children %}
     {% set child = API_TOOLS.findChildById(childId, children) %}
     {% set signatures = child.signatures %}
@@ -401,53 +408,53 @@
 {% endmacro %}
 
 {% macro @parametersTable(parameters, fnName) %}
-  <table class="table">
-    <thead>
-      <tr>
-        <th class="font-size--2">Parameter</th>
-        <th class="font-size--2">Type</th>
-        <th class="font-size--2">Default</th>
-        <th class="font-size--2">Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for param in parameters -%}
-        <tr id="{{fnName}}-{{param.name}}">
-          <td class="code-face">
-            <a href="#{{fnName}}-{{param.name}}" class="table-link">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M28.633 17.945l-4.118-4.426c.076 1.131-.034 2.262-.355 3.241l2.83 2.827a5.281 5.281 0 0 1 0 7.459 5.223 5.223 0 0 1-3.723 1.54 5.227 5.227 0 0 1-3.728-1.542l-5.459-5.459a5.276 5.276 0 0 1 0-7.452c.607-.609 1.361-1.048 2.1-1.229a1.833 1.833 0 0 0-.279-.414l-1.344-1.461c-.845.404-1.54.881-2.12 1.461a7.554 7.554 0 0 0-2.223 5.371c0 2.027.791 3.934 2.223 5.366l5.459 5.459a7.544 7.544 0 0 0 5.371 2.225 7.55 7.55 0 0 0 5.366-2.223c2.962-2.962 2.962-7.782 0-10.745zM8.711 3.497a5.23 5.23 0 0 1 3.726 1.54l5.459 5.457a5.279 5.279 0 0 1 0 7.454c-.605.605-1.356 1.043-2.105 1.222.086.154.166.301.287.421l1.422 1.422c.808-.394 1.476-.862 2.039-1.422 2.96-2.962 2.96-7.777 0-10.74L14.08 3.394c-1.434-1.435-3.342-2.225-5.369-2.225s-3.934.791-5.369 2.225C1.908 4.828 1.117 6.736 1.117 8.763s.791 3.934 2.225 5.369L7.46 18.56c-.076-1.131.034-2.262.355-3.239l-2.83-2.833c-.994-.991-1.542-2.316-1.542-3.726s.548-2.732 1.542-3.726a5.23 5.23 0 0 1 3.726-1.54z"/></svg>
-            </a>
-            <span class="code-face">{{param.name}}</span>
-            {% if param.defaultValue %}
-              {{ @flags({isOptional: true}) }}
-            {% elif not param.defaultValue and not param.flags.isOptional %}
-              {{ @flags({isRequired: true}) }}
-            {% else %}
-              {{ @flags(param.flags) }}
-            {% endif %}
-          </td>
-          <td class="code-face">{{@type(param.type)}}</td>
-          <td class="code-face">{{param.defaultValue}}</td>
-          <td class="body-face api-param-comment">
-            {% markdown -%}
-              {{ param.comment.shortText | safe | trim }}
-            {%- endmarkdown %}
-            {% markdown -%}
-              {{ param.comment.text | safe | trim }}
-            {%- endmarkdown %}
-          </td>
+  <div class="overflow-auto trailer-1">
+    <table class="table">
+      <thead>
+        <tr>
+          <th class="font-size--2">Parameter</th>
+          <th class="font-size--2">Type</th>
+          <th class="font-size--2">Default</th>
+          <th class="font-size--2">Notes</th>
         </tr>
-      {%- endfor %}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {% for param in parameters -%}
+          <tr id="{{fnName}}-{{param.name}}">
+            <td class="code-face">
+              <a href="#{{fnName}}-{{param.name}}" class="table-link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M28.633 17.945l-4.118-4.426c.076 1.131-.034 2.262-.355 3.241l2.83 2.827a5.281 5.281 0 0 1 0 7.459 5.223 5.223 0 0 1-3.723 1.54 5.227 5.227 0 0 1-3.728-1.542l-5.459-5.459a5.276 5.276 0 0 1 0-7.452c.607-.609 1.361-1.048 2.1-1.229a1.833 1.833 0 0 0-.279-.414l-1.344-1.461c-.845.404-1.54.881-2.12 1.461a7.554 7.554 0 0 0-2.223 5.371c0 2.027.791 3.934 2.223 5.366l5.459 5.459a7.544 7.544 0 0 0 5.371 2.225 7.55 7.55 0 0 0 5.366-2.223c2.962-2.962 2.962-7.782 0-10.745zM8.711 3.497a5.23 5.23 0 0 1 3.726 1.54l5.459 5.457a5.279 5.279 0 0 1 0 7.454c-.605.605-1.356 1.043-2.105 1.222.086.154.166.301.287.421l1.422 1.422c.808-.394 1.476-.862 2.039-1.422 2.96-2.962 2.96-7.777 0-10.74L14.08 3.394c-1.434-1.435-3.342-2.225-5.369-2.225s-3.934.791-5.369 2.225C1.908 4.828 1.117 6.736 1.117 8.763s.791 3.934 2.225 5.369L7.46 18.56c-.076-1.131.034-2.262.355-3.239l-2.83-2.833c-.994-.991-1.542-2.316-1.542-3.726s.548-2.732 1.542-3.726a5.23 5.23 0 0 1 3.726-1.54z"/></svg>
+              </a>
+              <span class="code-face">{{param.name}}</span>
+              {% if param.defaultValue %}
+                {{ @flags({isOptional: true}) }}
+              {% elif not param.defaultValue and not param.flags.isOptional %}
+                {{ @flags({isRequired: true}) }}
+              {% else %}
+                {{ @flags(param.flags) }}
+              {% endif %}
+            </td>
+            <td class="code-face">{{@type(param.type)}}</td>
+            <td class="code-face">{{param.defaultValue}}</td>
+            <td class="body-face api-param-comment">
+              {% markdown -%}
+                {{ param.comment.shortText | safe | trim }}
+              {%- endmarkdown %}
+              {% markdown -%}
+                {{ param.comment.text | safe | trim }}
+              {%- endmarkdown %}
+            </td>
+          </tr>
+        {%- endfor %}
+      </tbody>
+    </table>
+  <div>
 {% endmacro %}
 
-<div class="clearfix">
+<div class="clearfix trailer-half">
   <h1 class="left font-size-5 code-face trailer-0">{{name}}</h1>
-  <small class="{{icon}} font-size--2 right"><span class="tsd-kind-icon">{{kindString}}</span></small>
+  <small class="{{icon}} font-size--2 right leader-half margin-right-half"><span class="tsd-kind-icon">{{kindString}}</span></small>
 </div>
-
-<hr class="leader-half trailer-half">
 
 {% if comment %}
   {% markdown -%}

--- a/docs/src/api/_layout.html
+++ b/docs/src/api/_layout.html
@@ -19,36 +19,17 @@
       <ul class="list-plain">
         {% for package in data.typedoc.packages %}
         <li class="{{ package.icon }} api-list-item">
-          <nav-toggle
-            index="{{ loop.index }}"
-            package-name="{{ package.pkg.name }}"
-          ></nav-toggle>
-          <button
-            id="trigger{{ loop.index }}"
-            class="btn btn-transparent api-toggle-button"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="32"
-              height="32"
-              viewBox="0 0 32 32"
-              class="svg-icon"
-            >
+          <nav-toggle index="{{ loop.index }}" package-name="{{ package.pkg.name }}" ></nav-toggle>
+          <button id="trigger{{ loop.index }}" class="btn btn-transparent api-toggle-button" >
+            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon">
               <path d="M7 4h5l12 12-12 12H7l12-12L7 4z" />
             </svg>
           </button>
-          {% link package.pageUrl,
-          package.pkg.name.replace("@esri/arcgis-rest-",""),
-          class="tsd-kind-icon" %}
+          {% link package.pageUrl, package.pkg.name.replace("@esri/arcgis-rest-",""), class="tsd-kind-icon" %}
           <ul id="list{{ loop.index }}" class="api-package-content-list">
             {% for declaration in package.declarations %}
-            <li
-              class="{{
-                declaration.icon
-              }} padding-left-1 padding-right-1 visually-hidden api-list-item"
-            >
-              {% link declaration.pageUrl, declaration.name,
-              class="tsd-kind-icon padding-right-1" %}
+            <li class="{{ declaration.icon }} padding-right-1 visually-hidden api-list-item">
+              {% link declaration.pageUrl, declaration.name, class="tsd-kind-icon padding-right-1" %}
             </li>
             {% endfor %}
           </ul>
@@ -59,166 +40,165 @@
   </nav>
 
   <div class="column-18">
-    <div class="padding-left-2">
+    <div class="panel panel-white padding-left-1 padding-right-1 padding-trailer-1 padding-leader-half">
       {% block content %}{% endblock %}
     </div>
   </div>
 </div>
 {% endblock %} {% block footer %}
-<div class="grid-container">
-  <div class="column-24">
-    <h2>Legend</h2>
-    <div
-      class="block-group block-group-4-up tablet-block-group-2-up phone-block-group-1-up"
-    >
-      <div class="block">
-        <ul class="list-plain">
-          <li class="tsd-kind-module">
-            <span class="tsd-kind-icon">Module</span>
-          </li>
-          <li class="tsd-kind-object-literal">
-            <span class="tsd-kind-icon">Object literal</span>
-          </li>
-          <li class="tsd-kind-variable">
-            <span class="tsd-kind-icon">Variable</span>
-          </li>
-          <li class="tsd-kind-function">
-            <span class="tsd-kind-icon">Function</span>
-          </li>
-          <li class="tsd-kind-function tsd-has-type-parameter">
-            <span class="tsd-kind-icon">Function with type parameter</span>
-          </li>
-          <li class="tsd-kind-index-signature">
-            <span class="tsd-kind-icon">Index signature</span>
-          </li>
-          <li class="tsd-kind-type-alias">
-            <span class="tsd-kind-icon">Type alias</span>
-          </li>
-        </ul>
-      </div>
-      <div class="block">
-        <ul class="list-plain">
-          <li class="tsd-kind-enumeration">
-            <span class="tsd-kind-icon">Enumeration</span>
-          </li>
-          <li class="tsd-kind-enumeration-member">
-            <span class="tsd-kind-icon">Enumeration member</span>
-          </li>
-          <li class="tsd-kind-property tsd-parent-kind-enumeration">
-            <span class="tsd-kind-icon">Property</span>
-          </li>
-          <li class="tsd-kind-method tsd-parent-kind-enumeration">
-            <span class="tsd-kind-icon">Method</span>
-          </li>
-        </ul>
-      </div>
-      <div class="block">
-        <ul class="list-plain">
-          <li class="tsd-kind-interface">
-            <span class="tsd-kind-icon">Interface</span>
-          </li>
-          <li class="tsd-kind-interface tsd-has-type-parameter">
-            <span class="tsd-kind-icon">Interface with type parameter</span>
-          </li>
-          <li class="tsd-kind-constructor tsd-parent-kind-interface">
-            <span class="tsd-kind-icon">Constructor</span>
-          </li>
-          <li class="tsd-kind-property tsd-parent-kind-interface">
-            <span class="tsd-kind-icon">Property</span>
-          </li>
-          <li class="tsd-kind-method tsd-parent-kind-interface">
-            <span class="tsd-kind-icon">Method</span>
-          </li>
-          <li class="tsd-kind-index-signature tsd-parent-kind-interface">
-            <span class="tsd-kind-icon">Index signature</span>
-          </li>
-        </ul>
-      </div>
-      <div class="block">
-        <ul class="list-plain">
-          <li class="tsd-kind-class">
-            <span class="tsd-kind-icon">Class</span>
-          </li>
-          <li class="tsd-kind-class tsd-has-type-parameter">
-            <span class="tsd-kind-icon">Class with type parameter</span>
-          </li>
-          <li class="tsd-kind-constructor tsd-parent-kind-class">
-            <span class="tsd-kind-icon">Constructor</span>
-          </li>
-          <li class="tsd-kind-property tsd-parent-kind-class">
-            <span class="tsd-kind-icon">Property</span>
-          </li>
-          <li class="tsd-kind-method tsd-parent-kind-class">
-            <span class="tsd-kind-icon">Method</span>
-          </li>
-          <li class="tsd-kind-accessor tsd-parent-kind-class">
-            <span class="tsd-kind-icon">Accessor</span>
-          </li>
-          <li class="tsd-kind-index-signature tsd-parent-kind-class">
-            <span class="tsd-kind-icon">Index signature</span>
-          </li>
-        </ul>
-      </div>
-      <div class="block">
-        <ul class="list-plain">
-          <li
-            class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"
-          >
-            <span class="tsd-kind-icon">Inherited constructor</span>
-          </li>
-          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
-            <span class="tsd-kind-icon">Inherited property</span>
-          </li>
-          <li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-            <span class="tsd-kind-icon">Inherited method</span>
-          </li>
-          <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-inherited">
-            <span class="tsd-kind-icon">Inherited accessor</span>
-          </li>
-        </ul>
-      </div>
-      <div class="block">
-        <ul class="list-plain">
-          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected">
-            <span class="tsd-kind-icon">Protected property</span>
-          </li>
-          <li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected">
-            <span class="tsd-kind-icon">Protected method</span>
-          </li>
-          <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-protected">
-            <span class="tsd-kind-icon">Protected accessor</span>
-          </li>
-        </ul>
-      </div>
-      <div class="block">
-        <ul class="list-plain">
-          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-private">
-            <span class="tsd-kind-icon">Private property</span>
-          </li>
-          <li class="tsd-kind-method tsd-parent-kind-class tsd-is-private">
-            <span class="tsd-kind-icon">Private method</span>
-          </li>
-          <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-private">
-            <span class="tsd-kind-icon">Private accessor</span>
-          </li>
-        </ul>
-      </div>
-      <div class="block">
-        <ul class="list-plain">
-          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-static">
-            <span class="tsd-kind-icon">Static property</span>
-          </li>
-          <li
-            class="tsd-kind-call-signature tsd-parent-kind-class tsd-is-static"
-          >
-            <span class="tsd-kind-icon">Static method</span>
-          </li>
-        </ul>
+<div class="panel panel-white">
+  <div class="grid-container">
+    <div class="column-24">
+      <h2>Legend</h2>
+      <div
+        class="block-group block-group-4-up tablet-block-group-2-up phone-block-group-1-up"
+      >
+        <div class="block">
+          <ul class="list-plain">
+            <li class="tsd-kind-module">
+              <span class="tsd-kind-icon">Module</span>
+            </li>
+            <li class="tsd-kind-object-literal">
+              <span class="tsd-kind-icon">Object literal</span>
+            </li>
+            <li class="tsd-kind-variable">
+              <span class="tsd-kind-icon">Variable</span>
+            </li>
+            <li class="tsd-kind-function">
+              <span class="tsd-kind-icon">Function</span>
+            </li>
+            <li class="tsd-kind-function tsd-has-type-parameter">
+              <span class="tsd-kind-icon">Function with type parameter</span>
+            </li>
+            <li class="tsd-kind-index-signature">
+              <span class="tsd-kind-icon">Index signature</span>
+            </li>
+            <li class="tsd-kind-type-alias">
+              <span class="tsd-kind-icon">Type alias</span>
+            </li>
+          </ul>
+        </div>
+        <div class="block">
+          <ul class="list-plain">
+            <li class="tsd-kind-enumeration">
+              <span class="tsd-kind-icon">Enumeration</span>
+            </li>
+            <li class="tsd-kind-enumeration-member">
+              <span class="tsd-kind-icon">Enumeration member</span>
+            </li>
+            <li class="tsd-kind-property tsd-parent-kind-enumeration">
+              <span class="tsd-kind-icon">Property</span>
+            </li>
+            <li class="tsd-kind-method tsd-parent-kind-enumeration">
+              <span class="tsd-kind-icon">Method</span>
+            </li>
+          </ul>
+        </div>
+        <div class="block">
+          <ul class="list-plain">
+            <li class="tsd-kind-interface">
+              <span class="tsd-kind-icon">Interface</span>
+            </li>
+            <li class="tsd-kind-interface tsd-has-type-parameter">
+              <span class="tsd-kind-icon">Interface with type parameter</span>
+            </li>
+            <li class="tsd-kind-constructor tsd-parent-kind-interface">
+              <span class="tsd-kind-icon">Constructor</span>
+            </li>
+            <li class="tsd-kind-property tsd-parent-kind-interface">
+              <span class="tsd-kind-icon">Property</span>
+            </li>
+            <li class="tsd-kind-method tsd-parent-kind-interface">
+              <span class="tsd-kind-icon">Method</span>
+            </li>
+            <li class="tsd-kind-index-signature tsd-parent-kind-interface">
+              <span class="tsd-kind-icon">Index signature</span>
+            </li>
+          </ul>
+        </div>
+        <div class="block">
+          <ul class="list-plain">
+            <li class="tsd-kind-class">
+              <span class="tsd-kind-icon">Class</span>
+            </li>
+            <li class="tsd-kind-class tsd-has-type-parameter">
+              <span class="tsd-kind-icon">Class with type parameter</span>
+            </li>
+            <li class="tsd-kind-constructor tsd-parent-kind-class">
+              <span class="tsd-kind-icon">Constructor</span>
+            </li>
+            <li class="tsd-kind-property tsd-parent-kind-class">
+              <span class="tsd-kind-icon">Property</span>
+            </li>
+            <li class="tsd-kind-method tsd-parent-kind-class">
+              <span class="tsd-kind-icon">Method</span>
+            </li>
+            <li class="tsd-kind-accessor tsd-parent-kind-class">
+              <span class="tsd-kind-icon">Accessor</span>
+            </li>
+            <li class="tsd-kind-index-signature tsd-parent-kind-class">
+              <span class="tsd-kind-icon">Index signature</span>
+            </li>
+          </ul>
+        </div>
+        <div class="block">
+          <ul class="list-plain">
+            <li
+              class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"
+            >
+              <span class="tsd-kind-icon">Inherited constructor</span>
+            </li>
+            <li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
+              <span class="tsd-kind-icon">Inherited property</span>
+            </li>
+            <li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+              <span class="tsd-kind-icon">Inherited method</span>
+            </li>
+            <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-inherited">
+              <span class="tsd-kind-icon">Inherited accessor</span>
+            </li>
+          </ul>
+        </div>
+        <div class="block">
+          <ul class="list-plain">
+            <li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected">
+              <span class="tsd-kind-icon">Protected property</span>
+            </li>
+            <li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected">
+              <span class="tsd-kind-icon">Protected method</span>
+            </li>
+            <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-protected">
+              <span class="tsd-kind-icon">Protected accessor</span>
+            </li>
+          </ul>
+        </div>
+        <div class="block">
+          <ul class="list-plain">
+            <li class="tsd-kind-property tsd-parent-kind-class tsd-is-private">
+              <span class="tsd-kind-icon">Private property</span>
+            </li>
+            <li class="tsd-kind-method tsd-parent-kind-class tsd-is-private">
+              <span class="tsd-kind-icon">Private method</span>
+            </li>
+            <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-private">
+              <span class="tsd-kind-icon">Private accessor</span>
+            </li>
+          </ul>
+        </div>
+        <div class="block">
+          <ul class="list-plain">
+            <li class="tsd-kind-property tsd-parent-kind-class tsd-is-static">
+              <span class="tsd-kind-icon">Static property</span>
+            </li>
+            <li
+              class="tsd-kind-call-signature tsd-parent-kind-class tsd-is-static"
+            >
+              <span class="tsd-kind-icon">Static method</span>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
-
-    <hr class="leader-half trailer-half" />
   </div>
 </div>
-
 {% endblock %}

--- a/docs/src/api/_layout.html
+++ b/docs/src/api/_layout.html
@@ -1,126 +1,223 @@
-{% extends "_layout" %}
+{% extends "_layout" %} {% block scripts %}
+<script src="https://unpkg.com/vue@2.4.2/dist/vue.min.js"></script>
+<script src="https://unpkg.com/fuse.js@3.0.5/dist/fuse.min.js"></script>
+<script src="/arcgis-rest-js/js/index.js"></script>
+<script src="/arcgis-rest-js/js/api-search.js"></script>
+<script src="/arcgis-rest-js/js/nav-toggle.js"></script>
+<script>
+  new Vue({
+    el: "#page"
+  });
+</script>
 
-{% block scripts %}
-  <script src="https://unpkg.com/vue@2.4.2/dist/vue.min.js"></script>
-  <script src="https://unpkg.com/fuse.js@3.0.5/dist/fuse.min.js"></script>
-  <script src="/arcgis-rest-js/js/index.js"></script>
-  <script src="/arcgis-rest-js/js/api-search.js"></script>
-  <script src="/arcgis-rest-js/js/nav-toggle.js"></script>
-  <script>
-    new Vue({
-      el: "#page"
-    });
-  </script>
-
-{% endblock %}
-
-{% block main %}
-  <div class="grid-container trailer-1 leader-1">
-    <div class="column-6">
-      <api-search base-url="/arcgis-rest-js/">
-        <ul class="list-plain">
-          {% for package in data.typedoc.packages %}
-          <li class="{{ package.icon }} api-list-item">
-            <nav-toggle index="{{loop.index}}" package-name="{{package.pkg.name}}"></nav-toggle>
-            <button id="trigger{{loop.index}}" class="btn btn-transparent api-toggle-button">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M7 4h5l12 12-12 12H7l12-12L7 4z"/></svg>
-            </button>
-            {% link package.pageUrl, package.pkg.name.replace("@esri/arcgis-rest-",""), class="tsd-kind-icon" %}
-            <ul id="list{{loop.index}}" class="api-package-content-list">
+{% endblock %} {% block main %}
+<div class="grid-container trailer-1 leader-1">
+  <nav class="column-6">
+    <api-search base-url="/arcgis-rest-js/">
+      <h3 class="font-size--1 trailer-quarter">Packages</h3>
+      <hr class="leader-quarter trailer-quarter" />
+      <ul class="list-plain">
+        {% for package in data.typedoc.packages %}
+        <li class="{{ package.icon }} api-list-item">
+          <nav-toggle
+            index="{{ loop.index }}"
+            package-name="{{ package.pkg.name }}"
+          ></nav-toggle>
+          <button
+            id="trigger{{ loop.index }}"
+            class="btn btn-transparent api-toggle-button"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="32"
+              viewBox="0 0 32 32"
+              class="svg-icon"
+            >
+              <path d="M7 4h5l12 12-12 12H7l12-12L7 4z" />
+            </svg>
+          </button>
+          {% link package.pageUrl,
+          package.pkg.name.replace("@esri/arcgis-rest-",""),
+          class="tsd-kind-icon" %}
+          <ul id="list{{ loop.index }}" class="api-package-content-list">
             {% for declaration in package.declarations %}
-              <li class="{{ declaration.icon }} padding-left-1 padding-right-1 visually-hidden">{% link declaration.pageUrl, declaration.name, class="tsd-kind-icon padding-right-1" %}</li>
+            <li
+              class="{{
+                declaration.icon
+              }} padding-left-1 padding-right-1 visually-hidden api-list-item"
+            >
+              {% link declaration.pageUrl, declaration.name,
+              class="tsd-kind-icon padding-right-1" %}
+            </li>
             {% endfor %}
-            </ul>
-          </li>
-          {% endfor %}
-        </ul>
-      </api-search>
-    </div>
+          </ul>
+        </li>
+        {% endfor %}
+      </ul>
+    </api-search>
+  </nav>
 
-    <div class="column-18">
-      <div class="panel">
-        {% block content %}{% endblock %}
-      </div>
+  <div class="column-18">
+    <div class="padding-left-2">
+      {% block content %}{% endblock %}
     </div>
   </div>
-{% endblock %}
-
-{% block footer %}
+</div>
+{% endblock %} {% block footer %}
 <div class="grid-container">
   <div class="column-24">
     <h2>Legend</h2>
-    <div class="block-group block-group-4-up tablet-block-group-2-up phone-block-group-1-up">
+    <div
+      class="block-group block-group-4-up tablet-block-group-2-up phone-block-group-1-up"
+    >
       <div class="block">
         <ul class="list-plain">
-            <li class="tsd-kind-module"><span class="tsd-kind-icon">Module</span></li>
-            <li class="tsd-kind-object-literal"><span class="tsd-kind-icon">Object literal</span></li>
-            <li class="tsd-kind-variable"><span class="tsd-kind-icon">Variable</span></li>
-            <li class="tsd-kind-function"><span class="tsd-kind-icon">Function</span></li>
-            <li class="tsd-kind-function tsd-has-type-parameter"><span class="tsd-kind-icon">Function with type parameter</span></li>
-            <li class="tsd-kind-index-signature"><span class="tsd-kind-icon">Index signature</span></li>
-            <li class="tsd-kind-type-alias"><span class="tsd-kind-icon">Type alias</span></li>
+          <li class="tsd-kind-module">
+            <span class="tsd-kind-icon">Module</span>
+          </li>
+          <li class="tsd-kind-object-literal">
+            <span class="tsd-kind-icon">Object literal</span>
+          </li>
+          <li class="tsd-kind-variable">
+            <span class="tsd-kind-icon">Variable</span>
+          </li>
+          <li class="tsd-kind-function">
+            <span class="tsd-kind-icon">Function</span>
+          </li>
+          <li class="tsd-kind-function tsd-has-type-parameter">
+            <span class="tsd-kind-icon">Function with type parameter</span>
+          </li>
+          <li class="tsd-kind-index-signature">
+            <span class="tsd-kind-icon">Index signature</span>
+          </li>
+          <li class="tsd-kind-type-alias">
+            <span class="tsd-kind-icon">Type alias</span>
+          </li>
         </ul>
       </div>
       <div class="block">
         <ul class="list-plain">
-            <li class="tsd-kind-enumeration"><span class="tsd-kind-icon">Enumeration</span></li>
-            <li class="tsd-kind-enumeration-member"><span class="tsd-kind-icon">Enumeration member</span></li>
-            <li class="tsd-kind-property tsd-parent-kind-enumeration"><span class="tsd-kind-icon">Property</span></li>
-            <li class="tsd-kind-method tsd-parent-kind-enumeration"><span class="tsd-kind-icon">Method</span></li>
+          <li class="tsd-kind-enumeration">
+            <span class="tsd-kind-icon">Enumeration</span>
+          </li>
+          <li class="tsd-kind-enumeration-member">
+            <span class="tsd-kind-icon">Enumeration member</span>
+          </li>
+          <li class="tsd-kind-property tsd-parent-kind-enumeration">
+            <span class="tsd-kind-icon">Property</span>
+          </li>
+          <li class="tsd-kind-method tsd-parent-kind-enumeration">
+            <span class="tsd-kind-icon">Method</span>
+          </li>
         </ul>
       </div>
       <div class="block">
         <ul class="list-plain">
-          <li class="tsd-kind-interface"><span class="tsd-kind-icon">Interface</span></li>
-          <li class="tsd-kind-interface tsd-has-type-parameter"><span class="tsd-kind-icon">Interface with type parameter</span></li>
-          <li class="tsd-kind-constructor tsd-parent-kind-interface"><span class="tsd-kind-icon">Constructor</span></li>
-          <li class="tsd-kind-property tsd-parent-kind-interface"><span class="tsd-kind-icon">Property</span></li>
-          <li class="tsd-kind-method tsd-parent-kind-interface"><span class="tsd-kind-icon">Method</span></li>
-          <li class="tsd-kind-index-signature tsd-parent-kind-interface"><span class="tsd-kind-icon">Index signature</span></li>
+          <li class="tsd-kind-interface">
+            <span class="tsd-kind-icon">Interface</span>
+          </li>
+          <li class="tsd-kind-interface tsd-has-type-parameter">
+            <span class="tsd-kind-icon">Interface with type parameter</span>
+          </li>
+          <li class="tsd-kind-constructor tsd-parent-kind-interface">
+            <span class="tsd-kind-icon">Constructor</span>
+          </li>
+          <li class="tsd-kind-property tsd-parent-kind-interface">
+            <span class="tsd-kind-icon">Property</span>
+          </li>
+          <li class="tsd-kind-method tsd-parent-kind-interface">
+            <span class="tsd-kind-icon">Method</span>
+          </li>
+          <li class="tsd-kind-index-signature tsd-parent-kind-interface">
+            <span class="tsd-kind-icon">Index signature</span>
+          </li>
         </ul>
       </div>
       <div class="block">
         <ul class="list-plain">
-          <li class="tsd-kind-class"><span class="tsd-kind-icon">Class</span></li>
-          <li class="tsd-kind-class tsd-has-type-parameter"><span class="tsd-kind-icon">Class with type parameter</span></li>
-          <li class="tsd-kind-constructor tsd-parent-kind-class"><span class="tsd-kind-icon">Constructor</span></li>
-          <li class="tsd-kind-property tsd-parent-kind-class"><span class="tsd-kind-icon">Property</span></li>
-          <li class="tsd-kind-method tsd-parent-kind-class"><span class="tsd-kind-icon">Method</span></li>
-          <li class="tsd-kind-accessor tsd-parent-kind-class"><span class="tsd-kind-icon">Accessor</span></li>
-          <li class="tsd-kind-index-signature tsd-parent-kind-class"><span class="tsd-kind-icon">Index signature</span></li>
+          <li class="tsd-kind-class">
+            <span class="tsd-kind-icon">Class</span>
+          </li>
+          <li class="tsd-kind-class tsd-has-type-parameter">
+            <span class="tsd-kind-icon">Class with type parameter</span>
+          </li>
+          <li class="tsd-kind-constructor tsd-parent-kind-class">
+            <span class="tsd-kind-icon">Constructor</span>
+          </li>
+          <li class="tsd-kind-property tsd-parent-kind-class">
+            <span class="tsd-kind-icon">Property</span>
+          </li>
+          <li class="tsd-kind-method tsd-parent-kind-class">
+            <span class="tsd-kind-icon">Method</span>
+          </li>
+          <li class="tsd-kind-accessor tsd-parent-kind-class">
+            <span class="tsd-kind-icon">Accessor</span>
+          </li>
+          <li class="tsd-kind-index-signature tsd-parent-kind-class">
+            <span class="tsd-kind-icon">Index signature</span>
+          </li>
         </ul>
       </div>
       <div class="block">
         <ul class="list-plain">
-          <li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited constructor</span></li>
-          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited property</span></li>
-          <li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited method</span></li>
-          <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited accessor</span></li>
+          <li
+            class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"
+          >
+            <span class="tsd-kind-icon">Inherited constructor</span>
+          </li>
+          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
+            <span class="tsd-kind-icon">Inherited property</span>
+          </li>
+          <li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+            <span class="tsd-kind-icon">Inherited method</span>
+          </li>
+          <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-inherited">
+            <span class="tsd-kind-icon">Inherited accessor</span>
+          </li>
         </ul>
       </div>
       <div class="block">
         <ul class="list-plain">
-          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><span class="tsd-kind-icon">Protected property</span></li>
-          <li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected"><span class="tsd-kind-icon">Protected method</span></li>
-          <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-protected"><span class="tsd-kind-icon">Protected accessor</span></li>
+          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected">
+            <span class="tsd-kind-icon">Protected property</span>
+          </li>
+          <li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected">
+            <span class="tsd-kind-icon">Protected method</span>
+          </li>
+          <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-protected">
+            <span class="tsd-kind-icon">Protected accessor</span>
+          </li>
         </ul>
       </div>
       <div class="block">
         <ul class="list-plain">
-          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><span class="tsd-kind-icon">Private property</span></li>
-          <li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><span class="tsd-kind-icon">Private method</span></li>
-          <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-private"><span class="tsd-kind-icon">Private accessor</span></li>
+          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-private">
+            <span class="tsd-kind-icon">Private property</span>
+          </li>
+          <li class="tsd-kind-method tsd-parent-kind-class tsd-is-private">
+            <span class="tsd-kind-icon">Private method</span>
+          </li>
+          <li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-private">
+            <span class="tsd-kind-icon">Private accessor</span>
+          </li>
         </ul>
       </div>
       <div class="block">
         <ul class="list-plain">
-          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-static"><span class="tsd-kind-icon">Static property</span></li>
-          <li class="tsd-kind-call-signature tsd-parent-kind-class tsd-is-static"><span class="tsd-kind-icon">Static method</span></li>
+          <li class="tsd-kind-property tsd-parent-kind-class tsd-is-static">
+            <span class="tsd-kind-icon">Static property</span>
+          </li>
+          <li
+            class="tsd-kind-call-signature tsd-parent-kind-class tsd-is-static"
+          >
+            <span class="tsd-kind-icon">Static method</span>
+          </li>
         </ul>
       </div>
     </div>
 
-    <hr class="leader-half trailer-half">
+    <hr class="leader-half trailer-half" />
   </div>
 </div>
 

--- a/docs/src/api/_package.html
+++ b/docs/src/api/_package.html
@@ -1,14 +1,38 @@
-<small class="label right">Version {{pkg.version}}</small>
-<h1 class="{{icon}} font-size-3 trailer-half"> {% link url, pkg.name, class="tsd-kind-icon" %}</h1>
-<p class="trailer-half">{{pkg.description}}</p>
-<h2 class="font-size--1 trailer-half">npm install:</h2>
+<small class="label right">Version {{ pkg.version }}</small>
+<h1 class="{{ icon }} font-size-3 trailer-half code-face">
+  {% link url, pkg.name%}
+</h1>
+<p class="font-size--1 trailer-1 avenir-regular">{{ pkg.description }}</p>
+<h2 class="font-size-0 trailer-quarter">npm install:</h2>
 <pre><code>{% npmInstallCmd pkg %}</code></pre>
-<h2 class="font-size--1 trailer-half">CDN:</h2>
-<pre><code>{% scriptTag pkg %}</code></pre>
+<h2 class="font-size-0 trailer-quarter">Module Import:</h2>
+{% if pkg.esri.keyExports %}
+{% highlight "js" %}
+import {
+  {%- for name in pkg.esri.keyExports %}
+  {{name}}{{"," if not loop.last}}
+  {%- endfor %}
+} from "{{ pkg.name }}";
+{% endhighlight %}
+{% else %}
+{% highlight "js" %}
+import {
+  {%- for declaration in declarations -%}
+  {%- if declaration.kindString === "Function" or declaration.kindString === "Class" %}
+  {{declaration.name}}{{"," if not loop.last}}{%- endif -%}
+  {% endfor %}
+} from "{{ pkg.name }}";
+{% endhighlight %}
+{% endif %}
+<h2 class="font-size-0 trailer-quarter">CDN:</h2>
+{% scriptTag pkg %}
+<h2 class="font-size-0 trailer-quarter">CDN with SRI:</h2>
 {% scriptTagSRI pkg %}
-<hr class="leader-half trailer-half">
+<hr class="leader-half trailer-quarter" />
 <ul class="list-plain package-contents">
-{% for declaration in declarations %}
-  <li class="{{ declaration.icon }}">{% link declaration.pageUrl, declaration.name, class="tsd-kind-icon" %}</li>
-{% endfor %}
+  {% for declaration in declarations %}
+  <li class="{{ declaration.icon }}">
+    {% link declaration.pageUrl, declaration.name, class="tsd-kind-icon" %}
+  </li>
+  {% endfor %}
 </ul>

--- a/docs/src/api/index.html
+++ b/docs/src/api/index.html
@@ -4,11 +4,13 @@ layout: "api/_layout:content"
 
 <h1 class="font-size-4">Packages</h1>
 {% for package in data.typedoc.packages %}
-<section class="panel panel-white leader-1">
+  {% if not loop.first %}
+  <hr>
+  {% endif %}
   {% set pkg = package.pkg %}
   {% set declarations = package.declarations %}
   {% set url = package.pageUrl %}
   {% include "api/_package.html" %}
-</section>
+
 {% endfor %}
 </div>

--- a/docs/src/api/index.html
+++ b/docs/src/api/index.html
@@ -5,20 +5,10 @@ layout: "api/_layout:content"
 <h1 class="font-size-4">Packages</h1>
 {% for package in data.typedoc.packages %}
 <section class="panel panel-white leader-1">
-  <small class="label right">Version {{package.pkg.version}}</small>
-  <h2 class="{{package.icon}} font-size-3 trailer-half"> {% link package.pageUrl, package.pkg.name, class="tsd-kind-icon" %}</h2>
-  <p>{{package.pkg.description}}</p>
-  <h2 class="font-size--1 trailer-half">npm install:</h2>
-  <pre><code>{% npmInstallCmd package.pkg %}</code></pre>
-  <h2 class="font-size--1 trailer-half">CDN:</h2>
-  <pre><code>{% scriptTag package.pkg %}</code></pre>
-  {% scriptTagSRI package.pkg %}
-  <hr class="leader-half trailer-half">
-  <ul class="list-plain package-contents">
-  {% for declaration in package.declarations %}
-    <li class="{{declaration.icon}}">{% link declaration.pageUrl, declaration.name, class="tsd-kind-icon" %}</li>
-  {% endfor %}
-  </ul>
+  {% set pkg = package.pkg %}
+  {% set declarations = package.declarations %}
+  {% set url = package.pageUrl %}
+  {% include "api/_package.html" %}
 </section>
 {% endfor %}
 </div>

--- a/docs/src/js/api-search.js
+++ b/docs/src/js/api-search.js
@@ -1,7 +1,7 @@
 Vue.component("api-search", {
   template: `
     <div>
-      <form v-on:submit.prevent="onSubmit" class="input-group trailer-quarter leader-0  ">
+      <form v-on:submit.prevent="onSubmit" class="input-group trailer-half leader-0">
         <input ref="input" v-model="searchTerm" v-on:keyup.enter="onSubmit" v-on:keyup.up="onSelectPrevious" v-on:keyup.down="onSelectNext" v-on:keyup="onChange" class="input-group-input" type="text" placeholder="Search the API Reference">
         <span class="input-group-button">
           <button type="submit" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M31.607 27.838l-6.133-6.137a1.336 1.336 0 0 0-1.887 0l-.035.035-2.533-2.533-.014.014c3.652-4.556 3.422-11.195-.803-15.42-4.529-4.527-11.875-4.531-16.404 0-4.531 4.531-4.529 11.875 0 16.406 4.205 4.204 10.811 4.455 15.365.848l.004.003-.033.033 2.541 2.54a1.33 1.33 0 0 0 .025 1.848l6.135 6.133a1.33 1.33 0 0 0 1.887 0l1.885-1.883a1.332 1.332 0 0 0 0-1.887zM17.811 17.809a8.213 8.213 0 0 1-11.619 0 8.217 8.217 0 0 1 0-11.622 8.219 8.219 0 0 1 11.619.004 8.216 8.216 0 0 1 0 11.618z"/></svg></button>

--- a/docs/src/js/api-search.js
+++ b/docs/src/js/api-search.js
@@ -1,7 +1,7 @@
 Vue.component("api-search", {
   template: `
     <div>
-      <form v-on:submit.prevent="onSubmit" class="input-group trailer-half leader-0  ">
+      <form v-on:submit.prevent="onSubmit" class="input-group trailer-quarter leader-0  ">
         <input ref="input" v-model="searchTerm" v-on:keyup.enter="onSubmit" v-on:keyup.up="onSelectPrevious" v-on:keyup.down="onSelectNext" v-on:keyup="onChange" class="input-group-input" type="text" placeholder="Search the API Reference">
         <span class="input-group-button">
           <button type="submit" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path d="M31.607 27.838l-6.133-6.137a1.336 1.336 0 0 0-1.887 0l-.035.035-2.533-2.533-.014.014c3.652-4.556 3.422-11.195-.803-15.42-4.529-4.527-11.875-4.531-16.404 0-4.531 4.531-4.529 11.875 0 16.406 4.205 4.204 10.811 4.455 15.365.848l.004.003-.033.033 2.541 2.54a1.33 1.33 0 0 0 .025 1.848l6.135 6.133a1.33 1.33 0 0 0 1.887 0l1.885-1.883a1.332 1.332 0 0 0 0-1.887zM17.811 17.809a8.213 8.213 0 0 1-11.619 0 8.217 8.217 0 0 1 0-11.622 8.219 8.219 0 0 1 11.619.004 8.216 8.216 0 0 1 0 11.618z"/></svg></button>
@@ -17,7 +17,7 @@ Vue.component("api-search", {
       </div>
 
       <ul v-show="results.length > 0" class="list-plain">
-        <li v-for="result, index in results" class="api-search-result" v-bind:class="[result.icon, {'is-selected': index === selectedResultIndex}]">
+        <li v-for="result, index in results" class="api-search-result api-list-item" v-bind:class="[result.icon, {'is-selected': index === selectedResultIndex}]">
           <a v-bind:href="result.url" class="tsd-kind-icon" v-html="result.title"></a>
         </li>
       </ul>

--- a/docs/src/sass/style.scss
+++ b/docs/src/sass/style.scss
@@ -222,7 +222,10 @@ textarea,
 }
 
 .overflow-auto {
+  width: calc(100% + 1rem);
+
   table {
     margin: 0;
+    max-width: calc(100% - 1rem);
   }
 }

--- a/docs/src/sass/style.scss
+++ b/docs/src/sass/style.scss
@@ -6,7 +6,8 @@
   display: none;
 }
 
-body {
+body,
+.footer {
   background: #fafafa;
 }
 
@@ -178,15 +179,23 @@ a > code {
   }
 }
 
+.api-package-content-list {
+  .api-list-item {
+    padding-left: 0.5rem;
+  }
+}
+
 .api-list-item {
   font-size: 0.875rem;
   white-space: nowrap;
 }
 
-.list-item-active {
+.api-list-item.list-item-active {
   border-width: 1px;
   border-color: #0079c1;
   border-style: solid;
+  padding-left: 0;
+  margin-left: calc(0.5rem - 2px);
 }
 
 pre {
@@ -210,4 +219,10 @@ textarea,
 .input-group-button .btn,
 .input-group-button button {
   line-height: 0;
+}
+
+.overflow-auto {
+  table {
+    margin: 0;
+  }
 }

--- a/docs/src/sass/style.scss
+++ b/docs/src/sass/style.scss
@@ -42,7 +42,7 @@ tr:target,
 
 .table-link {
   position: absolute;
-  left: -1.25rem;
+  left: 1px;
   top: 50%;
   margin-top: -0.8375rem;
   display: none;
@@ -54,6 +54,7 @@ tr:target,
   height: 1.5rem;
   text-align: center;
   line-height: 1.5rem;
+  z-index: 100;
   &:hover {
     color: white;
     background: #005e95;

--- a/docs/src/sass/style.scss
+++ b/docs/src/sass/style.scss
@@ -6,6 +6,19 @@
   display: none;
 }
 
+body {
+  background: #fafafa;
+}
+
+dt {
+  font-weight: 400;
+}
+
+p {
+  font-size: 0.9375rem;
+  margin-bottom: 0.75rem;
+}
+
 tr:hover .table-link,
 .method-panel:hover header .table-link {
   display: block;
@@ -36,10 +49,10 @@ tr:target,
   background: white;
   border: 1px solid #cccccc;
   color: #0079c1;
-  width: 1.675rem;
-  height: 1.675rem;
+  width: 1.5rem;
+  height: 1.5rem;
   text-align: center;
-  line-height: 1.675rem;
+  line-height: 1.5rem;
   &:hover {
     color: white;
     background: #005e95;
@@ -48,16 +61,16 @@ tr:target,
   .svg-icon {
     vertical-align: auto;
     padding: 0;
-    width: 1rem;
-    height: 1rem;
-    top: 2px;
+    width: 0.875rem;
+    height: 0.875rem;
+    top: -1px;
     position: relative;
   }
 }
 
 .api-search-result {
   border: 1px solid transparent;
-  padding: 0.25rem;
+  padding: 0.125rem;
 
   &.is-selected {
     background: #f8f8f8;
@@ -87,6 +100,7 @@ tr:target,
 
 .api-package-content-list {
   margin-left: 1.1375rem;
+  padding: 0;
 }
 
 a > code {
@@ -139,6 +153,7 @@ a > code {
 
 .type-child-list {
   margin: 0;
+  text-indent: 0;
 }
 
 .type-child-name {
@@ -155,15 +170,44 @@ a > code {
 }
 
 .api-toggle-button {
-  padding: 0.1rem 0.1rem;
+  padding: 0;
+  line-height: normal;
+  vertical-align: 1px;
+  .svg-icon {
+    padding: 0;
+  }
 }
 
 .api-list-item {
+  font-size: 0.875rem;
   white-space: nowrap;
 }
 
 .list-item-active {
   border-width: 1px;
   border-color: #0079c1;
-  border-style: solid
+  border-style: solid;
+}
+
+pre {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+input,
+select,
+textarea {
+  font-size: 0.875rem;
+}
+
+input,
+select,
+textarea,
+.input-group-button .btn,
+.input-group-button button {
+  height: 1.75rem;
+}
+.input-group-button .btn,
+.input-group-button button {
+  line-height: 0;
 }

--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -58,5 +58,8 @@
     "arcgis",
     "esri",
     "ES6"
-  ]
+  ],
+  "esri": {
+    "keyExports": ["UserSession", "ApplicationSession"]
+  }
 }

--- a/packages/arcgis-rest-portal/src/groups/join.ts
+++ b/packages/arcgis-rest-portal/src/groups/join.ts
@@ -8,7 +8,7 @@ import { IGroupIdRequestOptions } from "./helpers";
 
 /**
  * ```js
- * import { joinGroup } from '@esri/arcgis-rest-groups';
+ * import { joinGroup } from '@esri/arcgis-rest-portal';
  * //
  * joinGroup({
  *   id: groupId,
@@ -33,7 +33,7 @@ export function joinGroup(
 
 /**
  * ```js
- * import { leaveGroup } from '@esri/arcgis-rest-groups';
+ * import { leaveGroup } from '@esri/arcgis-rest-portal';
  * //
  * leaveGroup({
  *   id: groupId,

--- a/packages/arcgis-rest-portal/src/groups/notification.ts
+++ b/packages/arcgis-rest-portal/src/groups/notification.ts
@@ -38,7 +38,7 @@ export interface IGroupNotificationRequestOptions
 
 /**
  * ```js
- * import { createGroupNotification } from '@esri/arcgis-rest-groups';
+ * import { createGroupNotification } from '@esri/arcgis-rest-portal';
  * // send an email to an entire group
  * createGroupNotification({
  *   authentication: UserSession,

--- a/packages/arcgis-rest-portal/src/groups/protect.ts
+++ b/packages/arcgis-rest-portal/src/groups/protect.ts
@@ -8,7 +8,7 @@ import { IGroupIdRequestOptions } from "./helpers";
 
 /**
  * ```js
- * import { protectGroup } from '@esri/arcgis-rest-groups';
+ * import { protectGroup } from '@esri/arcgis-rest-portal';
  * //
  * protectGroup({
  *   id: groupId,
@@ -33,7 +33,7 @@ export function protectGroup(
 
 /**
  * ```js
- * import { unprotectGroup } from '@esri/arcgis-rest-groups';
+ * import { unprotectGroup } from '@esri/arcgis-rest-portal';
  * //
  * unprotectGroup({
  *   id: groupId,

--- a/packages/arcgis-rest-portal/src/groups/remove.ts
+++ b/packages/arcgis-rest-portal/src/groups/remove.ts
@@ -8,7 +8,7 @@ import { IGroupIdRequestOptions } from "./helpers";
 
 /**
  * ```js
- * import { removeGroup } from '@esri/arcgis-rest-groups';
+ * import { removeGroup } from '@esri/arcgis-rest-portal';
  * //
  * removeGroup({
  *   id: groupId,

--- a/packages/arcgis-rest-portal/src/groups/update.ts
+++ b/packages/arcgis-rest-portal/src/groups/update.ts
@@ -11,7 +11,7 @@ export interface IGroupUpdateRequestOptions extends IRequestOptions {
 
 /**
  * ```js
- * import { updateGroup } from '@esri/arcgis-rest-groups';
+ * import { updateGroup } from '@esri/arcgis-rest-portal';
  * //
  * updateGroup({
  *   group: { id: "fgr344", title: "new" }

--- a/packages/arcgis-rest-portal/src/sharing/group-sharing.ts
+++ b/packages/arcgis-rest-portal/src/sharing/group-sharing.ts
@@ -187,6 +187,7 @@ function isItemSharedWithGroup(
 
   const url = `${getPortalUrl(options)}/search`;
 
+  // to do: just call searchItems now that its in the same package
   return request(url, options).then(searchResponse => {
     // if there are no search results at all, we know the item hasnt already been shared with the group
     if (searchResponse.total === 0) {

--- a/packages/arcgis-rest-portal/src/users/get-user.ts
+++ b/packages/arcgis-rest-portal/src/users/get-user.ts
@@ -21,7 +21,7 @@ export interface IGetUserRequestOptions extends IRequestOptions {
 
 /**
  * ```js
- * import { getUser } from '@esri/arcgis-rest-users';
+ * import { getUser } from '@esri/arcgis-rest-portal';
  * //
  * getUser("jsmith")
  *   .then(response)

--- a/packages/arcgis-rest-portal/src/users/invitation.ts
+++ b/packages/arcgis-rest-portal/src/users/invitation.ts
@@ -36,7 +36,7 @@ export interface IInvitationResult {
 
 /**
  * ```js
- * import { getUserInvitations } from '@esri/arcgis-rest-users';
+ * import { getUserInvitations } from '@esri/arcgis-rest-portal';
  * // username is inferred from UserSession
  * getUserInvitations({ authentication })
  *   .then(response) // response.userInvitations.length => 3
@@ -66,7 +66,7 @@ export interface IInvitationRequestOptions extends IUserRequestOptions {
 
 /**
  * ```js
- * import { getUserInvitation } from '@esri/arcgis-rest-users';
+ * import { getUserInvitation } from '@esri/arcgis-rest-portal';
  * // username is inferred from UserSession
  * getUserInvitation({
  *   invitationId: "3ef",
@@ -97,7 +97,7 @@ export function getUserInvitation(
 
 /**
  * ```js
- * import { acceptInvitation } from '@esri/arcgis-rest-users';
+ * import { acceptInvitation } from '@esri/arcgis-rest-portal';
  * // username is inferred from UserSession
  * acceptInvitation({
  *   invitationId: "3ef",
@@ -125,7 +125,7 @@ export function acceptInvitation(
 
 /**
  * ```js
- * import { declineInvitation } from '@esri/arcgis-rest-users';
+ * import { declineInvitation } from '@esri/arcgis-rest-portal';
  * // username is inferred from UserSession
  * declineInvitation({
  *   invitationId: "3ef",

--- a/packages/arcgis-rest-portal/src/users/notification.ts
+++ b/packages/arcgis-rest-portal/src/users/notification.ts
@@ -27,7 +27,7 @@ export interface INotificationResult {
 
 /**
  * ```js
- * import { getUserNotifications } from '@esri/arcgis-rest-users';
+ * import { getUserNotifications } from '@esri/arcgis-rest-portal';
  * // username is inferred from UserSession
  * getUserNotifications({ authentication })
  *   .then(results) // results.notifications.length) => 3

--- a/packages/arcgis-rest-portal/src/users/update.ts
+++ b/packages/arcgis-rest-portal/src/users/update.ts
@@ -26,7 +26,7 @@ export interface IUpdateUserResponse {
 
 /**
  * ```js
- * import { updateUser } from '@esri/arcgis-rest-users';
+ * import { updateUser } from '@esri/arcgis-rest-portal';
  * // any user can update their own profile
  * updateUser({
  *   authentication,

--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -50,5 +50,8 @@
     "arcgis",
     "esri",
     "ES6"
-  ]
+  ],
+  "esri": {
+    "keyExports": ["request"]
+  }
 }

--- a/packages/arcgis-rest-routing/src/solveRoute.ts
+++ b/packages/arcgis-rest-routing/src/solveRoute.ts
@@ -73,6 +73,7 @@ function isLocation(
  *
  * @param requestOptions Options to pass through to the routing service.
  * @returns A Promise that will resolve with routes and directions for the request.
+ * @restLink https://developers.arcgis.com/rest/network/api-reference/route-synchronous-service.htm
  */
 export function solveRoute(
   requestOptions: ISolveRouteRequestOptions

--- a/packages/arcgis-rest-routing/src/solveRoute.ts
+++ b/packages/arcgis-rest-routing/src/solveRoute.ts
@@ -73,7 +73,7 @@ function isLocation(
  *
  * @param requestOptions Options to pass through to the routing service.
  * @returns A Promise that will resolve with routes and directions for the request.
- * @restLink https://developers.arcgis.com/rest/network/api-reference/route-synchronous-service.htm
+ * @restlink https://developers.arcgis.com/rest/network/api-reference/route-synchronous-service.htm
  */
 export function solveRoute(
   requestOptions: ISolveRouteRequestOptions

--- a/packages/arcgis-rest-types/package.json
+++ b/packages/arcgis-rest-types/package.json
@@ -44,5 +44,8 @@
     "arcgis",
     "esri",
     "ES6"
-  ]
+  ],
+  "esri": {
+    "keyExports": ["IUser, IItem"]
+  }
 }


### PR DESCRIPTION
Resolves the following in https://github.com/Esri/arcgis-rest-js/issues/518

* [x] Add support for linking the the REST API page for each method. YOu can now add `@restlink https://developers.arcgis.com/rest/network/api-reference/route-synchronous-service.htm` to add a link to the REST API on teh developers site to any function. See `solveRoute()` for an example.
* [x] Fix formatting for return type of `updateGroup()` also https://github.com/Esri/arcgis-rest-js/pull/523)
* [x] Sort tables
* [x] Sort the lists of exported items in the API reference for clarity
* [x] Render values properly for things like `NODEJS_DEFAULT_REFERER_HEADER`.
* [x] Handle type params for `ISearchResponse`

This also fixes a lot of other small case:

* Tables with long strings now simply scroll left to right (see `UserSession`)
* Each package now includes a sample ES 6 import statement. By default this is all classes and functions but can be customized with a custom `esri.keyExports` field in `package.json` of each package (See `-request`, `-auth` and `-types`)
* Add a blacklist for blocking exports like `genericSearch` and `DEFAULT_ARCGIS_REQUEST_OPTIONS`.
* Update calcite web to latest
* General improvements to the information density of each doc page.

@jgravois this wraps up everything in the API ref that ISN'T actually writing doc. I'll do a separate PR for that later to day if you want to review this.