### PR TITLE
Force federation accross different ArcGIS Online environments

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -66,6 +66,13 @@ function defer<T>(): IDeferred<T> {
 }
 
 /**
+ *
+ */
+const arcgisOnlineUrlRegex = /^https?:\/\/\S+\.arcgis\.com.+/;
+const arcgisOnlinePortalRegex = /^https?:\/\/www\.arcgis\.com\/sharing\/rest+/;
+const arcgisOnlineOrgPortalRegex = /^https?:\/\/(?:[a-z0-9-]+\.maps)?.\arcgis\.com\/sharing\/rest/;
+
+/**
  * Options for static OAuth 2.0 helper methods on `UserSession`.
  */
 export interface IOAuth2Options {
@@ -709,8 +716,9 @@ export class UserSession implements IAuthenticationManager {
    */
   public getToken(url: string, requestOptions?: ITokenRequestOptions) {
     if (
-      /^https?:\/\/\S+\.arcgis\.com\/sharing\/rest/.test(this.portal) &&
-      /^https?:\/\/\S+\.arcgis\.com.+/.test(url)
+      (arcgisOnlinePortalRegex.test(this.portal) ||
+        arcgisOnlineOrgPortalRegex.test(this.portal)) &&
+      arcgisOnlineUrlRegex.test(url)
     ) {
       return this.getFreshToken(requestOptions);
     } else if (new RegExp(this.portal, "i").test(url)) {

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -71,7 +71,7 @@ function defer<T>(): IDeferred<T> {
 const arcgisOnlineUrlRegex = /^https?:\/\/\S+\.arcgis\.com.+/;
 
 /**
- * Used to test if a URL is an ArcGIS Online Portal
+ * Used to test if a URL is production ArcGIS Online Portal
  */
 const arcgisOnlinePortalRegex = /^https?:\/\/www\.arcgis\.com\/sharing\/rest+/;
 

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -66,10 +66,18 @@ function defer<T>(): IDeferred<T> {
 }
 
 /**
- *
+ * Used to test if a URL is an ArcGIS Online URL
  */
 const arcgisOnlineUrlRegex = /^https?:\/\/\S+\.arcgis\.com.+/;
+
+/**
+ * Used to test if a URL is an ArcGIS Online Portal
+ */
 const arcgisOnlinePortalRegex = /^https?:\/\/www\.arcgis\.com\/sharing\/rest+/;
+
+/**
+ * Used to test if a URL is an ArcGIS Online Organization Portal
+ */
 const arcgisOnlineOrgPortalRegex = /^https?:\/\/(?:[a-z0-9-]+\.maps)?.\arcgis\.com\/sharing\/rest/;
 
 /**


### PR DESCRIPTION
This PR extends the logic that @jgravois added in #560 to other ArcGIS Online environments. This is a requirement for us on the Vector Tile Style Editor since we want to be able to edit vector tile styles from other ArcGIS Online environments (like production) when ArcGIS REST JS is used the internal Esri dev environments.

This does this by tweaking the RegEx used to determine if we should short cut federation or not.

Prior to this PR this is how it worked:

1. Check if both the portal and the requested URL were both `*.arcgis.com`
2. Since both the internal environment and production environment are both `*.arcgis.com` short cut federation
3. The token from the internal environment was sent to the production server causing an error.
4. Since the error didn't occur in `UserSession.getTokenForServer()` no check for a public service happened.

With the PR the following will now happen in this case: 

1. Check if both the portal is the production ArcGIS Online portal (it isn't) and the requested URL were both `*.arcgis.com`
2. Do federation as normal
3. Federation will fail but the check to see if the service is publicly accessible will happen so the request will now succeed.

This means that code like the following will work.

```js
const { UserSession } = require("@esri/arcgis-rest-auth");
const { request } = require("@esri/arcgis-rest-request");

const session = new UserSession({
  portal: "INTERNAL DEVELOPMENT URL",
  token: "xyz",
  tokenExpires: new Date("March 2020")
});

request(
  "A PRODUCTION URL",
  {
    authentication: session
  }
).then(r => {
  console.log(r);
});
```