### PR TITLE
fix(portal): searchGroupUsers will now respect additional parameters

### DIFF
--- a/packages/arcgis-rest-portal/src/groups/get.ts
+++ b/packages/arcgis-rest-portal/src/groups/get.ts
@@ -107,6 +107,8 @@ export interface ISearchGroupUsersOptions
   name?: string;
   sortField?: string;
   sortOrder?: string;
+  joined?: number | number[];
+  memberType?: string;
   [key: string]: any;
 }
 
@@ -139,7 +141,7 @@ export function searchGroupUsers(
   const url = `${getPortalUrl(searchOptions)}/community/groups/${id}/userlist`;
   const options = appendCustomParams<ISearchGroupUsersOptions>(
     searchOptions,
-    ["name", "num", "start", "sortField", "sortOrder"],
+    ["name", "num", "start", "sortField", "sortOrder", "joined", "memberType"],
     {
       httpMethod: "GET"
     }

--- a/packages/arcgis-rest-portal/test/groups/get.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/get.test.ts
@@ -113,7 +113,9 @@ describe("groups", () => {
           sortField: "fullname",
           sortOrder: "asc",
           num: 2,
-          start: 2
+          start: 2,
+          joined: [null, 123456],
+          memberType: "member"
         },
         ...MOCK_REQOPTS
       })
@@ -121,7 +123,7 @@ describe("groups", () => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(
-            "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/userlist?f=json&name=jupe&sortField=fullname&sortOrder=asc&num=2&start=2&token=fake-token"
+            "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/userlist?f=json&name=jupe&sortField=fullname&sortOrder=asc&num=2&start=2&joined=%2C123456&memberType=member&token=fake-token"
           );
           expect(options.method).toBe("GET");
           done();


### PR DESCRIPTION
Now respects:
- `joined`
- `memberType`

AFFECTS PACKAGES:
@esri/arcgis-rest-portal