### PR TITLE
remove incorrect lerna instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,10 +8,6 @@ The command below bumps the version in each individual package.json file and par
 npm run release:prepare
 ```
 
-I don't know why, but sometimes lerna fails to increment a new version number for individual packages (like @esri/arcgis-rest-auth). **When this happens, it is necessary to increment the `version` number in the package (and anything that depends on it) manually.**
-
-You should **not** increment `peerDependency` version numbers manually _unless you know that your new version of the package needs to use the updated peer dependency_. They should remain as loose as possible.
-
 For some reason, in CHANGELOG.md, the unreleased section appears below this release. So please move it to the top.
 
 Afterwards, you can display a diff to give you a sense of what will be committed to master when you actually publish.


### PR DESCRIPTION
After re-reading the [lerna docs on fixed mode](https://github.com/lerna/lerna#fixedlocked-mode-default), I _think_ lerna is doing the right thing, in particular:

> When you run lerna publish, if a module has been updated since the last time a release was made, it will be updated to the new version you're releasing.

I think the ones that are not getting updated are the ones that have not been updated and do not depend on any packages that have been updated. For example, I'm in the middle of cutting a release now. The only package w/ changes is arcgis-rest-portal. When I run `npm run release:prepare` w/ the minor option, the only packages whose versions are updated from 2.9.0 to 2.10.0 are arcgis-rest-portal and those that depend on it. The "lower" level packages like arcgis-rest-request are untouched. That works b/c the peerDependency range for the ones that did bump is still `^2.0.0`.