### PR TITLE
Improve discovery of server root when url is for "services" endpoint.

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -781,7 +781,7 @@ export class UserSession implements IAuthenticationManager {
    * @param url the URl to determine the root url for.
    */
   public getServerRootUrl(url: string) {
-    const [root] = url.split(/\/rest(\/admin)?\/services\//);
+    const [root] = url.split(/\/rest(\/admin)?\/services(?:\/|#|\?|$)/);
     const [match, protocol, domainAndPath] = root.match(/(https?:\/\/)(.+)/);
     const [domain, ...path] = domainAndPath.split("/");
 


### PR DESCRIPTION
Previously it required a slash at the end. Now it works with pound,
question mark and end of string.