### PR TITLE
fix(sharing): correct the item sharing logic to reflect what the api allows

### DIFF
--- a/packages/arcgis-rest-portal/src/sharing/group-sharing.ts
+++ b/packages/arcgis-rest-portal/src/sharing/group-sharing.ts
@@ -103,14 +103,30 @@ function changeGroupSharing(
                 `This item can not be ${requestOptions.action}d by ${username} as they are not a member of the specified group ${requestOptions.groupId}.`
               );
             } else {
-              // they are some level of member or org-admin
-              // but only item owners can share/unshare items w/ shared editing groups
-              if (isSharedEditingGroup && itemOwner !== username) {
-                throw Error(
-                  `This item can not be ${requestOptions.action}d to shared editing group ${requestOptions.groupId} by ${username} as they not the item owner.`
-                );
+              // ...they are some level of membership or org-admin
+
+              // if the current user does not own the item, we had more checks...
+              if (itemOwner !== username) {
+                // only item owners can share/unshare items w/ shared editing groups
+                if (isSharedEditingGroup) {
+                  throw Error(
+                    `This item can not be ${requestOptions.action}d to shared editing group ${requestOptions.groupId} by ${username} as they not the item owner.`
+                  );
+                }
+                // only item-owners, group-admin's, group-owners can unshare an item from a normal group
+                if (
+                  requestOptions.action === "unshare" &&
+                  membership !== "admin" &&
+                  membership !== "owner"
+                ) {
+                  throw Error(
+                    `This item can not be ${requestOptions.action}d from group ${requestOptions.groupId} by ${username} as they not the item owner, group admin or group owner.`
+                  );
+                }
               }
-              // at this point, the user should be able to share the item to the group
+
+              // at this point, the user *should* be able to take the action
+
               // only question is what url to use
 
               // default to the non-owner url...

--- a/packages/arcgis-rest-portal/src/sharing/helpers.ts
+++ b/packages/arcgis-rest-portal/src/sharing/helpers.ts
@@ -71,7 +71,7 @@ export function getUserMembership(
       return group.userMembership.memberType;
     })
     .catch(() => {
-      return "nonmember" as GroupMembership;
+      return "none" as GroupMembership;
     });
 }
 

