### PR TITLE
Replace string union types with const enums

### DIFF
--- a/packages/arcgis-rest-types/src/statisticDefinition.ts
+++ b/packages/arcgis-rest-types/src/statisticDefinition.ts
@@ -2,7 +2,7 @@
  * Apache-2.0 */
 
 /**
- * Enum of all different statisticsType
+ * Enum of all different statistics operations
  */
 export const enum StatisticType {
   Count = "count",
@@ -16,6 +16,14 @@ export const enum StatisticType {
   DiscretePercentile = "percentile_disc"
 }
 
+/**
+ * Enum of sorting orders
+ */
+export const enum SortingOrder {
+  Ascending = "asc",
+  Descending = "desc"
+}
+
 export interface IStatisticDefinition {
   /**
    * Statistical operation to perform (count, sum, min, max, avg, stddev, var, percentile_cont, percentile_disc).
@@ -26,7 +34,7 @@ export interface IStatisticDefinition {
    */
   statisticParameter?: {
     value: number;
-    orderBy?: "asc" | "desc";
+    orderBy?: SortingOrder;
   };
   /**
    * Field on which to perform the statistical operation.

--- a/packages/arcgis-rest-types/src/statisticDefinition.ts
+++ b/packages/arcgis-rest-types/src/statisticDefinition.ts
@@ -28,13 +28,23 @@ export interface IStatisticDefinition {
   /**
    * Statistical operation to perform (count, sum, min, max, avg, stddev, var, percentile_cont, percentile_disc).
    */
-  statisticType: StatisticType;
+  statisticType:
+    | "count"
+    | "sum"
+    | "min"
+    | "max"
+    | "avg"
+    | "stddev"
+    | "var"
+    | "percentile_cont"
+    | "percentile_disc"
+    | StatisticType;
   /**
    * Parameter to be used along with statisticType. Currently, only applicable for percentile_cont (continuous percentile) and percentile_disc (discrete percentile).
    */
   statisticParameter?: {
     value: number;
-    orderBy?: SortingOrder;
+    orderBy?: "asc" | "desc" | SortingOrder;
   };
   /**
    * Field on which to perform the statistical operation.

--- a/packages/arcgis-rest-types/src/statisticDefinition.ts
+++ b/packages/arcgis-rest-types/src/statisticDefinition.ts
@@ -1,20 +1,26 @@
 /* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+/**
+ * Enum of all different statisticsType
+ */
+export const enum StatisticType {
+  Count = "count",
+  Sum = "sum",
+  Minimum = "min",
+  Maximum = "max",
+  Average = "avg",
+  StandardDeviation = "stddev",
+  Variance = "var",
+  ContinuousPercentile = "percentile_cont",
+  DiscretePercentile = "percentile_disc"
+}
+
 export interface IStatisticDefinition {
   /**
    * Statistical operation to perform (count, sum, min, max, avg, stddev, var, percentile_cont, percentile_disc).
    */
-  statisticType:
-    | "count"
-    | "sum"
-    | "min"
-    | "max"
-    | "avg"
-    | "stddev"
-    | "var"
-    | "percentile_cont"
-    | "percentile_disc";
+  statisticType: StatisticType;
   /**
    * Parameter to be used along with statisticType. Currently, only applicable for percentile_cont (continuous percentile) and percentile_disc (discrete percentile).
    */

--- a/packages/arcgis-rest-types/src/symbol.ts
+++ b/packages/arcgis-rest-types/src/symbol.ts
@@ -225,7 +225,7 @@ export const enum HorizontalAlignment {
  *
  */
 export interface ITextSymbol extends IMarkerSymbol {
-  type: SymbolType.TS;
+  type: "esriTS" | SymbolType.TS;
   color?: Color;
   backgroundColor?: Color;
   borderLineSize?: number; // <size>;

--- a/packages/arcgis-rest-types/src/symbol.ts
+++ b/packages/arcgis-rest-types/src/symbol.ts
@@ -185,6 +185,23 @@ export interface ISimpleMarkerSymbol extends IMarkerSymbol {
 /**
  *
  */
+export const enum VerticalAlignment {
+  Baseline = "baseline",
+  Top = "top",
+  Middle = "middle",
+  Bottom = "bottom"
+}
+
+export const enum HorizontalAlignment {
+  Left = "left",
+  Right = "right",
+  Center = "center",
+  Justify = "justify"
+}
+
+/**
+ *
+ */
 export interface ITextSymbol extends IMarkerSymbol {
   type: SymbolType.TS;
   color?: Color;
@@ -193,8 +210,8 @@ export interface ITextSymbol extends IMarkerSymbol {
   borderLineColor?: Color;
   haloSize?: number; // <size>;
   haloColor?: Color;
-  verticalAlignment?: "baseline" | "top" | "middle" | "bottom";
-  horizontalAlignment?: "left" | "right" | "center" | "justify";
+  verticalAlignment?: VerticalAlignment;
+  horizontalAlignment?: HorizontalAlignment;
   rightToLeft?: boolean;
   kerning?: boolean;
   font?: IFont;

--- a/packages/arcgis-rest-types/src/symbol.ts
+++ b/packages/arcgis-rest-types/src/symbol.ts
@@ -4,18 +4,6 @@
 /**
  *
  */
-export const enum SymbolType {
-  SLS = "esriSLS",
-  SMS = "esriSMS",
-  SFS = "esriSFS",
-  PMS = "esriPMS",
-  PFS = "esriPFS",
-  TS = "esriTS"
-}
-
-/**
- *
- */
 export type Color = [number, number, number, number];
 
 /**
@@ -69,6 +57,18 @@ export interface IPictureSourced {
   angle?: number;
   xoffset?: number;
   yoffset?: number;
+}
+
+/**
+ *
+ */
+export const enum SymbolType {
+  SLS = "esriSLS",
+  SMS = "esriSMS",
+  SFS = "esriSFS",
+  PMS = "esriPMS",
+  PFS = "esriPFS",
+  TS = "esriTS"
 }
 
 /**

--- a/packages/arcgis-rest-types/src/symbol.ts
+++ b/packages/arcgis-rest-types/src/symbol.ts
@@ -4,7 +4,47 @@
 /**
  *
  */
+export const enum SymbolType {
+  SLS = "esriSLS",
+  SMS = "esriSMS",
+  SFS = "esriSFS",
+  PMS = "esriPMS",
+  PFS = "esriPFS",
+  TS = "esriTS"
+}
+
+/**
+ *
+ */
 export type Color = [number, number, number, number];
+
+/**
+ *
+ */
+export const enum FontStyle {
+  Italic = "italic",
+  Normal = "normal",
+  Oblique = "oblique"
+}
+
+/**
+ *
+ */
+export const enum FontWeight {
+  Bold = "bold",
+  Bolder = "bolder",
+  Lighter = "lighter",
+  Normal = "normal"
+}
+
+/**
+ *
+ */
+export const enum FontDecoration {
+  LineThrough = "line-through",
+  Underline = "underline",
+  None = "none"
+}
 
 /**
  *
@@ -12,9 +52,9 @@ export type Color = [number, number, number, number];
 export interface IFont {
   family?: string; // "<fontFamily>";
   size?: number; // <fontSize>;
-  style?: "italic" | "normal" | "oblique";
-  weight?: "bold" | "bolder" | "lighter" | "normal";
-  decoration?: "line-through" | "underline" | "none";
+  style?: FontStyle;
+  weight?: FontWeight;
+  decoration?: FontDecoration;
 }
 
 /**
@@ -60,7 +100,7 @@ export interface IMarkerSymbol extends ISymbol {
  *
  */
 export interface IPictureFillSymbol extends ISymbol, IPictureSourced {
-  type: "esriPFS";
+  type: SymbolType.PFS;
   outline?: ISimpleLineSymbol; // if outline has been specified
   xscale?: number;
   yscale?: number;
@@ -70,60 +110,52 @@ export interface IPictureFillSymbol extends ISymbol, IPictureSourced {
  *
  */
 export interface IPictureMarkerSymbol extends IMarkerSymbol, IPictureSourced {
-  type: "esriPMS";
+  type: SymbolType.PMS;
 }
 
 /**
  *
  */
-export type SimpleMarkerSymbolStyle =
-  | "esriSMSCircle"
-  | "esriSMSCross"
-  | "esriSMSDiamond"
-  | "esriSMSSquare"
-  | "esriSMSX"
-  | "esriSMSTriangle";
+export const enum SimpleMarkerSymbolStyle {
+  Circle = "esriSMSCircle",
+  Cross = "esriSMSCross",
+  Diamond = "esriSMSDiamond",
+  Square = "esriSMSSquare",
+  X = "esriSMSX",
+  Triangle = "esriSMSTriangle"
+}
 
 /**
  *
  */
-export type SimpleLineSymbolStyle =
-  | "esriSLSDash"
-  | "esriSLSDashDot"
-  | "esriSLSDashDotDot"
-  | "esriSLSDot"
-  | "esriSLSNull"
-  | "esriSLSSolid";
+export const enum SimpleLineSymbolStyle {
+  Dash = "esriSLSDash",
+  DashDot = "esriSLSDashDot",
+  DashDotDot = "esriSLSDashDotDot",
+  Dot = "esriSLSDot",
+  Null = "esriSLSNull",
+  Solid = "esriSLSSolid"
+}
 
 /**
  *
  */
-export type SimpleFillSymbolStyle =
-  | "esriSFSBackwardDiagonal"
-  | "esriSFSCross"
-  | "esriSFSDiagonalCross"
-  | "esriSFSForwardDiagonal"
-  | "esriSFSHorizontal"
-  | "esriSFSNull"
-  | "esriSFSSolid"
-  | "esriSFSVertical";
-
-/**
- *
- */
-export type SymbolType =
-  | "esriSLS"
-  | "esriSMS"
-  | "esriSFS"
-  | "esriPMS"
-  | "esriPFS"
-  | "esriTS";
+export const enum SimpleFillSymbolStyle {
+  BackwardDiagonal = "esriSFSBackwardDiagonal",
+  Cross = "esriSFSCross",
+  DiagonalCross = "esriSFSDiagonalCross",
+  ForwardDiagonal = "esriSFSForwardDiagonal",
+  Horizontal = "esriSFSHorizontal",
+  Null = "esriSFSNull",
+  Solid = "esriSFSSolid",
+  Vertical = "esriSFSVertical"
+}
 
 /**
  *
  */
 export interface ISimpleFillSymbol extends ISymbol {
-  type: "esriSFS";
+  type: SymbolType.SFS;
   style?: SimpleFillSymbolStyle;
   color?: Color;
   outline?: ISimpleLineSymbol; // if outline has been specified
@@ -133,7 +165,7 @@ export interface ISimpleFillSymbol extends ISymbol {
  *
  */
 export interface ISimpleLineSymbol extends ISymbol {
-  type: "esriSLS";
+  type: SymbolType.SLS;
   style?: SimpleLineSymbolStyle;
   color?: Color;
   width?: number;
@@ -143,7 +175,7 @@ export interface ISimpleLineSymbol extends ISymbol {
  *
  */
 export interface ISimpleMarkerSymbol extends IMarkerSymbol {
-  type: "esriSMS";
+  type: SymbolType.SMS;
   style?: SimpleMarkerSymbolStyle;
   color?: Color;
   size?: number;
@@ -154,7 +186,7 @@ export interface ISimpleMarkerSymbol extends IMarkerSymbol {
  *
  */
 export interface ITextSymbol extends IMarkerSymbol {
-  type: "esriTS";
+  type: SymbolType.TS;
   color?: Color;
   backgroundColor?: Color;
   borderLineSize?: number; // <size>;

--- a/packages/arcgis-rest-types/src/symbol.ts
+++ b/packages/arcgis-rest-types/src/symbol.ts
@@ -40,9 +40,9 @@ export const enum FontDecoration {
 export interface IFont {
   family?: string; // "<fontFamily>";
   size?: number; // <fontSize>;
-  style?: FontStyle;
-  weight?: FontWeight;
-  decoration?: FontDecoration;
+  style?: "italic" | "normal" | "oblique" | FontStyle;
+  weight?: "bold" | "bolder" | "lighter" | "normal" | FontWeight;
+  decoration?: "line-through" | "underline" | "none" | FontDecoration;
 }
 
 /**
@@ -75,15 +75,14 @@ export const enum SymbolType {
  *
  */
 export interface ISymbol {
-  type: SymbolType;
-  style?: string;
-}
-
-/**
- *
- */
-export interface ISymbol {
-  type: SymbolType;
+  type:
+    | "esriSLS"
+    | "esriSMS"
+    | "esriSFS"
+    | "esriPMS"
+    | "esriPFS"
+    | "esriTS"
+    | SymbolType;
   style?: string;
 }
 
@@ -100,7 +99,7 @@ export interface IMarkerSymbol extends ISymbol {
  *
  */
 export interface IPictureFillSymbol extends ISymbol, IPictureSourced {
-  type: SymbolType.PFS;
+  type: "esriPFS" | SymbolType.PFS;
   outline?: ISimpleLineSymbol; // if outline has been specified
   xscale?: number;
   yscale?: number;
@@ -110,7 +109,7 @@ export interface IPictureFillSymbol extends ISymbol, IPictureSourced {
  *
  */
 export interface IPictureMarkerSymbol extends IMarkerSymbol, IPictureSourced {
-  type: SymbolType.PMS;
+  type: "esriPMS" | SymbolType.PMS;
 }
 
 /**
@@ -155,8 +154,17 @@ export const enum SimpleFillSymbolStyle {
  *
  */
 export interface ISimpleFillSymbol extends ISymbol {
-  type: SymbolType.SFS;
-  style?: SimpleFillSymbolStyle;
+  type: "esriSFS" | SymbolType.SFS;
+  style?:
+    | "esriSFSBackwardDiagonal"
+    | "esriSFSCross"
+    | "esriSFSDiagonalCross"
+    | "esriSFSForwardDiagonal"
+    | "esriSFSHorizontal"
+    | "esriSFSNull"
+    | "esriSFSSolid"
+    | "esriSFSVertical"
+    | SimpleFillSymbolStyle;
   color?: Color;
   outline?: ISimpleLineSymbol; // if outline has been specified
 }
@@ -165,8 +173,15 @@ export interface ISimpleFillSymbol extends ISymbol {
  *
  */
 export interface ISimpleLineSymbol extends ISymbol {
-  type: SymbolType.SLS;
-  style?: SimpleLineSymbolStyle;
+  type: "esriSLS" | SymbolType.SLS;
+  style?:
+    | "esriSLSDash"
+    | "esriSLSDashDot"
+    | "esriSLSDashDotDot"
+    | "esriSLSDot"
+    | "esriSLSNull"
+    | "esriSLSSolid"
+    | SimpleLineSymbolStyle;
   color?: Color;
   width?: number;
 }
@@ -175,8 +190,15 @@ export interface ISimpleLineSymbol extends ISymbol {
  *
  */
 export interface ISimpleMarkerSymbol extends IMarkerSymbol {
-  type: SymbolType.SMS;
-  style?: SimpleMarkerSymbolStyle;
+  type: "esriSMS" | SymbolType.SMS;
+  style?:
+    | "esriSMSCircle"
+    | "esriSMSCross"
+    | "esriSMSDiamond"
+    | "esriSMSSquare"
+    | "esriSMSX"
+    | "esriSMSTriangle"
+    | SimpleMarkerSymbolStyle;
   color?: Color;
   size?: number;
   outline?: ISimpleLineSymbol;
@@ -210,8 +232,18 @@ export interface ITextSymbol extends IMarkerSymbol {
   borderLineColor?: Color;
   haloSize?: number; // <size>;
   haloColor?: Color;
-  verticalAlignment?: VerticalAlignment;
-  horizontalAlignment?: HorizontalAlignment;
+  verticalAlignment?:
+    | "baseline"
+    | "top"
+    | "middle"
+    | "bottom"
+    | VerticalAlignment;
+  horizontalAlignment?:
+    | "left"
+    | "right"
+    | "center"
+    | "justify"
+    | HorizontalAlignment;
   rightToLeft?: boolean;
   kerning?: boolean;
   font?: IFont;

--- a/packages/arcgis-rest-types/src/webmap.ts
+++ b/packages/arcgis-rest-types/src/webmap.ts
@@ -22,20 +22,21 @@ import {
 /**
  * Field type.
  */
-export type FieldType =
-  | "esriFieldTypeBlob"
-  | "esriFieldTypeDate"
-  | "esriFieldTypeDouble"
-  | "esriFieldTypeGeometry"
-  | "esriFieldTypeGlobalID"
-  | "esriFieldTypeGUID"
-  | "esriFieldTypeInteger"
-  | "esriFieldTypeOID"
-  | "esriFieldTypeRaster"
-  | "esriFieldTypeSingle"
-  | "esriFieldTypeSmallInteger"
-  | "esriFieldTypeString"
-  | "esriFieldTypeXML";
+export const enum FieldType {
+  Blob = "esriFieldTypeBlob",
+  Date = "esriFieldTypeDate",
+  Double = "esriFieldTypeDouble",
+  Geometry = "esriFieldTypeGeometry",
+  GlobalID = "esriFieldTypeGlobalID",
+  GUID = "esriFieldTypeGUID",
+  Integer = "esriFieldTypeInteger",
+  OID = "esriFieldTypeOID",
+  Raster = "esriFieldTypeRaster",
+  Single = "esriFieldTypeSingle",
+  SmallInteger = "esriFieldTypeSmallInteger",
+  String = "esriFieldTypeString",
+  XML = "esriFieldTypeXML"
+}
 
 /**
  * Contains information about an attribute field.
@@ -50,7 +51,21 @@ export interface IField {
   /** A string defining the field name. */
   name: string;
   /** A string defining the field type. */
-  type: FieldType;
+  type:
+    | "esriFieldTypeBlob"
+    | "esriFieldTypeDate"
+    | "esriFieldTypeDouble"
+    | "esriFieldTypeGeometry"
+    | "esriFieldTypeGlobalID"
+    | "esriFieldTypeGUID"
+    | "esriFieldTypeInteger"
+    | "esriFieldTypeOID"
+    | "esriFieldTypeRaster"
+    | "esriFieldTypeSingle"
+    | "esriFieldTypeSmallInteger"
+    | "esriFieldTypeString"
+    | "esriFieldTypeXML"
+    | FieldType;
   /** A string defining the field alias. */
   alias?: string;
   /** The domain objects if applicable. */
@@ -82,6 +97,28 @@ export interface IPagingParams {
 }
 
 /**
+ * Date fields types to specify how the date should appear in popup windows
+ */
+export const enum DateFormat {
+  ShortDate = "shortDate",
+  ShortDateLE = "shortDateLE",
+  LongMonthDayYear = "longMonthDayYear",
+  DayShortMonthYear = "dayShortMonthYear",
+  LongDate = "longDate",
+  ShortDateShortTime = "shortDateShortTime",
+  ShortDateLEShortTime = "shortDateLEShortTime",
+  ShortDateShortTime24 = "shortDateShortTime24",
+  ShortDateLEShortTime24 = "shortDateLEShortTime24",
+  ShortDateLongTime = "shortDateLongTime",
+  ShortDateLELongTime = "shortDateLELongTime",
+  ShortDateLongTime24 = "shortDateLongTime24",
+  ShortDateLELongTime24 = "shortDateLELongTime24",
+  LongMonthYear = "longMonthYear",
+  ShortMonthYear = "shortMonthYear",
+  Year = "year"
+}
+
+/**
  * The format object can be used with numerical or date fields to provide more detail about how values should be displayed in popup windows.
  */
 export interface IFieldFormat {
@@ -102,7 +139,8 @@ export interface IFieldFormat {
     | "shortDateLELongTime24"
     | "longMonthYear"
     | "shortMonthYear"
-    | "year";
+    | "year"
+    | DateFormat;
 
   /**
    * A Boolean used with numerical fields. A value of true allows the number to have a digit (or thousands) separator when the value appears in popup windows.


### PR DESCRIPTION
- Fixes https://github.com/Esri/arcgis-rest-js/issues/654
- `enum` names can be changed. Currently went with what seemed more intuitive.
- ~Some breaking changes are possible. For instance:~ See https://github.com/Esri/arcgis-rest-js/pull/656#issuecomment-591798396.

Earlier, we had:
```ts
export interface ISimpleFillSymbol extends ISymbol {
  type: "esriSFS";
  style?: SimpleFillSymbolStyle;
  color?: Color;
  outline?: ISimpleLineSymbol; // if outline has been specified
}

// The following is OK for TSC
const sample: ISimpleFillSymbol = {
  type: "esriSFS"
}; 
```

But now we have:
 ```ts
export const enum SymbolType {
  SLS = "esriSLS",
  SMS = "esriSMS",
  SFS = "esriSFS",
  PMS = "esriPMS",
  PFS = "esriPFS",
  TS = "esriTS"
}

export interface ISimpleFillSymbol extends ISymbol {
  type: SymbolType.SFS;
  style?: SimpleFillSymbolStyle;
  color?: Color;
  outline?: ISimpleLineSymbol; // if outline has been specified
}

// The following is WRONG for TSC
const sample: ISimpleFillSymbol = {
  type: "esriSFS"
};

// The following is OK for TSC
const sample2: ISimpleFillSymbol = {
  type: SymbolType.SFS
};
```