### PR TITLE
Doc new methods for v2.0.0

### DIFF
--- a/docs/acetate.config.js
+++ b/docs/acetate.config.js
@@ -252,4 +252,11 @@ module.exports = function(acetate) {
       : [];
     return `npm install ${package.name} ${peers.join(" ")}`;
   });
+
+  acetate.filter("stripThisFromParams", function(params) {
+    if (!params || !params.length) {
+      return [];
+    }
+    return params.filter(p => p.name !== "this");
+  });
 };

--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -23,7 +23,8 @@ const md = new MarkdownIt();
         "--module",
         "common",
         "--tsconfig",
-        "./tsconfig.json"
+        "./tsconfig.json",
+        "--excludePrivate"
       ],
       {
         stdio: "inherit"

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -258,9 +258,17 @@
 {% endmacro %}
 
 {% macro @signatures(signatures) %}
- {% markdown -%}
-    {{ signatures[0].comment.shortText | safe }}
-  {%- endmarkdown %}
+  {%- if signatures[0].comment.shortText -%}
+    {% markdown -%}
+      {{ signatures[0].comment.shortText | safe }}
+    {%- endmarkdown %}
+  {%- endif %}
+
+  {% if signatures[0].comment.text %}
+    {% markdown -%}
+      {{ signatures[0].comment.text | safe }}
+    {%- endmarkdown %}
+  {% endif %}
 
   <div class="panel padding-leader-half padding-trailer-half padding-right-quarter padding-left-half trailer-half">
     <ul class="list-plain tsd-signatures {{icon}} trailer-0 leader-0">
@@ -295,14 +303,6 @@
   <div class="fonts-size--1 panel padding-leader-half padding-trailer-half padding-right-half padding-left-half trailer-half">
   {{@type(signatures[0].type)}}
   </div>
-
-  {% if signatures[0].comment.text %}
-    <hr class="leader-half trailer-half">
-
-    {% markdown -%}
-      {{ signatures[0].comment.text | safe }}
-    {%- endmarkdown %}
-  {% endif %}
 
   {% if (signatures[0].type.name === "Promise" and signatures[0].type.typeArguments[0].type === "reference") %}
     {% set id = API_TOOLS.findByName(data.typedoc, signatures[0].type.typeArguments[0].name).id %}

--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -1,4 +1,4 @@
-{% macro @type(type, isArray) -%}
+{% macro @type(type, isArray, isRest) -%}
   {%- if type.type === 'stringLiteral' -%}
     <span class="text-green">"{{type.value}}"</span>
   {%- endif -%}
@@ -15,6 +15,10 @@
     <i class="no-wrap">{{ @type(type.elementType, true) }}</i>
   {%- elif  type.type === 'array'  -%}
     <i class="no-wrap">{{ @type(type.elementType) }}<span class="text-light-gray">{{ '[]' }}</span></i>
+  {%- endif -%}
+
+  {%- if type.type === 'array'  -%}
+    <span class="text-light-gray">{{ ' | ' }}</span>{{ @type(type.elementType) }}
   {%- endif -%}
 
   {%- if type.type === 'intrinsic' -%}
@@ -81,11 +85,13 @@
 {%- endmacro %}
 
 {% macro @param(param) -%}
-  {{param.name}}: {{@type(param.type)}}
+  {%- if param -%}
+    {{param.name}}: {{@type(param.type, undefined, param.flags.isRest)}}
+  {%- endif -%}
 {%- endmacro %}
 
 {% macro @signatureParams(params) -%}
-  {% for param in params -%}{{ @param(param) }}{{ ', ' if (loop.last === false)}}{%- endfor %}
+  {% for param in params | stripThisFromParams -%}{{ @param(param) }}{{ ', ' if (loop.last === false)}}{%- endfor %}
 {%- endmacro %}
 
 {% macro @signature(signature) -%}
@@ -347,6 +353,7 @@
       </tbody>
     </table>
   </div>
+
   {% for childId in group.children %}
     {% set child = API_TOOLS.findChildById(childId, children) %}
     {% set signatures = child.signatures %}
@@ -380,13 +387,15 @@
         {%- endmarkdown %}
       </div>
 
-      <ul class="list-plain tsd-signatures trailer-half {{signatures[0].icon}}">
-        {% for signature in signatures %}
-          {{ @signature(signature) }}
-        {% endfor %}
-      </ul>
+      <div class="fonts-size--1 panel padding-leader-half padding-trailer-half padding-right-half padding-left-half trailer-half">
+        <ul class="list-plain trailer-0 tsd-signatures trailer-half {{signatures[0].icon}}">
+          {% for signature in signatures %}
+            {{ @signature(signature) }}
+          {% endfor %}
+        </ul>
+      </div>
 
-      {% if signatures[0].parameters %}
+      {% if (signatures[0].parameters | stripThisFromParams).length > 0 %}
         <h2 class="font-size-1 trailer-half">Parameters</h2>
         {{@parametersTable(signatures[0].parameters, signatures[0].name)}}
       {% endif %}
@@ -394,8 +403,12 @@
       <h2 class="font-size-1 trailer-half">Returns</h2>
 
       {%- markdown -%}
-        <code>{{@type(signatures[0].type)}}</code>{{" - " if signatures[0].comment.returns}}{{ signatures[0].comment.returns | safe }}
+        {{ signatures[0].comment.returns | safe }}
       {%- endmarkdown %}
+
+      <div class="fonts-size--1 panel padding-leader-half padding-trailer-half padding-right-half padding-left-half trailer-half">
+      {{@type(signatures[0].type)}}
+      </div>
 
       {% if signatures[0].comment.text %}
         <hr class="leader-half trailer-half">
@@ -425,7 +438,7 @@
         </tr>
       </thead>
       <tbody>
-        {% for param in parameters -%}
+        {% for param in parameters | stripThisFromParams -%}
           <tr id="{{fnName}}-{{param.name}}">
             <td class="code-face">
               <a href="#{{fnName}}-{{param.name}}" class="table-link">
@@ -531,14 +544,16 @@
 
     {% if group.title == 'Constructors' %}
       {% set firstSignature = API_TOOLS.findChildById(group.children[0], children).signatures[0] %}
-      <ul class="list-plain trailer-1 {{ API_TOOLS.findChildById(group.children[0], children).icon }}">
-        {% for id in group.children %}
-          {% set signatures = API_TOOLS.findChildById(id, children).signatures %}
-          {% for signature in signatures %}
-            {{ @signature(signature) }}
+      <div class="fonts-size--1 panel padding-leader-half padding-trailer-half padding-right-half padding-left-half trailer-half">
+        <ul class="list-plain trailer-0 {{ API_TOOLS.findChildById(group.children[0], children).icon }}">
+          {% for id in group.children %}
+            {% set signatures = API_TOOLS.findChildById(id, children).signatures %}
+            {% for signature in signatures %}
+              {{ @signature(signature) }}
+            {% endfor %}
           {% endfor %}
-        {% endfor %}
-      </ul>
+        </ul>
+      </div>
 
       <h2 class="font-size-1">Constructor Parameters</h2>
       {{@parametersTable(firstSignature.parameters, 'Constructor')}}

--- a/docs/src/sass/style.scss
+++ b/docs/src/sass/style.scss
@@ -118,6 +118,7 @@ a > code {
 
 .method-table-signatures {
   margin: 0;
+  padding: 0;
   li {
     margin: 0;
   }
@@ -229,4 +230,13 @@ textarea,
     margin: 0;
     max-width: calc(100% - 1rem);
   }
+}
+
+table p {
+  font-size: 0.875rem;
+}
+
+table pre {
+  margin-bottom: 0;
+  margin-top: 0.5rem;
 }

--- a/packages/arcgis-rest-portal/src/util/SearchQueryBuilder.ts
+++ b/packages/arcgis-rest-portal/src/util/SearchQueryBuilder.ts
@@ -1,6 +1,6 @@
 import { IParamBuilder, warn } from "@esri/arcgis-rest-request";
 /**
- * `SearchQueryBuilder` can be used to constuct the `q` param for [`ISearchRequestOptions`](/arcgis-rest-js/api/portal/ISearchRequestOptions#q), [`searchItems`](/arcgis-rest-js/api/portal/searchItems#searchItems-search) or [`searchGroups`](/arcgis-rest-js/api/portal/searchGroups#searchGroups-search). You can chain methods to build complex search queries.
+ * `SearchQueryBuilder` can be used to construct the `q` param for [`searchItems`](/arcgis-rest-js/api/portal/searchItems#searchItems-search) or [`searchGroups`](/arcgis-rest-js/api/portal/searchGroups#searchGroups-search). By chaining methods, it helps build complex search queries.
  *
  * ```js
  * const query = new SearchQueryBuilder()
@@ -25,7 +25,10 @@ import { IParamBuilder, warn } from "@esri/arcgis-rest-request";
  * });
  * ```
  *
- * Will search for items matching `owner: Patrick AND (type: "Web Mapping Application" OR type: "Mobile Application" OR type: Application) AND Demo App`.
+ * Will search for items matching
+ * ```
+ * "owner: Patrick AND (type: "Web Mapping Application" OR type: "Mobile Application" OR type: Application) AND Demo App"
+ * ```
  */
 export class SearchQueryBuilder implements IParamBuilder {
   private termStack: any[] = [];
@@ -42,7 +45,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   }
 
   /**
-   * Define strings to search for.
+   * Defines strings to search for.
    *
    * ```js
    * const query = new SearchQueryBuilder()
@@ -57,7 +60,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   }
 
   /**
-   * Define fields to search in. You can pass `"*"` or call without argumnets to search a default set of fields
+   * Defines fields to search in. You can pass `"*"` or call this method without arguments to search a default set of fields
    *
    * ```js
    * const query = new SearchQueryBuilder()
@@ -86,7 +89,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   }
 
   /**
-   * Start a new search group.
+   * Starts a new search group.
    *
    * ```js
    * const query = new SearchQueryBuilder()
@@ -112,7 +115,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   }
 
   /**
-   * Ends the previously started search group.
+   * Ends a search group.
    *
    * ```js
    * const query = new SearchQueryBuilder()
@@ -140,7 +143,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   }
 
   /**
-   * Joins 2 sets of queries with and `AND` clause.
+   * Joins two sets of queries with an `AND` clause.
    *
    * ```js
    * const query = new SearchQueryBuilder()
@@ -156,7 +159,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   }
 
   /**
-   * Joins 2 sets of queries with and `OR` clause.
+   * Joins two sets of queries with an `OR` clause.
    *
    * ```js
    * const query = new SearchQueryBuilder()
@@ -172,7 +175,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   }
 
   /**
-   * Joins 2 sets of queries with and `NOT` clause.
+   * Joins two sets of queries with a `NOT` clause.
    *
    * ```js
    * const query = new SearchQueryBuilder()
@@ -232,7 +235,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   }
 
   /**
-   * Boosts the previous term making it rank higher in results.
+   * Boosts the previous term to increase its rank in the results.
    *
    * ```js
    * const query = new SearchQueryBuilder()
@@ -251,7 +254,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   }
 
   /**
-   * Returns the current query string. Called internall when the request is made.
+   * Returns the current query string. Called internally when the request is made.
    */
   public toParam() {
     this.commit();

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -20,17 +20,18 @@ let DEFAULT_ARCGIS_REQUEST_OPTIONS: IRequestOptions = {
 };
 
 /**
- * Sets the default options that will be passed to any request. **THIS AFFECTS EVERY REQUEST ACROSS ALL OF the `@esri/arcgis-rest-*` MODULES**.
+ * Sets the default options that will be passed in **all requests across all `@esri/arcgis-rest-js` modules**.
  *
  *
  * ```js
+ * import { setDefaultRequestOptions } from "@esri/arcgis-rest-request";
  * setDefaultRequestOptions({
  *   authentication: userSession // all requests will use this session by default
  * })
  * ```
- * You should never set a default `authentication` when you are in a server side environment where you may have a single server handling requests for many authenticated users.
+ * You should **never** set a default `authentication` when you are in a server side environment where you may be handling requests for many different authenticated users.
  *
- * @param options The defualt options to pass with every request. Existing default will be overwritten.
+ * @param options The default options to pass with every request. Existing default will be overwritten.
  * @param hideWarnings Silence warnings about setting default `authentication` in shared environments.
  */
 export function setDefaultRequestOptions(

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -19,6 +19,20 @@ let DEFAULT_ARCGIS_REQUEST_OPTIONS: IRequestOptions = {
   }
 };
 
+/**
+ * Sets the default options that will be passed to any request. **THIS AFFECTS EVERY REQUEST ACROSS ALL OF the `@esri/arcgis-rest-*` MODULES**.
+ *
+ *
+ * ```js
+ * setDefaultRequestOptions({
+ *   authentication: userSession // all requests will use this session by default
+ * })
+ * ```
+ * You should never set a default `authentication` when you are in a server side environment where you may have a single server handling requests for many authenticated users.
+ *
+ * @param options The defualt options to pass with every request. Existing default will be overwritten.
+ * @param hideWarnings Silence warnings about setting default `authentication` in shared environments.
+ */
 export function setDefaultRequestOptions(
   options: typeof DEFAULT_ARCGIS_REQUEST_OPTIONS,
   hideWarnings?: boolean

--- a/packages/arcgis-rest-request/src/utils/with-options.ts
+++ b/packages/arcgis-rest-request/src/utils/with-options.ts
@@ -1,5 +1,38 @@
 import { IRequestOptions } from "../utils/IRequestOptions";
 
+/**
+ * `withOptions()` allows you to wrap request methods with a default set of options. This is useful to avoid setting the same option more then once for a particular request method.
+ *
+ * This allows for interacting and setting defaults in a functional manner that can greatly reduce the amount of duplication from passing in options to every request.
+ *
+ * ```js
+ * import { withOptions } from "@esri/arcgis-rest-request";
+ * import { queryFeatures } from '@esri/arcgis-rest-feature-layer'; *
+ *
+ * const queryTrails = withOptions({
+ *   url: "https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0/"}, queryFeatures);
+ *
+ * queryTrails({
+ *   where: "ELEV_FT > 1000"
+ * }).then(result);
+ *
+ * queryTrails({
+ *   where: "PARK_NAME = 'National Parks Service'"
+ * }).then(result);
+ *
+ * const queryTrailsAsUser = withOptions({
+ *   authentication: userSession
+ * }, queryTrails);
+ *
+ * queryTrailsAsUser({
+ *   where: "TRL_NAME LIKE '%backbone%'"
+ * }).then(result);
+ * ```
+ *
+ * @param defaultOptions The options to pass into to the `func`.
+ * @param func Any function that accepts anything extending `IRequestOptions` as its last parameter.
+ * @returns A copy of `func` with the `defaultOptions` passed in as defaults.
+ */
 export function withOptions<
   K extends IRequestOptions,
   T extends (...args: any[]) => any

--- a/packages/arcgis-rest-request/src/utils/with-options.ts
+++ b/packages/arcgis-rest-request/src/utils/with-options.ts
@@ -1,23 +1,17 @@
 import { IRequestOptions } from "../utils/IRequestOptions";
 
 /**
- * `withOptions()` allows you to wrap request methods with a default set of options. This is useful to avoid setting the same option more then once for a particular request method.
- *
- * This allows for interacting and setting defaults in a functional manner that can greatly reduce the amount of duplication from passing in options to every request.
+ * Allows you to wrap individual methods with a default set of request options. This is useful to avoid setting the same option more then once and allows for interacting and setting defaults in a functional manner.
  *
  * ```js
  * import { withOptions } from "@esri/arcgis-rest-request";
- * import { queryFeatures } from '@esri/arcgis-rest-feature-layer'; *
+ * import { queryFeatures } from '@esri/arcgis-rest-feature-layer';
  *
  * const queryTrails = withOptions({
  *   url: "https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0/"}, queryFeatures);
  *
  * queryTrails({
  *   where: "ELEV_FT > 1000"
- * }).then(result);
- *
- * queryTrails({
- *   where: "PARK_NAME = 'National Parks Service'"
  * }).then(result);
  *
  * const queryTrailsAsUser = withOptions({


### PR DESCRIPTION
Covers the remaining REST API items for #518 by documenting `SearchQueryBuilder`, `withOptions()` and `setDefaultRequestOptions()` also:

* excludes private methods and properties from all public doc
* Properly handle the `this` type when rendering
* Handles types like `(IItem | IGroup)[]`
* Better handling of generics when rendering params
* Better handling of rest params `...terms: string[]` now renders as `string[] | string`
* Improve table styling
* Improve function signature rendering for constructor and class methods
