### PR TITLE
fix: default to GET when fetching attachments

### DIFF
--- a/packages/arcgis-rest-feature-layer/src/getAttachments.ts
+++ b/packages/arcgis-rest-feature-layer/src/getAttachments.ts
@@ -42,9 +42,14 @@ export interface IAttachmentInfo {
 export function getAttachments(
   requestOptions: IGetAttachmentsOptions
 ): Promise<{ attachmentInfos: IAttachmentInfo[] }> {
+  const options: IGetAttachmentsOptions = {
+    httpMethod: "GET",
+    ...requestOptions
+  };
+
   // pass through
   return request(
-    `${cleanUrl(requestOptions.url)}/${requestOptions.featureId}/attachments`,
-    requestOptions
+    `${cleanUrl(options.url)}/${options.featureId}/attachments`,
+    options
   );
 }

--- a/packages/arcgis-rest-feature-layer/test/attachments.test.ts
+++ b/packages/arcgis-rest-feature-layer/test/attachments.test.ts
@@ -45,8 +45,7 @@ describe("attachment methods", () => {
       featureId: 42,
       params: {
         gdbVersion: "SDE.DEFAULT"
-      },
-      httpMethod: "GET"
+      }
     } as IGetAttachmentsOptions;
     fetchMock.once("*", getAttachmentsResponse);
     getAttachments(requestOptions)


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-feature-layer