### PR TITLE
Fix/handle binary data consistently and deprecate addItemJsonData

### DIFF
--- a/packages/arcgis-rest-portal/src/items/add.ts
+++ b/packages/arcgis-rest-portal/src/items/add.ts
@@ -12,48 +12,13 @@ import {
   determineOwner,
   IManageItemRelationshipOptions
 } from "./helpers";
+import { updateItem, IUpdateItemOptions } from "./update";
 
 export interface IAddItemDataOptions extends IUserItemOptions {
   /**
    * Object to store
    */
   data: any;
-}
-
-/**
- * ```js
- * import { addItemJsonData } from "@esri/arcgis-rest-portal";
- * //
- * addItemJsonData({
- *   id: '3ef',
- *   data: {}
- *   authentication
- * })
- *   .then(response)
- * ```
- * Send json to an item to be stored as the `/data` resource. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/update-item.htm) for more information.
- *
- * @param requestOptions - Options for the request
- * @returns A Promise that will resolve with an object reporting
- *        success/failure and echoing the item id.
- */
-export function addItemJsonData(
-  requestOptions: IAddItemDataOptions
-): Promise<IUpdateItemResponse> {
-  const owner = determineOwner(requestOptions);
-  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
-    requestOptions.id
-  }/update`;
-
-  // Portal API requires that the 'data' be stringified and POSTed in
-  // a `text` form field. It can also be sent with the `.create` call by sending
-  // a `.data` property.
-  requestOptions.params = {
-    text: requestOptions.data,
-    ...requestOptions.params
-  };
-
-  return request(url, requestOptions);
 }
 
 /**
@@ -77,18 +42,18 @@ export function addItemData(
   requestOptions: IAddItemDataOptions
 ): Promise<IUpdateItemResponse> {
   const owner = determineOwner(requestOptions);
-
-  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
-    requestOptions.id
-  }/update`;
-
-  // Portal API requires that the 'data' be POSTed in a `file` form field.
-  requestOptions.params = {
-    file: requestOptions.data,
-    ...requestOptions.params
+  const options: any = {
+    item: {
+      id: requestOptions.id,
+      data: requestOptions.data
+    },
+    ...requestOptions
   };
 
-  return request(url, requestOptions);
+  delete options.id;
+  delete options.data;
+
+  return updateItem(options as IUpdateItemOptions);
 }
 
 /**

--- a/packages/arcgis-rest-portal/src/items/helpers.ts
+++ b/packages/arcgis-rest-portal/src/items/helpers.ts
@@ -165,12 +165,16 @@ export function serializeItem(item: IItemAdd | IItemUpdate | IItem): any {
   // create a clone so we're not messing with the original
   const clone = JSON.parse(JSON.stringify(item));
 
-  // convert .data to .text
+  // binary data needs POSTed as a `file`
+  // JSON object literals should be passed as `text`.
   if (clone.data) {
-    clone.text = clone.data;
+    (typeof Blob !== "undefined" && item.data instanceof Blob) ||
+    // Node.js doesn't implement Blob
+    item.data.constructor.name === "ReadStream"
+      ? (clone.file = item.data)
+      : (clone.text = item.data);
     delete clone.data;
   }
-
   return clone;
 }
 

--- a/packages/arcgis-rest-portal/test/items/add.test.ts
+++ b/packages/arcgis-rest-portal/test/items/add.test.ts
@@ -6,7 +6,6 @@ import * as fetchMock from "fetch-mock";
 import { attachmentFile } from "../../../arcgis-rest-feature-layer/test/attachments.test";
 
 import {
-  addItemJsonData,
   addItemData,
   addItemResource,
   addItemRelationship
@@ -47,8 +46,8 @@ describe("search", () => {
           key: "someValue"
         }
       };
-      // addItemJsonData("3ef", "dbouwman", fakeData, MOCK_REQOPTS)
-      addItemJsonData({
+      // addItemData("3ef", "dbouwman", fakeData, MOCK_REQOPTS)
+      addItemData({
         id: "3ef",
         owner: "dbouwman",
         data: fakeData,
@@ -82,8 +81,8 @@ describe("search", () => {
           key: "someValue"
         }
       };
-      // addItemJsonData("3ef", "dbouwman", fakeData, MOCK_REQOPTS)
-      addItemJsonData({
+      // addItemData("3ef", "dbouwman", fakeData, MOCK_REQOPTS)
+      addItemData({
         id: "3ef",
         data: fakeData,
         ...MOCK_USER_REQOPTS
@@ -116,8 +115,8 @@ describe("search", () => {
           key: "someValue"
         }
       };
-      // addItemJsonData("3ef", "dbouwman", fakeData, MOCK_REQOPTS)
-      addItemJsonData({
+      // addItemData("3ef", "dbouwman", fakeData, MOCK_REQOPTS)
+      addItemData({
         id: "3ef",
         data: fakeData,
         ...MOCK_USER_REQOPTS,
@@ -154,6 +153,7 @@ describe("search", () => {
       const file = attachmentFile();
 
       addItemData({
+        // this would work on item: { type: "Code Sample" }
         id: "3ef",
         // File() is only available in the browser
         data: file,
@@ -167,6 +167,7 @@ describe("search", () => {
           );
           expect(options.method).toBe("POST");
           expect(options.body instanceof FormData).toBeTruthy();
+          // to do: figure out how to inspect these parameters from Node.js
           const params = options.body as FormData;
           if (params.get) {
             expect(params.get("token")).toEqual("fake-token");


### PR DESCRIPTION
i couldn't resist the urge to deprecate `addItemJsonData` and just ensure that `addItemData` handles _both_ JSON object literals and binary files.

when i dug into this, @tomwayson and i realized that there was a bug in `createItem` and `updateItem` that kept _them_ both from passing through binary files appropriately.

this PR:
1. fixes the bug in `createItem` and `updateItem`
2. deprecates `addItemJsonData` and ensures that remaining method (`addItemData`) handles both. keeping things DRY by calling `updateItem` internally.

i promise i'm done now :smile: