### PR TITLE
aggs counts should be an array

### DIFF
--- a/packages/arcgis-rest-portal/src/util/search.ts
+++ b/packages/arcgis-rest-portal/src/util/search.ts
@@ -27,12 +27,12 @@ export interface ISearchResult<T extends IItem | IGroup | IUser> {
    * Aggregations will only be present on item searches when [`fieldCounts`](https://developers.arcgis.com/rest/users-groups-and-items/search.htm#GUID-1C625F8A-4A12-45BB-B537-74C82315759A) are requested.
    */
   aggregations?: {
-    counts: Array<{
+    counts: {
       fieldName: string;
       fieldValues: Array<{
         value: any;
         count: number;
       }>;
-    }>;
+    };
   };
 }

--- a/packages/arcgis-rest-portal/src/util/search.ts
+++ b/packages/arcgis-rest-portal/src/util/search.ts
@@ -27,12 +27,12 @@ export interface ISearchResult<T extends IItem | IGroup | IUser> {
    * Aggregations will only be present on item searches when [`fieldCounts`](https://developers.arcgis.com/rest/users-groups-and-items/search.htm#GUID-1C625F8A-4A12-45BB-B537-74C82315759A) are requested.
    */
   aggregations?: {
-    counts: {
+    counts: Array<{
       fieldName: string;
       fieldValues: Array<{
         value: any;
         count: number;
       }>;
-    };
+    }>;
   };
 }


### PR DESCRIPTION
Per AGO documentation, `aggregations.counts` is an array of objects
https://developers.arcgis.com/rest/users-groups-and-items/search.htm#GUID-1C625F8A-4A12-45BB-B537-74C82315759A