### PR TITLE
refactor(portal interfaces): renames portal request/response interfac…

### DIFF
--- a/packages/arcgis-rest-portal/src/groups/create.ts
+++ b/packages/arcgis-rest-portal/src/groups/create.ts
@@ -6,7 +6,7 @@ import { IGroupAdd, IGroup } from "@esri/arcgis-rest-types";
 
 import { getPortalUrl } from "../util/get-portal-url";
 
-export interface IGroupAddRequestOptions extends IRequestOptions {
+export interface ICreateGroupOptions extends IRequestOptions {
   group: IGroupAdd;
 }
 
@@ -30,7 +30,7 @@ export interface IGroupAddRequestOptions extends IRequestOptions {
  * @returns A Promise that will resolve with the success/failure status of the request
  */
 export function createGroup(
-  requestOptions: IGroupAddRequestOptions
+  requestOptions: ICreateGroupOptions
 ): Promise<{ success: boolean; group: IGroup }> {
   const url = `${getPortalUrl(requestOptions)}/community/createGroup`;
 

--- a/packages/arcgis-rest-portal/src/groups/get.ts
+++ b/packages/arcgis-rest-portal/src/groups/get.ts
@@ -6,7 +6,7 @@ import { IPagingParams, IGroup, IItem } from "@esri/arcgis-rest-types";
 
 import { getPortalUrl } from "../util/get-portal-url";
 
-export interface IPagingParamsRequestOptions extends IRequestOptions {
+export interface IGetGroupContentOptions extends IRequestOptions {
   paging: IPagingParams;
 }
 
@@ -59,7 +59,7 @@ export function getGroup(
  */
 export function getGroupContent(
   id: string,
-  requestOptions?: IPagingParamsRequestOptions
+  requestOptions?: IGetGroupContentOptions
 ): Promise<IGroup> {
   const url = `${getPortalUrl(requestOptions)}/content/groups/${id}`;
 
@@ -68,7 +68,7 @@ export function getGroupContent(
     ...{ httpMethod: "GET" },
     params: { start: 1, num: 100 },
     ...requestOptions
-  } as IPagingParamsRequestOptions;
+  } as IGetGroupContentOptions;
 
   // is this the most concise way to mixin with the defaults above?
   if (requestOptions && requestOptions.paging) {

--- a/packages/arcgis-rest-portal/src/groups/helpers.ts
+++ b/packages/arcgis-rest-portal/src/groups/helpers.ts
@@ -3,6 +3,12 @@
 
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
-export interface IGroupIdRequestOptions extends IUserRequestOptions {
+/**
+ * Base options interface for making authenticated requests for groups.
+ */
+export interface IUserGroupOptions extends IUserRequestOptions {
+  /**
+   * Unique identifier of the group.
+   */
   id: string;
 }

--- a/packages/arcgis-rest-portal/src/groups/join.ts
+++ b/packages/arcgis-rest-portal/src/groups/join.ts
@@ -4,7 +4,7 @@
 import { request } from "@esri/arcgis-rest-request";
 
 import { getPortalUrl } from "../util/get-portal-url";
-import { IGroupIdRequestOptions } from "./helpers";
+import { IUserGroupOptions } from "./helpers";
 
 /**
  * ```js
@@ -22,7 +22,7 @@ import { IGroupIdRequestOptions } from "./helpers";
  * @returns A Promise that will resolve with the success/failure status of the request and the groupId.
  */
 export function joinGroup(
-  requestOptions: IGroupIdRequestOptions
+  requestOptions: IUserGroupOptions
 ): Promise<{ success: boolean; groupId: string }> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
@@ -47,7 +47,7 @@ export function joinGroup(
  * @returns A Promise that will resolve with the success/failure status of the request and the groupId.
  */
 export function leaveGroup(
-  requestOptions: IGroupIdRequestOptions
+  requestOptions: IUserGroupOptions
 ): Promise<{ success: boolean; groupId: string }> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id

--- a/packages/arcgis-rest-portal/src/groups/notification.ts
+++ b/packages/arcgis-rest-portal/src/groups/notification.ts
@@ -2,14 +2,13 @@
  * Apache-2.0 */
 
 import { request } from "@esri/arcgis-rest-request";
-import { IGroupIdRequestOptions } from "./helpers";
+import { IUserGroupOptions } from "./helpers";
 
 import { getPortalUrl } from "../util/get-portal-url";
 
 export type NotificationChannelType = "push" | "email" | "builtin";
 
-export interface IGroupNotificationRequestOptions
-  extends IGroupIdRequestOptions {
+export interface ICreateGroupNotificationOptions extends IUserGroupOptions {
   /**
    * Subject of the notification. This only applies to email and builtin notifications. For push notifications, subject/title is provided as a part of the message payload.
    */
@@ -54,13 +53,13 @@ export interface IGroupNotificationRequestOptions
  * @returns A Promise that will resolve with the success/failure status of the request
  */
 export function createGroupNotification(
-  requestOptions: IGroupNotificationRequestOptions
+  requestOptions: ICreateGroupNotificationOptions
 ): Promise<any> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
   }/createNotification`;
 
-  const options: IGroupNotificationRequestOptions = {
+  const options: ICreateGroupNotificationOptions = {
     params: {
       subject: requestOptions.subject,
       message: requestOptions.message,

--- a/packages/arcgis-rest-portal/src/groups/protect.ts
+++ b/packages/arcgis-rest-portal/src/groups/protect.ts
@@ -4,7 +4,7 @@
 import { request } from "@esri/arcgis-rest-request";
 
 import { getPortalUrl } from "../util/get-portal-url";
-import { IGroupIdRequestOptions } from "./helpers";
+import { IUserGroupOptions } from "./helpers";
 
 /**
  * ```js
@@ -22,7 +22,7 @@ import { IGroupIdRequestOptions } from "./helpers";
  * @returns A Promise that will resolve with the success/failure status of the request
  */
 export function protectGroup(
-  requestOptions: IGroupIdRequestOptions
+  requestOptions: IUserGroupOptions
 ): Promise<{ success: boolean }> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
@@ -46,7 +46,7 @@ export function protectGroup(
  * @returns A Promise that will resolve with the success/failure status of the request
  */
 export function unprotectGroup(
-  requestOptions: IGroupIdRequestOptions
+  requestOptions: IUserGroupOptions
 ): Promise<{ success: boolean }> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id

--- a/packages/arcgis-rest-portal/src/groups/remove.ts
+++ b/packages/arcgis-rest-portal/src/groups/remove.ts
@@ -4,7 +4,7 @@
 import { request } from "@esri/arcgis-rest-request";
 
 import { getPortalUrl } from "../util/get-portal-url";
-import { IGroupIdRequestOptions } from "./helpers";
+import { IUserGroupOptions } from "./helpers";
 
 /**
  * ```js
@@ -21,13 +21,11 @@ import { IGroupIdRequestOptions } from "./helpers";
  * @param requestOptions - Options for the request
  * @returns A Promise that will resolve with the success/failure status of the request
  */
-export function removeGroup(
-  requestOptions: IGroupIdRequestOptions
-): Promise<any> {
+export function removeGroup(requestOptions: IUserGroupOptions): Promise<any> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.id
   }/delete`;
-  const options: IGroupIdRequestOptions = {
+  const options: IUserGroupOptions = {
     ...requestOptions
   };
   return request(url, options);

--- a/packages/arcgis-rest-portal/src/groups/search.ts
+++ b/packages/arcgis-rest-portal/src/groups/search.ts
@@ -3,7 +3,7 @@
 
 import { IGroup } from "@esri/arcgis-rest-types";
 import { SearchQueryBuilder } from "../util/SearchQueryBuilder";
-import { ISearchRequestOptions, ISearchResult } from "../util/search";
+import { ISearchOptions, ISearchResult } from "../util/search";
 import { genericSearch } from "../util/generic-search";
 
 /**
@@ -19,7 +19,7 @@ import { genericSearch } from "../util/generic-search";
  * @returns A Promise that will resolve with the data from the response.
  */
 export function searchGroups(
-  search: string | ISearchRequestOptions | SearchQueryBuilder
+  search: string | ISearchOptions | SearchQueryBuilder
 ): Promise<ISearchResult<IGroup>> {
   return genericSearch<IGroup>(search, "group");
 }

--- a/packages/arcgis-rest-portal/src/groups/update.ts
+++ b/packages/arcgis-rest-portal/src/groups/update.ts
@@ -5,7 +5,7 @@ import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 import { IItemUpdate } from "@esri/arcgis-rest-types";
 import { getPortalUrl } from "../util/get-portal-url";
 
-export interface IGroupUpdateRequestOptions extends IRequestOptions {
+export interface IUpdateGroupOptions extends IRequestOptions {
   group: IItemUpdate;
 }
 
@@ -24,7 +24,7 @@ export interface IGroupUpdateRequestOptions extends IRequestOptions {
  * @returns A Promise that will resolve with the success/failure status of the request
  */
 export function updateGroup(
-  requestOptions: IGroupUpdateRequestOptions
+  requestOptions: IUpdateGroupOptions
 ): Promise<{ success: boolean; groupId: string }> {
   const url = `${getPortalUrl(requestOptions)}/community/groups/${
     requestOptions.group.id

--- a/packages/arcgis-rest-portal/src/items/add.ts
+++ b/packages/arcgis-rest-portal/src/items/add.ts
@@ -5,15 +5,15 @@ import { request, appendCustomParams } from "@esri/arcgis-rest-request";
 
 import { getPortalUrl } from "../util/get-portal-url";
 import {
-  IItemIdRequestOptions,
-  IItemResourceRequestOptions,
-  IItemAddResponse,
+  IUserItemOptions,
+  IItemResourceOptions,
+  IUpdateItemResponse,
   IItemResourceResponse,
   determineOwner,
-  IManageItemRelationshipRequestOptions
+  IManageItemRelationshipOptions
 } from "./helpers";
 
-export interface IItemDataAddRequestOptions extends IItemIdRequestOptions {
+export interface IAddItemDataOptions extends IUserItemOptions {
   /**
    * Object to store
    */
@@ -38,8 +38,8 @@ export interface IItemDataAddRequestOptions extends IItemIdRequestOptions {
  *        success/failure and echoing the item id.
  */
 export function addItemJsonData(
-  requestOptions: IItemDataAddRequestOptions
-): Promise<IItemAddResponse> {
+  requestOptions: IAddItemDataOptions
+): Promise<IUpdateItemResponse> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.id
@@ -74,8 +74,8 @@ export function addItemJsonData(
  *        success/failure and echoing the item id.
  */
 export function addItemData(
-  requestOptions: IItemDataAddRequestOptions
-): Promise<IItemAddResponse> {
+  requestOptions: IAddItemDataOptions
+): Promise<IUpdateItemResponse> {
   const owner = determineOwner(requestOptions);
 
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
@@ -109,14 +109,14 @@ export function addItemData(
  * @returns A Promise to add item resources.
  */
 export function addItemRelationship(
-  requestOptions: IManageItemRelationshipRequestOptions
+  requestOptions: IManageItemRelationshipOptions
 ): Promise<{ success: boolean }> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(
     requestOptions
   )}/content/users/${owner}/addRelationship`;
 
-  const options = appendCustomParams<IManageItemRelationshipRequestOptions>(
+  const options = appendCustomParams<IManageItemRelationshipOptions>(
     requestOptions,
     ["originItemId", "destinationItemId", "relationshipType"],
     { params: { ...requestOptions.params } }
@@ -153,7 +153,7 @@ export function addItemRelationship(
  * @returns A Promise to add item resources.
  */
 export function addItemResource(
-  requestOptions: IItemResourceRequestOptions
+  requestOptions: IItemResourceOptions
 ): Promise<IItemResourceResponse> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${

--- a/packages/arcgis-rest-portal/src/items/create.ts
+++ b/packages/arcgis-rest-portal/src/items/create.ts
@@ -7,21 +7,25 @@ import { IItemAdd } from "@esri/arcgis-rest-types";
 import { getPortalUrl } from "../util/get-portal-url";
 import {
   IAddFolderResponse,
-  IItemAddResponse,
-  IItemCrudRequestOptions,
+  IUpdateItemResponse,
+  ICreateUpdateItemOptions,
   serializeItem,
   determineOwner
 } from "./helpers";
 
-export interface IAddFolderRequestOptions extends IItemCrudRequestOptions {
+export interface ICreateFolderOptions extends ICreateUpdateItemOptions {
   /**
    * Name of the folder to create.
    */
   title: string;
 }
 
-export interface IItemAddRequestOptions extends IItemCrudRequestOptions {
+export interface ICreateItemOptions extends ICreateUpdateItemOptions {
   item: IItemAdd;
+}
+
+export interface ICreateItemResponse extends IUpdateItemResponse {
+  folder: string;
 }
 
 /**
@@ -40,7 +44,7 @@ export interface IItemAddRequestOptions extends IItemCrudRequestOptions {
  * @returns A Promise that resolves with folder details once the folder has been created
  */
 export function createFolder(
-  requestOptions: IAddFolderRequestOptions
+  requestOptions: ICreateFolderOptions
 ): Promise<IAddFolderResponse> {
   const owner = determineOwner(requestOptions);
 
@@ -74,8 +78,8 @@ export function createFolder(
  * @param requestOptions = Options for the request
  */
 export function createItemInFolder(
-  requestOptions: IItemAddRequestOptions
-): Promise<IItemAddResponse> {
+  requestOptions: ICreateItemOptions
+): Promise<ICreateItemResponse> {
   const owner = determineOwner(requestOptions);
 
   const baseUrl = `${getPortalUrl(requestOptions)}/content/users/${owner}`;
@@ -113,12 +117,12 @@ export function createItemInFolder(
  * @returns A Promise that creates an item.
  */
 export function createItem(
-  requestOptions: IItemAddRequestOptions
-): Promise<IItemAddResponse> {
+  requestOptions: ICreateItemOptions
+): Promise<ICreateItemResponse> {
   // delegate to createItemInFolder placing in the root of the filestore
   const options = {
     folderId: null,
     ...requestOptions
-  } as IItemAddRequestOptions;
+  } as ICreateItemOptions;
   return createItemInFolder(options);
 }

--- a/packages/arcgis-rest-portal/src/items/get.ts
+++ b/packages/arcgis-rest-portal/src/items/get.ts
@@ -5,10 +5,7 @@ import { request, IRequestOptions } from "@esri/arcgis-rest-request";
 import { IItem, IGroup } from "@esri/arcgis-rest-types";
 
 import { getPortalUrl } from "../util/get-portal-url";
-import {
-  IItemDataRequestOptions,
-  IItemRelationshipRequestOptions
-} from "./helpers";
+import { IItemDataOptions, IItemRelationshipOptions } from "./helpers";
 
 /**
  * ```
@@ -57,11 +54,11 @@ export function getItem(
  */
 export function getItemData(
   id: string,
-  requestOptions?: IItemDataRequestOptions
+  requestOptions?: IItemDataOptions
 ): Promise<any> {
   const url = `${getPortalUrl(requestOptions)}/content/items/${id}/data`;
   // default to a GET request
-  const options: IItemDataRequestOptions = {
+  const options: IItemDataOptions = {
     ...{ httpMethod: "GET", params: {} },
     ...requestOptions
   };
@@ -104,13 +101,13 @@ export interface IGetRelatedItemsResponse {
  * @returns A Promise to get some item resources.
  */
 export function getRelatedItems(
-  requestOptions: IItemRelationshipRequestOptions
+  requestOptions: IItemRelationshipOptions
 ): Promise<IGetRelatedItemsResponse> {
   const url = `${getPortalUrl(requestOptions)}/content/items/${
     requestOptions.id
   }/relatedItems`;
 
-  const options: IItemRelationshipRequestOptions = {
+  const options: IItemRelationshipOptions = {
     httpMethod: "GET",
     params: {
       direction: requestOptions.direction
@@ -151,7 +148,7 @@ export function getItemResources(
   return request(url, requestOptions);
 }
 
-export interface IItemGroupResponse {
+export interface IGetItemGroupsResponse {
   admin?: IGroup[];
   member?: IGroup[];
   other?: IGroup[];
@@ -173,7 +170,7 @@ export interface IItemGroupResponse {
 export function getItemGroups(
   id: string,
   requestOptions?: IRequestOptions
-): Promise<IItemGroupResponse> {
+): Promise<IGetItemGroupsResponse> {
   const url = `${getPortalUrl(requestOptions)}/content/items/${id}/groups`;
 
   return request(url, requestOptions);

--- a/packages/arcgis-rest-portal/src/items/helpers.ts
+++ b/packages/arcgis-rest-portal/src/items/helpers.ts
@@ -5,11 +5,10 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IItemAdd, IItemUpdate, IItem } from "@esri/arcgis-rest-types";
 import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
-export interface IItemRequestOptions extends IUserRequestOptions {
-  item: IItem;
-}
-
-export interface IItemIdRequestOptions extends IUserRequestOptions {
+/**
+ * Base options interface for making authenticated requests for items.
+ */
+export interface IUserItemOptions extends IUserRequestOptions {
   /**
    * Unique identifier of the item.
    */
@@ -20,7 +19,7 @@ export interface IItemIdRequestOptions extends IUserRequestOptions {
   owner?: string;
 }
 
-export interface IFolderIdRequestOptions extends IUserRequestOptions {
+export interface IFolderIdOptions extends IUserRequestOptions {
   /**
    * Unique identifier of the folder.
    */
@@ -52,9 +51,9 @@ export type ItemRelationshipType =
   | "Service2Layer"
   | "Area2CustomPackage";
 
-export interface IItemRelationshipRequestOptions extends IRequestOptions {
+export interface IItemRelationshipOptions extends IRequestOptions {
   /**
-   * Id of the item.
+   * Unique identifier of the item.
    */
   id: string;
   /**
@@ -67,14 +66,13 @@ export interface IItemRelationshipRequestOptions extends IRequestOptions {
   direction?: "forward" | "reverse";
 }
 
-export interface IManageItemRelationshipRequestOptions
-  extends IUserRequestOptions {
+export interface IManageItemRelationshipOptions extends IUserRequestOptions {
   originItemId: string;
   destinationItemId: string;
   relationshipType: ItemRelationshipType;
 }
 
-export interface IItemResourceRequestOptions extends IItemIdRequestOptions {
+export interface IItemResourceOptions extends IUserItemOptions {
   /**
    * New resource filename.
    */
@@ -93,7 +91,7 @@ export interface IItemResourceRequestOptions extends IItemIdRequestOptions {
   resource?: any;
 }
 
-export interface IItemCrudRequestOptions extends IUserRequestOptions {
+export interface ICreateUpdateItemOptions extends IUserRequestOptions {
   /**
    * The owner of the item. If this property is not present, `item.owner` will be passed, or lastly `authentication.username`.
    */
@@ -104,20 +102,16 @@ export interface IItemCrudRequestOptions extends IUserRequestOptions {
   folderId?: string;
 }
 
-export interface IItemDataRequestOptions extends IRequestOptions {
+export interface IItemDataOptions extends IRequestOptions {
   /**
    * Used to request binary data.
    */
   file?: boolean;
 }
 
-export interface IItemUpdateResponse {
+export interface IUpdateItemResponse {
   success: boolean;
   id: string;
-}
-
-export interface IItemAddResponse extends IItemUpdateResponse {
-  folder: string;
 }
 
 export interface IItemResourceResponse {
@@ -142,7 +136,7 @@ export interface IAddFolderResponse {
   };
 }
 
-export interface IItemMoveResponse {
+export interface IMoveItemResponse {
   /**
    * Success or failure of request.
    */

--- a/packages/arcgis-rest-portal/src/items/protect.ts
+++ b/packages/arcgis-rest-portal/src/items/protect.ts
@@ -4,7 +4,7 @@
 import { request } from "@esri/arcgis-rest-request";
 
 import { getPortalUrl } from "../util/get-portal-url";
-import { IItemIdRequestOptions, determineOwner } from "./helpers";
+import { IUserItemOptions, determineOwner } from "./helpers";
 
 /**
  * Protect an item. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/protect.htm) for more information.
@@ -12,9 +12,7 @@ import { IItemIdRequestOptions, determineOwner } from "./helpers";
  * @param requestOptions - Options for the request
  * @returns A Promise to protect an item.
  */
-export function protectItem(
-  requestOptions: IItemIdRequestOptions
-): Promise<any> {
+export function protectItem(requestOptions: IUserItemOptions): Promise<any> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.id
@@ -28,9 +26,7 @@ export function protectItem(
  * @param requestOptions - Options for the request
  * @returns A Promise to unprotect an item.
  */
-export function unprotectItem(
-  requestOptions: IItemIdRequestOptions
-): Promise<any> {
+export function unprotectItem(requestOptions: IUserItemOptions): Promise<any> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.id

--- a/packages/arcgis-rest-portal/src/items/protect.ts
+++ b/packages/arcgis-rest-portal/src/items/protect.ts
@@ -12,7 +12,9 @@ import { IUserItemOptions, determineOwner } from "./helpers";
  * @param requestOptions - Options for the request
  * @returns A Promise to protect an item.
  */
-export function protectItem(requestOptions: IUserItemOptions): Promise<any> {
+export function protectItem(
+  requestOptions: IUserItemOptions
+): Promise<{ success: boolean }> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.id
@@ -26,7 +28,9 @@ export function protectItem(requestOptions: IUserItemOptions): Promise<any> {
  * @param requestOptions - Options for the request
  * @returns A Promise to unprotect an item.
  */
-export function unprotectItem(requestOptions: IUserItemOptions): Promise<any> {
+export function unprotectItem(
+  requestOptions: IUserItemOptions
+): Promise<{ success: boolean }> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.id

--- a/packages/arcgis-rest-portal/src/items/remove.ts
+++ b/packages/arcgis-rest-portal/src/items/remove.ts
@@ -5,11 +5,11 @@ import { request, appendCustomParams } from "@esri/arcgis-rest-request";
 
 import { getPortalUrl } from "../util/get-portal-url";
 import {
-  IItemIdRequestOptions,
-  IItemResourceRequestOptions,
-  IFolderIdRequestOptions,
+  IUserItemOptions,
+  IItemResourceOptions,
+  IFolderIdOptions,
   determineOwner,
-  IManageItemRelationshipRequestOptions
+  IManageItemRelationshipOptions
 } from "./helpers";
 
 /**
@@ -26,9 +26,7 @@ import {
  * @param requestOptions - Options for the request
  * @returns A Promise that deletes an item.
  */
-export function removeItem(
-  requestOptions: IItemIdRequestOptions
-): Promise<any> {
+export function removeItem(requestOptions: IUserItemOptions): Promise<any> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.id
@@ -54,14 +52,14 @@ export function removeItem(
  * @returns A Promise to add item resources.
  */
 export function removeItemRelationship(
-  requestOptions: IManageItemRelationshipRequestOptions
+  requestOptions: IManageItemRelationshipOptions
 ): Promise<{ success: boolean }> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(
     requestOptions
   )}/content/users/${owner}/removeRelationship`;
 
-  const options = appendCustomParams<IManageItemRelationshipRequestOptions>(
+  const options = appendCustomParams<IManageItemRelationshipOptions>(
     requestOptions,
     ["originItemId", "destinationItemId", "relationshipType"],
     { params: { ...requestOptions.params } }
@@ -77,8 +75,8 @@ export function removeItemRelationship(
  * @returns A Promise that deletes an item resource.
  */
 export function removeItemResource(
-  requestOptions: IItemResourceRequestOptions
-): Promise<any> {
+  requestOptions: IItemResourceOptions
+): Promise<{ success: boolean }> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.id
@@ -112,7 +110,7 @@ export function removeItemResource(
  * @returns A Promise that deletes a folder
  */
 export function removeFolder(
-  requestOptions: IFolderIdRequestOptions
+  requestOptions: IFolderIdOptions
 ): Promise<{
   success: boolean;
   folder: {

--- a/packages/arcgis-rest-portal/src/items/remove.ts
+++ b/packages/arcgis-rest-portal/src/items/remove.ts
@@ -26,7 +26,9 @@ import {
  * @param requestOptions - Options for the request
  * @returns A Promise that deletes an item.
  */
-export function removeItem(requestOptions: IUserItemOptions): Promise<any> {
+export function removeItem(
+  requestOptions: IUserItemOptions
+): Promise<{ success: boolean; itemId: string }> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.id

--- a/packages/arcgis-rest-portal/src/items/search.ts
+++ b/packages/arcgis-rest-portal/src/items/search.ts
@@ -3,7 +3,7 @@
 
 import { IItem } from "@esri/arcgis-rest-types";
 import { SearchQueryBuilder } from "../util/SearchQueryBuilder";
-import { ISearchRequestOptions, ISearchResult } from "../util/search";
+import { ISearchOptions, ISearchResult } from "../util/search";
 import { genericSearch } from "../util/generic-search";
 
 /**
@@ -19,7 +19,7 @@ import { genericSearch } from "../util/generic-search";
  * @returns A Promise that will resolve with the data from the response.
  */
 export function searchItems(
-  search: string | ISearchRequestOptions | SearchQueryBuilder
+  search: string | ISearchOptions | SearchQueryBuilder
 ): Promise<ISearchResult<IItem>> {
   return genericSearch<IItem>(search, "item");
 }

--- a/packages/arcgis-rest-portal/src/items/update.ts
+++ b/packages/arcgis-rest-portal/src/items/update.ts
@@ -6,19 +6,20 @@ import { IItemUpdate } from "@esri/arcgis-rest-types";
 
 import { getPortalUrl } from "../util/get-portal-url";
 import {
-  IItemCrudRequestOptions,
-  IItemMoveResponse,
-  IItemResourceRequestOptions,
-  IItemUpdateResponse,
+  ICreateUpdateItemOptions,
+  IMoveItemResponse,
+  IItemResourceOptions,
+  IItemResourceResponse,
+  IUpdateItemResponse,
   serializeItem,
   determineOwner
 } from "./helpers";
 
-export interface IItemUpdateRequestOptions extends IItemCrudRequestOptions {
+export interface IUpdateItemOptions extends ICreateUpdateItemOptions {
   item: IItemUpdate;
 }
 
-export interface IItemMoveRequestOptions extends IItemCrudRequestOptions {
+export interface IMoveItemOptions extends ICreateUpdateItemOptions {
   /**
    * Alphanumeric id of item to be moved.
    */
@@ -50,8 +51,8 @@ export interface IItemMoveRequestOptions extends IItemCrudRequestOptions {
  * @returns A Promise that updates an item.
  */
 export function updateItem(
-  requestOptions: IItemUpdateRequestOptions
-): Promise<IItemUpdateResponse> {
+  requestOptions: IUpdateItemOptions
+): Promise<IUpdateItemResponse> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.item.id
@@ -84,8 +85,8 @@ export function updateItem(
  * @returns A Promise that updates an item resource.
  */
 export function updateItemResource(
-  requestOptions: IItemResourceRequestOptions
-): Promise<any> {
+  requestOptions: IItemResourceOptions
+): Promise<IItemResourceResponse> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(
     requestOptions as IRequestOptions
@@ -124,8 +125,8 @@ export function updateItemResource(
  * @returns A Promise that resolves with owner and folder details once the move has been completed
  */
 export function moveItem(
-  requestOptions: IItemMoveRequestOptions
-): Promise<IItemMoveResponse> {
+  requestOptions: IMoveItemOptions
+): Promise<IMoveItemResponse> {
   const owner = determineOwner(requestOptions);
   const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
     requestOptions.itemId

--- a/packages/arcgis-rest-portal/src/sharing/access.ts
+++ b/packages/arcgis-rest-portal/src/sharing/access.ts
@@ -4,14 +4,14 @@
 import { request } from "@esri/arcgis-rest-request";
 
 import {
-  ISharingRequestOptions,
+  ISharingOptions,
   ISharingResponse,
   isItemOwner,
   getSharingUrl,
   isOrgAdmin
 } from "./helpers";
 
-export interface ISetAccessRequestOptions extends ISharingRequestOptions {
+export interface ISetAccessOptions extends ISharingOptions {
   /**
    * "private" indicates that the item can only be accessed by the user. "public" means accessible to anyone. An item shared to the organization has an access level of "org".
    */
@@ -34,7 +34,7 @@ export interface ISetAccessRequestOptions extends ISharingRequestOptions {
  * @returns A Promise that will resolve with the data from the response.
  */
 export function setItemAccess(
-  requestOptions: ISetAccessRequestOptions
+  requestOptions: ISetAccessOptions
 ): Promise<ISharingResponse> {
   const url = getSharingUrl(requestOptions);
 
@@ -60,7 +60,7 @@ export function setItemAccess(
 
 function updateItemAccess(
   url: string,
-  requestOptions: ISetAccessRequestOptions
+  requestOptions: ISetAccessOptions
 ): Promise<any> {
   requestOptions.params = {
     org: false,

--- a/packages/arcgis-rest-portal/src/sharing/group-sharing.ts
+++ b/packages/arcgis-rest-portal/src/sharing/group-sharing.ts
@@ -5,22 +5,13 @@ import { request } from "@esri/arcgis-rest-request";
 import { IItem } from "@esri/arcgis-rest-types";
 import { getPortalUrl } from "../util/get-portal-url";
 import {
-  ISharingRequestOptions,
+  IGroupSharingOptions,
   ISharingResponse,
   isOrgAdmin,
   getUserMembership
 } from "./helpers";
 
-export interface IGroupSharingRequestOptions extends ISharingRequestOptions {
-  /**
-   * Group identifier
-   */
-  groupId: string;
-  confirmItemControl?: boolean;
-}
-
-interface IGroupSharingUnsharingRequestOptions
-  extends IGroupSharingRequestOptions {
+interface IGroupSharingUnsharingOptions extends IGroupSharingOptions {
   action: "share" | "unshare";
 }
 
@@ -40,7 +31,7 @@ interface IGroupSharingUnsharingRequestOptions
  * @returns A Promise that will resolve with the data from the response.
  */
 export function shareItemWithGroup(
-  requestOptions: IGroupSharingRequestOptions
+  requestOptions: IGroupSharingOptions
 ): Promise<ISharingResponse> {
   return changeGroupSharing({ action: "share", ...requestOptions });
 }
@@ -62,7 +53,7 @@ export function shareItemWithGroup(
  * @returns A Promise that will resolve with the data from the response.
  */
 export function unshareItemWithGroup(
-  requestOptions: IGroupSharingRequestOptions
+  requestOptions: IGroupSharingOptions
 ): Promise<ISharingResponse> {
   return changeGroupSharing({ action: "unshare", ...requestOptions });
 }
@@ -72,7 +63,7 @@ export function unshareItemWithGroup(
  * @returns A Promise that will resolve with the data from the response.
  */
 function changeGroupSharing(
-  requestOptions: IGroupSharingUnsharingRequestOptions
+  requestOptions: IGroupSharingUnsharingOptions
 ): Promise<ISharingResponse> {
   const username = requestOptions.authentication.username;
   const owner = requestOptions.owner || username;
@@ -167,7 +158,7 @@ function changeGroupSharing(
  * @returns A Promise that will resolve with the data from the response.
  */
 function isItemSharedWithGroup(
-  requestOptions: IGroupSharingRequestOptions
+  requestOptions: IGroupSharingOptions
 ): Promise<boolean> {
   const query = {
     q: `id: ${requestOptions.id} AND group: ${requestOptions.groupId}`,

--- a/packages/arcgis-rest-portal/src/sharing/helpers.ts
+++ b/packages/arcgis-rest-portal/src/sharing/helpers.ts
@@ -1,23 +1,17 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IGroup, IUser, GroupMembership } from "@esri/arcgis-rest-types";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 import { getPortalUrl } from "../util/get-portal-url";
 import { getGroup } from "../groups/get";
-import { IGroupSharingRequestOptions } from "./group-sharing";
 
-export interface ISharingRequestOptions extends IRequestOptions {
+export interface ISharingOptions extends IUserRequestOptions {
   /**
    * Unique identifier for the item.
    */
   id: string;
-  /**
-   * Represents a user with privileges to update item sharing.
-   */
-  authentication: UserSession;
   /**
    * Item owner, if different from the authenticated user.
    */
@@ -30,7 +24,7 @@ export interface ISharingResponse {
   itemId: string;
 }
 
-export function getSharingUrl(requestOptions: ISharingRequestOptions): string {
+export function getSharingUrl(requestOptions: ISharingOptions): string {
   const username = requestOptions.authentication.username;
   const owner = requestOptions.owner || username;
   return `${getPortalUrl(requestOptions)}/content/users/${encodeURIComponent(
@@ -38,7 +32,7 @@ export function getSharingUrl(requestOptions: ISharingRequestOptions): string {
   )}/items/${requestOptions.id}/share`;
 }
 
-export function isItemOwner(requestOptions: ISharingRequestOptions): boolean {
+export function isItemOwner(requestOptions: ISharingOptions): boolean {
   const username = requestOptions.authentication.username;
   const owner = requestOptions.owner || username;
   return owner === username;
@@ -49,9 +43,7 @@ export function isItemOwner(requestOptions: ISharingRequestOptions): boolean {
  * @param requestOptions
  * @returns Promise resolving in a boolean indicating if the user is an ArcGIS Organization administrator
  */
-export function isOrgAdmin(
-  requestOptions: ISharingRequestOptions
-): Promise<boolean> {
+export function isOrgAdmin(requestOptions: ISharingOptions): Promise<boolean> {
   const session = requestOptions.authentication;
 
   return session.getUser(requestOptions).then((user: IUser) => {
@@ -67,11 +59,11 @@ export function isOrgAdmin(
  * Get the User Membership for a particular group. Use this if all you have is the groupId.
  * If you have the group object, check the `userMembership.memberType` property instead of calling this method.
  *
- * @param IGroupIdRequestOptions options to pass through in the request
+ * @param requestOptions
  * @returns A Promise that resolves with "owner" | "admin" | "member" | "nonmember"
  */
 export function getUserMembership(
-  requestOptions: IGroupSharingRequestOptions
+  requestOptions: IGroupSharingOptions
 ): Promise<GroupMembership> {
   // fetch the group...
   return getGroup(requestOptions.groupId, requestOptions)
@@ -81,4 +73,12 @@ export function getUserMembership(
     .catch(() => {
       return "nonmember" as GroupMembership;
     });
+}
+
+export interface IGroupSharingOptions extends ISharingOptions {
+  /**
+   * Group identifier
+   */
+  groupId: string;
+  confirmItemControl?: boolean;
 }

--- a/packages/arcgis-rest-portal/src/users/get-user.ts
+++ b/packages/arcgis-rest-portal/src/users/get-user.ts
@@ -8,7 +8,7 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 
 import { getPortalUrl } from "../util/get-portal-url";
 
-export interface IGetUserRequestOptions extends IRequestOptions {
+export interface IGetUserOptions extends IRequestOptions {
   /**
    * A session representing a logged in user.
    */
@@ -33,10 +33,10 @@ export interface IGetUserRequestOptions extends IRequestOptions {
  * @returns A Promise that will resolve with metadata about the user
  */
 export function getUser(
-  requestOptions?: string | IGetUserRequestOptions
+  requestOptions?: string | IGetUserOptions
 ): Promise<IUser> {
   let url;
-  let options = { httpMethod: "GET" } as IGetUserRequestOptions;
+  let options = { httpMethod: "GET" } as IGetUserOptions;
 
   // if a username is passed, assume ArcGIS Online
   if (typeof requestOptions === "string") {

--- a/packages/arcgis-rest-portal/src/users/invitation.ts
+++ b/packages/arcgis-rest-portal/src/users/invitation.ts
@@ -112,7 +112,12 @@ export function getUserInvitation(
  */
 export function acceptInvitation(
   requestOptions: IGetUserInvitationOptions
-): Promise<any> {
+): Promise<{
+  success: boolean;
+  username: string;
+  groupId: string;
+  id: string;
+}> {
   const username = encodeURIComponent(requestOptions.authentication.username);
   const portalUrl = getPortalUrl(requestOptions);
   const url = `${portalUrl}/community/users/${username}/invitations/${
@@ -140,7 +145,12 @@ export function acceptInvitation(
  */
 export function declineInvitation(
   requestOptions: IGetUserInvitationOptions
-): Promise<any> {
+): Promise<{
+  success: boolean;
+  username: string;
+  groupId: string;
+  id: string;
+}> {
   const username = encodeURIComponent(requestOptions.authentication.username);
   const portalUrl = getPortalUrl(requestOptions);
   const url = `${portalUrl}/community/users/${username}/invitations/${

--- a/packages/arcgis-rest-portal/src/users/invitation.ts
+++ b/packages/arcgis-rest-portal/src/users/invitation.ts
@@ -60,7 +60,7 @@ export function getUserInvitations(
   return request(url, options);
 }
 
-export interface IInvitationRequestOptions extends IUserRequestOptions {
+export interface IGetUserInvitationOptions extends IUserRequestOptions {
   invitationId: string;
 }
 
@@ -80,7 +80,7 @@ export interface IInvitationRequestOptions extends IUserRequestOptions {
  * @returns A Promise that will resolve with the invitation
  */
 export function getUserInvitation(
-  requestOptions: IInvitationRequestOptions
+  requestOptions: IGetUserInvitationOptions
 ): Promise<IInvitation> {
   const username = encodeURIComponent(requestOptions.authentication.username);
   const portalUrl = getPortalUrl(requestOptions);
@@ -88,7 +88,7 @@ export function getUserInvitation(
     requestOptions.invitationId
   }`;
 
-  let options = { httpMethod: "GET" } as IInvitationRequestOptions;
+  let options = { httpMethod: "GET" } as IGetUserInvitationOptions;
   options = { ...requestOptions, ...options };
 
   // send the request
@@ -111,7 +111,7 @@ export function getUserInvitation(
  * @returns A Promise that will resolve with the success/failure status of the request
  */
 export function acceptInvitation(
-  requestOptions: IInvitationRequestOptions
+  requestOptions: IGetUserInvitationOptions
 ): Promise<any> {
   const username = encodeURIComponent(requestOptions.authentication.username);
   const portalUrl = getPortalUrl(requestOptions);
@@ -119,7 +119,7 @@ export function acceptInvitation(
     requestOptions.invitationId
   }/accept`;
 
-  const options: IInvitationRequestOptions = { ...requestOptions };
+  const options: IGetUserInvitationOptions = { ...requestOptions };
   return request(url, options);
 }
 
@@ -139,7 +139,7 @@ export function acceptInvitation(
  * @returns A Promise that will resolve with the success/failure status of the request
  */
 export function declineInvitation(
-  requestOptions: IInvitationRequestOptions
+  requestOptions: IGetUserInvitationOptions
 ): Promise<any> {
   const username = encodeURIComponent(requestOptions.authentication.username);
   const portalUrl = getPortalUrl(requestOptions);
@@ -147,6 +147,6 @@ export function declineInvitation(
     requestOptions.invitationId
   }/decline`;
 
-  const options: IInvitationRequestOptions = { ...requestOptions };
+  const options: IGetUserInvitationOptions = { ...requestOptions };
   return request(url, options);
 }

--- a/packages/arcgis-rest-portal/src/users/notification.ts
+++ b/packages/arcgis-rest-portal/src/users/notification.ts
@@ -59,7 +59,7 @@ export function getUserNotifications(
  */
 export function removeNotification(
   requestOptions: IRemoveNotificationOptions
-): Promise<any> {
+): Promise<{ success: boolean; notificationId: string }> {
   const username = encodeURIComponent(requestOptions.authentication.username);
   const portalUrl = getPortalUrl(requestOptions);
   const url = `${portalUrl}/community/users/${username}/notifications/${

--- a/packages/arcgis-rest-portal/src/users/notification.ts
+++ b/packages/arcgis-rest-portal/src/users/notification.ts
@@ -15,7 +15,7 @@ export interface INotification {
   data: { [key: string]: any };
 }
 
-export interface INotificationIdRequestOptions extends IUserRequestOptions {
+export interface IRemoveNotificationOptions extends IUserRequestOptions {
   /**
    * Unique identifier of the item.
    */
@@ -58,7 +58,7 @@ export function getUserNotifications(
  * @returns A Promise that will resolve with the success/failure status of the request
  */
 export function removeNotification(
-  requestOptions: INotificationIdRequestOptions
+  requestOptions: IRemoveNotificationOptions
 ): Promise<any> {
   const username = encodeURIComponent(requestOptions.authentication.username);
   const portalUrl = getPortalUrl(requestOptions);

--- a/packages/arcgis-rest-portal/src/users/update.ts
+++ b/packages/arcgis-rest-portal/src/users/update.ts
@@ -1,18 +1,14 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, IRequestOptions } from "@esri/arcgis-rest-request";
+import { request } from "@esri/arcgis-rest-request";
 import { IUser } from "@esri/arcgis-rest-types";
 
-import { UserSession } from "@esri/arcgis-rest-auth";
+import { IUserRequestOptions } from "@esri/arcgis-rest-auth";
 
 import { getPortalUrl } from "../util/get-portal-url";
 
-export interface IUpdateUserRequestOptions extends IRequestOptions {
-  /**
-   * A session representing a logged in user.
-   */
-  authentication: UserSession;
+export interface IUpdateUserOptions extends IUserRequestOptions {
   /**
    * The user properties to be updated.
    */
@@ -47,7 +43,7 @@ export interface IUpdateUserResponse {
  * @returns A Promise that will resolve with metadata about the user
  */
 export function updateUser(
-  requestOptions?: IUpdateUserRequestOptions
+  requestOptions?: IUpdateUserOptions
 ): Promise<IUpdateUserResponse> {
   // default to the authenticated username unless another username is provided manually
   const username =

--- a/packages/arcgis-rest-portal/src/util/generic-search.ts
+++ b/packages/arcgis-rest-portal/src/util/generic-search.ts
@@ -10,10 +10,10 @@ import { IItem, IGroup } from "@esri/arcgis-rest-types";
 
 import { SearchQueryBuilder } from "./SearchQueryBuilder";
 import { getPortalUrl } from "../util/get-portal-url";
-import { ISearchRequestOptions, ISearchResult } from "../util/search";
+import { ISearchOptions, ISearchResult } from "../util/search";
 
 export function genericSearch<T extends IItem | IGroup>(
-  search: string | ISearchRequestOptions | SearchQueryBuilder,
+  search: string | ISearchOptions | SearchQueryBuilder,
   searchType: "item" | "group"
 ): Promise<ISearchResult<T>> {
   let url: string;
@@ -26,7 +26,7 @@ export function genericSearch<T extends IItem | IGroup>(
       }
     };
   } else {
-    options = appendCustomParams<ISearchRequestOptions>(
+    options = appendCustomParams<ISearchOptions>(
       search,
       ["q", "num", "start", "sortField", "sortDir", "sortOrder"],
       {
@@ -43,7 +43,7 @@ export function genericSearch<T extends IItem | IGroup>(
   return request(url, options).then(r => {
     if (r.nextStart && r.nextStart !== -1) {
       r.nextPage = function() {
-        let newOptions: ISearchRequestOptions;
+        let newOptions: ISearchOptions;
 
         if (
           typeof search === "string" ||

--- a/packages/arcgis-rest-portal/src/util/search.ts
+++ b/packages/arcgis-rest-portal/src/util/search.ts
@@ -5,7 +5,7 @@ import { IRequestOptions } from "@esri/arcgis-rest-request";
 import { IPagingParams, IItem, IGroup } from "@esri/arcgis-rest-types";
 import { SearchQueryBuilder } from "./SearchQueryBuilder";
 
-export interface ISearchRequestOptions extends IRequestOptions, IPagingParams {
+export interface ISearchOptions extends IRequestOptions, IPagingParams {
   q: string | SearchQueryBuilder;
   sortField?: string;
   sortDir?: string;

--- a/packages/arcgis-rest-portal/test/mocks/items/item.ts
+++ b/packages/arcgis-rest-portal/test/mocks/items/item.ts
@@ -4,7 +4,7 @@
 import { IItem } from "@esri/arcgis-rest-types";
 import {
   IGetRelatedItemsResponse,
-  IItemGroupResponse
+  IGetItemGroupsResponse
 } from "../../../src/items/get";
 
 export const ItemSuccessResponse: any = {
@@ -43,7 +43,7 @@ export const ItemDataResponse: any = {
   }
 };
 
-export const ItemGroupResponse: IItemGroupResponse = {
+export const ItemGroupResponse: IGetItemGroupsResponse = {
   admin: [
     {
       id: "2ecb37a8c8fb4051af9c086c25503bb0",

--- a/packages/arcgis-rest-service-admin/src/create.ts
+++ b/packages/arcgis-rest-service-admin/src/create.ts
@@ -6,7 +6,7 @@ import { IExtent, ISpatialReference } from "@esri/arcgis-rest-types";
 
 import {
   moveItem,
-  IItemCrudRequestOptions,
+  ICreateUpdateItemOptions,
   determineOwner,
   getPortalUrl
 } from "@esri/arcgis-rest-portal";
@@ -85,7 +85,7 @@ export interface ICreateServiceParams {
   };
 }
 
-export interface ICreateServiceOptions extends IItemCrudRequestOptions {
+export interface ICreateServiceOptions extends ICreateUpdateItemOptions {
   /**
    * A JSON object specifying the properties of the newly-created service. See the [REST
    * Documentation](https://developers.arcgis.com/rest/users-groups-and-items/working-with-users-groups-and-items.htm)

--- a/packages/arcgis-rest-service-admin/test/mocks/move.ts
+++ b/packages/arcgis-rest-service-admin/test/mocks/move.ts
@@ -1,9 +1,9 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { IItemMoveResponse } from "@esri/arcgis-rest-portal";
+import { IMoveItemResponse } from "@esri/arcgis-rest-portal";
 
-export const MoveToFolderResponse: IItemMoveResponse = {
+export const MoveToFolderResponse: IMoveItemResponse = {
   folder: "83216cba44bf4357bf06687ec88a847b",
   itemId: "1b1a3c914ef94c49ae55ce223cac5754",
   owner: "casey",


### PR DESCRIPTION
…es to match their functions

AFFECTS PACKAGES:
@esri/arcgis-rest-portal
@esri/arcgis-rest-service-admin

BREAKING CHANGE:
removes "Request" from portal option interfaces & renames response interfaces