### PR TITLE
Ignore trailing slashes in server url

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -787,7 +787,7 @@ export class UserSession implements IAuthenticationManager {
    * @param url the URl to determine the root url for.
    */
   public getServerRootUrl(url: string) {
-    const [root] = url.split(/\/rest(\/admin)?\/services(?:\/|#|\?|$)/);
+    const [root] = cleanUrl(url).split(/\/rest(\/admin)?\/services(?:\/|#|\?|$)/);
     const [match, protocol, domainAndPath] = root.match(/(https?:\/\/)(.+)/);
     const [domain, ...path] = domainAndPath.split("/");
 


### PR DESCRIPTION
Prevent issues with authenticating with standalone server url's that contain trailing slashes

https://github.com/Esri/arcgis-rest-js/issues/604