### PR TITLE
Correct service-admin link and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Some useful commands include:
 * [`@esri/arcgis-rest-auth`](./packages/arcgis-rest-auth) - Provides methods for authenticating named users and applications.
 * [`@esri/arcgis-rest-portal`](./packages/arcgis-rest-portal) - Methods for working with ArcGIS Online/Enterprise content and users.
 * [`@esri/arcgis-rest-feature-layer`](./packages/arcgis-rest-feature-layer) - Functions for querying and editing features inside of hosted feature layers.
-* [`@esri/arcgis-rest-service-admin`](./packages/arcgis-rest-feature-service-admin) - Functions for administering hosted services.
+* [`@esri/arcgis-rest-service-admin`](./packages/arcgis-rest-service-admin) - Functions for administering hosted feature services.
 * [`@esri/arcgis-rest-geocoding`](./packages/arcgis-rest-geocoding) - Geocoding wrapper for `@esri/arcgis-rest-js`
 * [`@esri/arcgis-rest-routing`](./packages/arcgis-rest-routing) - Routing and directions wrapper for `@esri/arcgis-rest-js`.
 * [`@esri/arcgis-rest-types`](./packages/arcgis-rest-types/) - Common Typings for TypeScript developers.


### PR DESCRIPTION
Link was incorrect.

updated description to disambiguate this module from service administration, which means different things to different people across the entire REST API