### PR TITLE
Add percentile related properties

### DIFF
--- a/packages/arcgis-rest-feature-layer/src/query.ts
+++ b/packages/arcgis-rest-feature-layer/src/query.ts
@@ -29,9 +29,25 @@ export interface IGetFeatureOptions extends IGetLayerOptions {
 
 export interface IStatisticDefinition {
   /**
-   * Statistical operation to perform (count, sum, min, max, avg, stddev, var).
+   * Statistical operation to perform (count, sum, min, max, avg, stddev, var, percentile_cont, percentile_disc).
    */
-  statisticType: "count" | "sum" | "min" | "max" | "avg" | "stddev" | "var";
+  statisticType:
+    | "count"
+    | "sum"
+    | "min"
+    | "max"
+    | "avg"
+    | "stddev"
+    | "var"
+    | "percentile_cont"
+    | "percentile_disc";
+  /**
+   * Parameter to be used along with statisticType. Currently, only applicable for percentile_cont (continuous percentile) and percentile_disc (discrete percentile).
+   */
+  statisticParameter?: {
+    value: number;
+    orderBy?: "asc" | "desc";
+  };
   /**
    * Field on which to perform the statistical operation.
    */

--- a/packages/arcgis-rest-types/src/webmap.ts
+++ b/packages/arcgis-rest-types/src/webmap.ts
@@ -1002,6 +1002,7 @@ export interface ILayerDefinition extends IHasZM {
     supportsOrderBy?: boolean;
     supportsDistinct?: boolean;
     supportsSqlExpression?: boolean;
+    supportsPercentileStatistics?: boolean;
   };
   allowTrueCurvesUpdates?: boolean;
   onlyAllowTrueCurveUpdatesByTrueCurveClients?: boolean;


### PR DESCRIPTION
- Just adding the interface updates in this PR
- #645 needs `IStatisticDefinition` to be exported. That isn't done in this PR.

Edit:
Didn't figure out the second part earlier. It's ready [now](https://github.com/maneetgoyal/arcgis-rest-js/tree/export-statistic-definition). Can push after this is reviewed and merged.