### PR TITLE
Move IStatisticDefinition to arcgis-rest-types

### DIFF
--- a/packages/arcgis-rest-feature-layer/src/query.ts
+++ b/packages/arcgis-rest-feature-layer/src/query.ts
@@ -12,7 +12,8 @@ import {
   IFeatureSet,
   IFeature,
   Units,
-  IExtent
+  IExtent,
+  IStatisticDefinition
 } from "@esri/arcgis-rest-types";
 
 import { IGetLayerOptions, ISharedQueryOptions } from "./helpers";
@@ -25,37 +26,6 @@ export interface IGetFeatureOptions extends IGetLayerOptions {
    * Unique identifier of the feature.
    */
   id: number;
-}
-
-export interface IStatisticDefinition {
-  /**
-   * Statistical operation to perform (count, sum, min, max, avg, stddev, var, percentile_cont, percentile_disc).
-   */
-  statisticType:
-    | "count"
-    | "sum"
-    | "min"
-    | "max"
-    | "avg"
-    | "stddev"
-    | "var"
-    | "percentile_cont"
-    | "percentile_disc";
-  /**
-   * Parameter to be used along with statisticType. Currently, only applicable for percentile_cont (continuous percentile) and percentile_disc (discrete percentile).
-   */
-  statisticParameter?: {
-    value: number;
-    orderBy?: "asc" | "desc";
-  };
-  /**
-   * Field on which to perform the statistical operation.
-   */
-  onStatisticField: string;
-  /**
-   * Field name for the returned statistic field. If outStatisticFieldName is empty or missing, the server will assign one. A valid field name can only contain alphanumeric characters and an underscore. If the outStatisticFieldName is a reserved keyword of the underlying DBMS, the operation can fail. Try specifying an alternative outStatisticFieldName.
-   */
-  outStatisticFieldName: string;
 }
 
 /**

--- a/packages/arcgis-rest-types/src/index.ts
+++ b/packages/arcgis-rest-types/src/index.ts
@@ -6,3 +6,4 @@ export * from "./service";
 export * from "./symbol";
 export * from "./user";
 export * from "./webmap";
+export * from "./statisticDefinition";

--- a/packages/arcgis-rest-types/src/statisticDefinition.ts
+++ b/packages/arcgis-rest-types/src/statisticDefinition.ts
@@ -1,0 +1,33 @@
+/* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+export interface IStatisticDefinition {
+  /**
+   * Statistical operation to perform (count, sum, min, max, avg, stddev, var, percentile_cont, percentile_disc).
+   */
+  statisticType:
+    | "count"
+    | "sum"
+    | "min"
+    | "max"
+    | "avg"
+    | "stddev"
+    | "var"
+    | "percentile_cont"
+    | "percentile_disc";
+  /**
+   * Parameter to be used along with statisticType. Currently, only applicable for percentile_cont (continuous percentile) and percentile_disc (discrete percentile).
+   */
+  statisticParameter?: {
+    value: number;
+    orderBy?: "asc" | "desc";
+  };
+  /**
+   * Field on which to perform the statistical operation.
+   */
+  onStatisticField: string;
+  /**
+   * Field name for the returned statistic field. If outStatisticFieldName is empty or missing, the server will assign one. A valid field name can only contain alphanumeric characters and an underscore. If the outStatisticFieldName is a reserved keyword of the underlying DBMS, the operation can fail. Try specifying an alternative outStatisticFieldName.
+   */
+  outStatisticFieldName: string;
+}


### PR DESCRIPTION
- #645 needed `IStatisticDefinition` to be exported by `arcgis-rest-types` so proposing that change.
- Fixes #645 