### PR TITLE
fix(portal): setting item access to public shares correctly

### DIFF
--- a/packages/arcgis-rest-portal/src/sharing/access.ts
+++ b/packages/arcgis-rest-portal/src/sharing/access.ts
@@ -77,7 +77,9 @@ function updateItemAccess(
   }
   // if sharing with everyone, share with the entire organization as well.
   if (requestOptions.access === "public") {
-    requestOptions.params.org = true;
+    // this is how the ArcGIS Online Home app sets public access
+    // setting org = true instead of account = true will cancel out all sharing
+    requestOptions.params.account = true;
     requestOptions.params.everyone = true;
   }
   return request(url, requestOptions);

--- a/packages/arcgis-rest-portal/test/sharing/access.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/access.test.ts
@@ -47,7 +47,7 @@ describe("setItemAccess()", () => {
         expect(response).toEqual(SharingResponse);
         expect(options.body).toContain("f=json");
         expect(options.body).toContain("everyone=true");
-        expect(options.body).toContain("org=true");
+        expect(options.body).toContain("account=true");
         done();
       })
       .catch(e => {


### PR DESCRIPTION
Currently whe sharing a item w/ access public, the library requests `everyone=true&org=true`. Unfortunately, these appear to cancel each other out and the item is not shared at all. The ArcGIS Onlie Home app sets account=true and everyone=true when sharing publicly. This PR follows suit with the Home App.