--- a/packages/arcgis-rest-portal/test/mocks/items/item.ts
+++ b/packages/arcgis-rest-portal/test/mocks/items/item.ts
@@ -113,7 +113,7 @@ export const ItemGroupResponse: IGetItemGroupsResponse = {
       access: "public",
       userMembership: {
         username: "jsmith",
-        memberType: "nonmember"
+        memberType: "none"
       },
       isFav: false,
       autoJoin: false,

--- a/packages/arcgis-rest-portal/test/mocks/users/user.ts
+++ b/packages/arcgis-rest-portal/test/mocks/users/user.ts
@@ -97,7 +97,7 @@ export const GroupNonMemberUserResponse: IUser = {
       access: "org",
       userMembership: {
         username: "jsmith",
-        memberType: "member",
+        memberType: "none",
         applications: 0
       },
       protected: false,

--- a/packages/arcgis-rest-portal/test/sharing/group-sharing.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/group-sharing.test.ts
@@ -94,7 +94,7 @@ describe("shareItemWithGroup() ::", () => {
     fetchMock.post("https://myorg.maps.arcgis.com/sharing/rest/generateToken", {
       token: "fake-token",
       expires: TOMORROW.getTime(),
-      username: " jsmith"
+      username: "jsmith"
     });
 
     // make sure session doesnt cache metadata
@@ -210,7 +210,6 @@ describe("shareItemWithGroup() ::", () => {
       "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
       SharingResponse
     );
-
     shareItemWithGroup({
       authentication: MOCK_USER_SESSION,
       id: "n3v",
@@ -238,7 +237,7 @@ describe("shareItemWithGroup() ::", () => {
       });
   });
 
-  it("should share an item with a group by org administrator and pass through confirmItemControl", done => {
+  it("should fail share an item with a group by org administrator and pass through confirmItemControl", done => {
     fetchMock.once(
       "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
       OrgAdminUserResponse
@@ -255,38 +254,21 @@ describe("shareItemWithGroup() ::", () => {
       GroupOwnerResponse
     );
 
-    fetchMock.once(
-      "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
-      SharingResponse
-    );
-
     shareItemWithGroup({
       authentication: MOCK_USER_SESSION,
       id: "n3v",
       groupId: "t6b",
       owner: "casey",
       confirmItemControl: true
-    })
-      .then(response => {
-        expect(fetchMock.done()).toBeTruthy(
-          "All fetchMocks should have been called"
-        );
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
-        );
-        expect(url).toBe(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
-        );
-        expect(options.method).toBe("POST");
-        expect(response).toEqual(SharingResponse);
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain("groups=t6b");
-        expect(options.body).toContain("confirmItemControl=true");
-        done();
-      })
-      .catch(e => {
-        fail(e);
-      });
+    }).catch(e => {
+      expect(fetchMock.done()).toBeTruthy(
+        "All fetchMocks should have been called"
+      );
+      expect(e.message).toBe(
+        "This item can not be shared to shared editing group t6b by jsmith as they not the item owner."
+      );
+      done();
+    });
   });
 
   it("should share an item with a group by group owner/admin", done => {
@@ -370,7 +352,56 @@ describe("shareItemWithGroup() ::", () => {
       });
   });
 
-  it("should throw if the person trying to share doesnt own the item, is not an admin or member of said group", done => {
+  it("should allow group owner/admin/member to share item they do not own", done => {
+    fetchMock.once(
+      "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
+      GroupMemberUserResponse
+    );
+
+    fetchMock.once(
+      "https://myorg.maps.arcgis.com/sharing/rest/search",
+      SearchResponse
+    );
+
+    // called when we determine if the user is a member of the group
+    fetchMock.get(
+      "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b?f=json&token=fake-token",
+      GroupMemberResponse
+    );
+
+    fetchMock.once(
+      "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+      SharingResponse
+    );
+
+    shareItemWithGroup({
+      authentication: MOCK_USER_SESSION,
+      id: "n3v",
+      groupId: "t6b",
+      owner: "casey"
+    })
+      .then(response => {
+        expect(fetchMock.done()).toBeTruthy(
+          "All fetchMocks should have been called"
+        );
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+        );
+        expect(url).toBe(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+        );
+        expect(options.method).toBe("POST");
+        expect(response).toEqual(SharingResponse);
+        expect(options.body).toContain("f=json");
+        expect(options.body).toContain("groups=t6b");
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
+  it("should throw is non-owner tries to share to shared editing group", done => {
     fetchMock.once(
       "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
       GroupMemberUserResponse
@@ -391,13 +422,14 @@ describe("shareItemWithGroup() ::", () => {
       authentication: MOCK_USER_SESSION,
       id: "n3v",
       groupId: "t6b",
-      owner: "casey"
+      owner: "casey",
+      confirmItemControl: true
     }).catch(e => {
       expect(fetchMock.done()).toBeTruthy(
         "All fetchMocks should have been called"
       );
       expect(e.message).toContain(
-        "This item can not be shared by jsmith as they are neither the owner, a groupAdmin of t6b, nor an org_admin."
+        "This item can not be shared to shared editing group t6b by jsmith as they not the item owner."
       );
       done();
     });

--- a/packages/arcgis-rest-portal/test/sharing/helpers.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/helpers.test.ts
@@ -24,7 +24,7 @@ describe("sharing helpers ::", () => {
       })
         .then(result => {
           expect(fetchMock.done()).toBeTruthy();
-          expect(result).toBe("nonmember", "should return nonmember");
+          expect(result).toBe("none", "should return none");
           done();
         })
         .catch(e => {

--- a/packages/arcgis-rest-types/src/group.ts
+++ b/packages/arcgis-rest-types/src/group.ts
@@ -8,7 +8,7 @@
  * import { GroupMembership } from "@esri/arcgis-rest-portal";
  * ```
  */
-export type GroupMembership = "owner" | "admin" | "member" | "nonmember";
+export type GroupMembership = "owner" | "admin" | "member" | "none";
 
 /**
  * A [Group](https://developers.arcgis.com/rest/users-groups-and-items/common-parameters.htm) that has not been created yet.


### PR DESCRIPTION
- Correct groupMembership enum to include the actual non-member value of 'none'
- Update sharing so that only owners can share/unshare items from shared edit groups
- Update sharing so that item owners can unshare items from groups they are members of
- Update sharing so group owners, group admins, can unshare items they don't own from groups they belong to


AFFECTS PACKAGES:
@esri/arcgis-rest-portal
@esri/arcgis-rest-types