### PR TITLE
Fixed Markdown links

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -39,7 +39,8 @@ interface IDeferred<T> {
 export type AuthenticationProvider = "arcgis" | "facebook" | "google";
 
 /**
- * Represents a [credential]((https://developers.arcgis.com/javascript/latest/api-reference/esri-identity-Credential.html)) object used to access a secure ArcGIS resource.
+ * Represents a [credential](https://developers.arcgis.com/javascript/latest/api-reference/esri-identity-Credential.html)
+ * object used to access a secure ArcGIS resource.
  */
 export interface ICredential {
   expires: number;

--- a/packages/arcgis-rest-portal/src/sharing/group-sharing.ts
+++ b/packages/arcgis-rest-portal/src/sharing/group-sharing.ts
@@ -25,7 +25,10 @@ interface IGroupSharingUnsharingOptions extends IGroupSharingOptions {
  *   authentication
  * })
  * ```
- * Share an item with a group, either as an [item owner](https://developers.arcgis.com/rest/users-groups-and-items/share-item-as-item-owner-.htm), [group admin]((https://developers.arcgis.com/rest/users-groups-and-items/share-item-as-group-admin-.htm)) or organization admin.
+ * Share an item with a group, either as an
+ * [item owner](https://developers.arcgis.com/rest/users-groups-and-items/share-item-as-item-owner-.htm),
+ * [group admin](https://developers.arcgis.com/rest/users-groups-and-items/share-item-as-group-admin-.htm) or
+ * organization admin.
  *
  * @param requestOptions - Options for the request.
  * @returns A Promise that will resolve with the data from the response.
@@ -37,7 +40,10 @@ export function shareItemWithGroup(
 }
 
 /**
- * Stop sharing an item with a group, either as an [item owner](https://developers.arcgis.com/rest/users-groups-and-items/unshare-item-as-item-owner-.htm), [group admin]((https://developers.arcgis.com/rest/users-groups-and-items/unshare-item-as-group-admin-.htm)) or organization admin.
+ * Stop sharing an item with a group, either as an
+ * [item owner](https://developers.arcgis.com/rest/users-groups-and-items/unshare-item-as-item-owner-.htm),
+ * [group admin](https://developers.arcgis.com/rest/users-groups-and-items/unshare-item-as-group-admin-.htm) or
+ * organization admin.
  *
  * ```js
  * import { unshareItemWithGroup } from '@esri/arcgis-rest-portal';


### PR DESCRIPTION
[ICredential](https://esri.github.io/arcgis-rest-js/api/auth/ICredential/)'s "credential" link in "Represents a credential object used to access a secure ArcGIS resource."

[shareItemWithGroup](https://esri.github.io/arcgis-rest-js/api/portal/shareItemWithGroup/)'s "group admin" link in "Share an item with a group, either as an item owner, group admin or organization admin."

[unshareItemWithGroupFunction](https://esri.github.io/arcgis-rest-js/api/portal/unshareItemWithGroup/)'s "group admin" link in "Stop sharing an item with a group, either as an item owner, group admin or organization admin."

