### PR TITLE
fix(getItemResources): do not mutate requestOptions in getItemResources

### DIFF
--- a/packages/arcgis-rest-portal/src/items/get.ts
+++ b/packages/arcgis-rest-portal/src/items/get.ts
@@ -148,13 +148,16 @@ export function getItemResources(
 ): Promise<any> {
   const url = `${getPortalUrl(requestOptions)}/content/items/${id}/resources`;
 
-  // mix in user supplied params
-  requestOptions.params = {
-    ...requestOptions.params,
-    num: 1000
+  // Mix in num:1000 with any user supplied params
+  // Key thing - we don't want to mutate the passed in requestOptions
+  // as that may be used in other (subsequent) calls in the course
+  // of a long promise chains
+  const options: IRequestOptions = {
+    ...requestOptions
   };
+  options.params = { ...options.params, ...{ num: 1000 } };
 
-  return request(url, requestOptions);
+  return request(url, options);
 }
 
 export interface IGetItemGroupsResponse {

--- a/packages/arcgis-rest-portal/src/items/get.ts
+++ b/packages/arcgis-rest-portal/src/items/get.ts
@@ -155,7 +155,7 @@ export function getItemResources(
   const options: IRequestOptions = {
     ...requestOptions
   };
-  options.params = { ...options.params, ...{ num: 1000 } };
+  options.params = { num: 1000, ...options.params };
 
   return request(url, options);
 }


### PR DESCRIPTION
Perviously we mutated the requestOptions, but this causes issues if the same requestOptions
instance is used in multiple calls - as in the case of long-promise chains orchestrating complex
interactions with the platform.

AFFECTS PACKAGES:
@esri/arcgis-rest-portal