### PR TITLE
Accounting for update group owner

### DIFF
--- a/packages/arcgis-rest-portal/src/sharing/group-sharing.ts
+++ b/packages/arcgis-rest-portal/src/sharing/group-sharing.ts
@@ -217,7 +217,7 @@ function shareToGroupAsNonOwner(
       if (group) {
         // they are in the group...
         // check member type
-        if (group.userMembership.memberType !== "admin") {
+        if (group.userMembership.memberType === "member") {
           // promote them
           return updateUserMemberships({
             id: requestOptions.groupId,


### PR DESCRIPTION
Current Situation
**Given** Admin is trying to share an item to an update group,
**Then** Item Owner must be an admin in that group
**Result** So, the current code promotes Item Owner to group admin if not already group admin.

The problem is that the Item Owner may be the group _owner_, in which case they don't need to be promoted. The fix is to check only if they are a lowly `member`, instead of checking if they are NOT an admin.

