### PR TITLE
fix(geocode): ensure the magicKey property is passed through.

### DIFF
--- a/packages/arcgis-rest-geocoding/src/geocode.ts
+++ b/packages/arcgis-rest-geocoding/src/geocode.ts
@@ -102,7 +102,8 @@ export function geocode(
         "region",
         "postal",
         "postalExt",
-        "countryCode"
+        "countryCode",
+        "magicKey"
       ],
       { params: { ...address.params } }
     );


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-geocoding

ISSUES CLOSED: #601