### PR TITLE
Add Portal getSubscriptionInfo fn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5205,7 +5205,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5229,13 +5230,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5252,19 +5255,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5395,7 +5401,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5409,6 +5416,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5425,6 +5433,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5433,13 +5442,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5460,6 +5471,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5548,7 +5560,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5562,6 +5575,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5657,7 +5671,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5699,6 +5714,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5720,6 +5736,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5768,13 +5785,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/arcgis-rest-portal/src/util/get-subscription-info.ts
+++ b/packages/arcgis-rest-portal/src/util/get-subscription-info.ts
@@ -1,0 +1,43 @@
+/* Copyright (c) 2017-2019 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { request, IRequestOptions } from "@esri/arcgis-rest-request";
+
+import { getPortalUrl } from "./get-portal-url";
+
+export interface ISubscriptionInfo {
+  id: string;
+  [key: string]: any;
+}
+
+/**
+ * ```js
+ * import { getSubscriptionInfo } from "@esri/arcgis-rest-request";
+ * //
+ * getSubscriptionInfo()
+ * getSubscriptionInfo("fe8")
+ * getSubscriptionInfo(null, { portal: "https://custom.maps.arcgis.com/sharing/rest/" })
+ * ```
+ * Fetch subscription information about the current portal by id. If no id is passed, portals/self/subscriptionInfo will be called
+ * @param id
+ * @param requestOptions
+ */
+export function getSubscriptionInfo(
+  id?: string,
+  requestOptions?: IRequestOptions
+): Promise<ISubscriptionInfo> {
+  // construct the search url
+  const idOrSelf = id ? id : "self";
+  const url = `${getPortalUrl(
+    requestOptions
+  )}/portals/${idOrSelf}/subscriptionInfo`;
+
+  // default to a GET request
+  const options: IRequestOptions = {
+    ...{ httpMethod: "GET" },
+    ...requestOptions
+  };
+
+  // send the request
+  return request(url, options);
+}

--- a/packages/arcgis-rest-portal/test/mocks/portal/response.ts
+++ b/packages/arcgis-rest-portal/test/mocks/portal/response.ts
@@ -2,6 +2,7 @@
  * Apache-2.0 */
 
 import { IPortal } from "../../../src/util/get-portal";
+import { ISubscriptionInfo } from "../../../src/util/get-subscription-info";
 
 export const PortalResponse: IPortal = {
   access: "public",
@@ -109,4 +110,17 @@ export const PortalResponse: IPortal = {
   mfaEnabled: false,
   user: {},
   appInfo: {}
+};
+
+export const SubscriptionInfoResponse: ISubscriptionInfo = {
+  id: "LjjARY1mkhxulWPq",
+  type: "In House",
+  state: "active",
+  expDate: 1591253999000,
+  userLicenseTypes: {},
+  maxUsersPerLevel: {},
+  maxUsers: 60,
+  availableCredits: 9999.99,
+  collaborationSettings: {},
+  orgCapabilities: []
 };

--- a/packages/arcgis-rest-portal/test/util/portal.test.ts
+++ b/packages/arcgis-rest-portal/test/util/portal.test.ts
@@ -2,8 +2,12 @@
  * Apache-2.0 */
 
 import { getSelf, getPortal } from "../../src/util/get-portal";
+import { getSubscriptionInfo } from "../../src/util/get-subscription-info";
 
-import { PortalResponse } from "./../mocks/portal/response";
+import {
+  PortalResponse,
+  SubscriptionInfoResponse
+} from "./../mocks/portal/response";
 
 import * as fetchMock from "fetch-mock";
 
@@ -85,6 +89,53 @@ describe("portal", () => {
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/portals/self?f=json&token=fake-token"
+          );
+          expect(options.method).toBe("GET");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+  });
+
+  describe("getSubscriptionInfo", () => {
+    // setup an authmgr to use in all these tests
+    const MOCK_AUTH = {
+      getToken() {
+        return Promise.resolve("fake-token");
+      },
+      portal: "https://myorg.maps.arcgis.com/sharing/rest"
+    };
+    const MOCK_REQOPTS = {
+      authentication: MOCK_AUTH
+    };
+
+    it("should get the portal subscriptionInfo by id", done => {
+      fetchMock.once("*", SubscriptionInfoResponse);
+      getSubscriptionInfo("5BZFaKe", MOCK_REQOPTS)
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/portals/5BZFaKe/subscriptionInfo?f=json&token=fake-token"
+          );
+          expect(options.method).toBe("GET");
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
+    it("should get the portal self subscriptionInfo if no id", done => {
+      fetchMock.once("*", SubscriptionInfoResponse);
+      getSubscriptionInfo(null, MOCK_REQOPTS)
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/portals/self/subscriptionInfo?f=json&token=fake-token"
           );
           expect(options.method).toBe("GET");
           done();


### PR DESCRIPTION
Added a Portal `getSubscriptionInfo` method -- essentially the same thing as `getPortal` or `getSelf` but with `/subscriptionInfo` appended to the URL. Needed to access certain properties only available from this endpoint.