### PR TITLE
Fix completeOAuth2 for edge case where window is opened from another window.open call

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -348,7 +348,7 @@ export class UserSession implements IAuthenticationManager {
   /* istanbul ignore next */
   public static completeOAuth2(options: IOAuth2Options, win: any = window) {
     const { portal, clientId }: IOAuth2Options = {
-      ...{ portal: "https://www.arcgis.com/sharing/rest" },
+      ...{ portal: "https://www.arcgis.com/sharing/rest", popup: true },
       ...options
     };
 

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -353,7 +353,7 @@ export class UserSession implements IAuthenticationManager {
     };
 
     function completeSignIn(error: any, oauthInfo?: IFetchTokenResponse) {
-      if (win.opener && win.opener.parent && win.opener.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`] && popup) {
+      if (popup && win.opener && win.opener.parent && win.opener.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`]) {
         const handlerFn = win.opener[`__ESRI_REST_AUTH_HANDLER_${clientId}`];
         if (handlerFn) {
           handlerFn(
@@ -365,7 +365,7 @@ export class UserSession implements IAuthenticationManager {
         return undefined;
       }
 
-      if (win !== win.parent && win.parent && win.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`] && popup) {
+      if (popup && win !== win.parent && win.parent && win.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`]) {
         const handlerFn = win.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`];
         if (handlerFn) {
           handlerFn(

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -353,7 +353,7 @@ export class UserSession implements IAuthenticationManager {
     };
 
     function completeSignIn(error: any, oauthInfo?: IFetchTokenResponse) {
-      if (win.opener && win.opener.parent) {
+      if (win.opener && win.opener.parent && win.opener.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`] && popup) {
         const handlerFn = win.opener[`__ESRI_REST_AUTH_HANDLER_${clientId}`];
         if (handlerFn) {
           handlerFn(
@@ -365,7 +365,7 @@ export class UserSession implements IAuthenticationManager {
         return undefined;
       }
 
-      if (win !== win.parent) {
+      if (win !== win.parent && win.parent && win.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`] && popup) {
         const handlerFn = win.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`];
         if (handlerFn) {
           handlerFn(

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -361,7 +361,8 @@ export class UserSession implements IAuthenticationManager {
           win.opener.parent &&
           win.opener.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`]
         ) {
-          const handlerFn = win.opener[`__ESRI_REST_AUTH_HANDLER_${clientId}`];
+          const handlerFn =
+            win.opener.parent[`__ESRI_REST_AUTH_HANDLER_${clientId}`];
           if (handlerFn) {
             handlerFn(
               error ? JSON.stringify(error) : undefined,
@@ -390,7 +391,7 @@ export class UserSession implements IAuthenticationManager {
         }
       } catch (e) {
         throw new ArcGISAuthError(
-          `Unable to complete authentication. You specified popup based oAuth2 but no handler from "beginOAuth2()" present. This generally happens because the "popup" option differs between "beginOAuth2()" and "completeOAuth2()".`
+          `Unable to complete authentication. It's possible you specified popup based oAuth2 but no handler from "beginOAuth2()" present. This generally happens because the "popup" option differs between "beginOAuth2()" and "completeOAuth2()".`
         );
       }
 

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1014,7 +1014,7 @@ describe("UserSession", () => {
 
     it("should throw an error if the handler or parent window cannot be accessed", () => {
       const MockParent = {
-        get opener() {
+        get parent() {
           throw new Error(
             "This window isn't where auth started, but was opened from somewhere else via window.open() perhaps from another domain which would cause a cross domain error when read."
           );
@@ -1026,7 +1026,7 @@ describe("UserSession", () => {
           href:
             "https://example-app.com/redirect-uri#error=Invalid_Signin&error_description=Invalid_Signin"
         },
-        get parent() {
+        get opener() {
           return MockParent;
         }
       };

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1011,6 +1011,36 @@ describe("UserSession", () => {
         );
       }).toThrowError(ArcGISRequestError, "Invalid_Signin: Invalid_Signin");
     });
+
+    it("should throw an error if the handler or parent window cannot be accessed", () => {
+      const MockParent = {
+        get opener() {
+          throw new Error(
+            "This window isn't where auth started, but was opened from somewhere else via window.open() perhaps from another domain which would cause a cross domain error when read."
+          );
+        }
+      };
+
+      const MockWindow = {
+        location: {
+          href:
+            "https://example-app.com/redirect-uri#error=Invalid_Signin&error_description=Invalid_Signin"
+        },
+        get parent() {
+          return MockParent;
+        }
+      };
+
+      expect(function() {
+        UserSession.completeOAuth2(
+          {
+            clientId: "clientId",
+            redirectUri: "https://example-app.com/redirect-uri"
+          },
+          MockWindow
+        );
+      }).toThrowError(ArcGISAuthError);
+    });
   });
 
   describe(".authorize()", () => {

--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,7 @@
     "object-literal-sort-keys": false,
     "interface-name": [true, "always-prefix"],
     "no-string-literal": false,
-    "no-console": false
+    "no-console": false,
+    "no-var-keyword": false
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -11,7 +11,6 @@
     "object-literal-sort-keys": false,
     "interface-name": [true, "always-prefix"],
     "no-string-literal": false,
-    "no-console": false,
-    "no-var-keyword": false
+    "no-console": false
   }
 }


### PR DESCRIPTION
In cases like the ArcGIS Online app switcher the windows of each respective app are opened with `window.open` which sets `window.opener` and `window.opener.parent` to ArcGIS Online. When used with `{popup: false}` this means that when you call `completeOAuth2` after auth happens `window.opener` is still set and the auth assumes you are in a popup workflow.

This PR adds some extra checks:

1. Check that `popup` is true in the options.
2. Check that the handler exists before trying to call it.

This MIGHT be considered a breaking change because up until now we didn't really do anything if you didn't pass `popup` to `completeOAuth2`. it all still worked because didn't really check popup, which is the error here so this could also be considered a bug. 

I think that by adding a default of `popup:true` this will prevent a breaking change. Users in the popup:true` workflow already has to pass popup:false` to both oAuth function to get this to work which is still the case. 