### PR TITLE
Export getService for arcgis-rest-feature-layer

### DIFF
--- a/packages/arcgis-rest-feature-layer/src/index.ts
+++ b/packages/arcgis-rest-feature-layer/src/index.ts
@@ -11,6 +11,7 @@ export * from "./updateAttachment";
 export * from "./deleteAttachments";
 export * from "./queryRelated";
 export * from "./getLayer";
+export * from "./getService";
 export * from "./decodeValues";
 export * from "./helpers";
 export {


### PR DESCRIPTION
Looks like this got forgotten in PR #607 

AFFECTS PACKAGES:
@esri/arcgis-rest-feature-layer