### PR TITLE
getItemData() throws JSON error if data is empty

### DIFF
--- a/packages/arcgis-rest-portal/src/items/get.ts
+++ b/packages/arcgis-rest-portal/src/items/get.ts
@@ -80,7 +80,7 @@ export function getItemData(
     /* if the item doesn't include data, the response will be empty
        and the internal call to response.json() will fail */
     const emptyResponseErr = RegExp(
-      /Unexpected end of (JSON input|data at line 1 column 1)/i
+      /The string did not match the expected pattern|(Unexpected end of (JSON input|data at line 1 column 1))/i
     );
     /* istanbul ignore else */
     if (emptyResponseErr.test(err.message)) {


### PR DESCRIPTION
If item data is empty, the error message is `SyntaxError: The string did not match the expected pattern` in safari.
Please test the issue by the public item:  `38503de66a594dd7a656c72a34c04183`.