### PR TITLE
Add missing param to interface

### DIFF
--- a/packages/arcgis-rest-portal/src/items/update.ts
+++ b/packages/arcgis-rest-portal/src/items/update.ts
@@ -16,7 +16,15 @@ import {
 } from "./helpers";
 
 export interface IUpdateItemOptions extends ICreateUpdateItemOptions {
+  /**
+   * Portions of item to update; contents are serialized before being sent
+   */
   item: IItemUpdate;
+  /**
+   * Additional content to merge into parameters; in particular, useful for content that you don't
+   * want to serialize (e.g., blobs such as an item's thumbnail or metadata)
+   */
+  params?: any;
 }
 
 export interface IMoveItemOptions extends ICreateUpdateItemOptions {


### PR DESCRIPTION
The `updateItem` function in `arcgis-rest-portal` has a single argument of type `IUpdateItemOptions`. This type does not include the optional property `params`; however, that property is accepted by the function
```js
export function updateItem(
  requestOptions: IUpdateItemOptions
): Promise<IUpdateItemResponse> {
  const owner = determineOwner(requestOptions);
  const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
    requestOptions.item.id
  }/update`;

  // serialize the item into something Portal will accept
  requestOptions.params = {
    ...requestOptions.params,
    ...serializeItem(requestOptions.item)
  };

  return request(url, requestOptions);
}
```
and is used in the package's tests
```js
it("should update an item with custom params", done => {
    :           :           :
  updateItem({
    item: fakeItem,
    authentication: MOCK_USER_SESSION,
    params: {
      clearEmptyFields: true
    }
  })
    .then(response => {
      :           :           :
    });
});
```

The absence of this property in `IUpdateItemOptions` can cause a type error in callers that use the property.