### PR TITLE
refactor: props on feature-layer crud responses arent optional

### DIFF
--- a/packages/arcgis-rest-feature-layer/src/add.ts
+++ b/packages/arcgis-rest-feature-layer/src/add.ts
@@ -42,7 +42,7 @@ export interface IAddFeaturesOptions extends ISharedEditOptions {
  */
 export function addFeatures(
   requestOptions: IAddFeaturesOptions
-): Promise<{ addResults?: IEditFeatureResult[] }> {
+): Promise<{ addResults: IEditFeatureResult[] }> {
   const url = `${cleanUrl(requestOptions.url)}/addFeatures`;
 
   // edit operations are POST only

--- a/packages/arcgis-rest-feature-layer/src/delete.ts
+++ b/packages/arcgis-rest-feature-layer/src/delete.ts
@@ -41,7 +41,7 @@ export interface IDeleteFeaturesOptions
  */
 export function deleteFeatures(
   requestOptions: IDeleteFeaturesOptions
-): Promise<{ deleteResults?: IEditFeatureResult[] }> {
+): Promise<{ deleteResults: IEditFeatureResult[] }> {
   const url = `${cleanUrl(requestOptions.url)}/deleteFeatures`;
 
   // edit operations POST only

--- a/packages/arcgis-rest-feature-layer/src/index.ts
+++ b/packages/arcgis-rest-feature-layer/src/index.ts
@@ -12,6 +12,7 @@ export * from "./deleteAttachments";
 export * from "./queryRelated";
 export * from "./getLayer";
 export * from "./decodeValues";
+export * from "./helpers";
 export {
   IFeature,
   ISpatialReference,

--- a/packages/arcgis-rest-feature-layer/src/update.ts
+++ b/packages/arcgis-rest-feature-layer/src/update.ts
@@ -42,7 +42,7 @@ export interface IUpdateFeaturesOptions extends ISharedEditOptions {
  */
 export function updateFeatures(
   requestOptions: IUpdateFeaturesOptions
-): Promise<{ updateResults?: IEditFeatureResult[] }> {
+): Promise<{ updateResults: IEditFeatureResult[] }> {
   const url = `${cleanUrl(requestOptions.url)}/updateFeatures`;
 
   // edit operations are POST only


### PR DESCRIPTION
needed for https://github.com/Esri/hub.js/pull/156

AFFECTS PACKAGES:
@esri/arcgis-rest-feature-layer