### PR TITLE
Revert "Merge pull request #656 from maneetgoyal/symbol-enums"

### DIFF
--- a/packages/arcgis-rest-types/src/statisticDefinition.ts
+++ b/packages/arcgis-rest-types/src/statisticDefinition.ts
@@ -1,29 +1,6 @@
 /* Copyright (c) 2017-2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-/**
- * Enum of all different statistics operations
- */
-export const enum StatisticType {
-  Count = "count",
-  Sum = "sum",
-  Minimum = "min",
-  Maximum = "max",
-  Average = "avg",
-  StandardDeviation = "stddev",
-  Variance = "var",
-  ContinuousPercentile = "percentile_cont",
-  DiscretePercentile = "percentile_disc"
-}
-
-/**
- * Enum of sorting orders
- */
-export const enum SortingOrder {
-  Ascending = "asc",
-  Descending = "desc"
-}
-
 export interface IStatisticDefinition {
   /**
    * Statistical operation to perform (count, sum, min, max, avg, stddev, var, percentile_cont, percentile_disc).
@@ -37,14 +14,13 @@ export interface IStatisticDefinition {
     | "stddev"
     | "var"
     | "percentile_cont"
-    | "percentile_disc"
-    | StatisticType;
+    | "percentile_disc";
   /**
    * Parameter to be used along with statisticType. Currently, only applicable for percentile_cont (continuous percentile) and percentile_disc (discrete percentile).
    */
   statisticParameter?: {
     value: number;
-    orderBy?: "asc" | "desc" | SortingOrder;
+    orderBy?: "asc" | "desc";
   };
   /**
    * Field on which to perform the statistical operation.

--- a/packages/arcgis-rest-types/src/symbol.ts
+++ b/packages/arcgis-rest-types/src/symbol.ts
@@ -9,40 +9,12 @@ export type Color = [number, number, number, number];
 /**
  *
  */
-export const enum FontStyle {
-  Italic = "italic",
-  Normal = "normal",
-  Oblique = "oblique"
-}
-
-/**
- *
- */
-export const enum FontWeight {
-  Bold = "bold",
-  Bolder = "bolder",
-  Lighter = "lighter",
-  Normal = "normal"
-}
-
-/**
- *
- */
-export const enum FontDecoration {
-  LineThrough = "line-through",
-  Underline = "underline",
-  None = "none"
-}
-
-/**
- *
- */
 export interface IFont {
   family?: string; // "<fontFamily>";
   size?: number; // <fontSize>;
-  style?: "italic" | "normal" | "oblique" | FontStyle;
-  weight?: "bold" | "bolder" | "lighter" | "normal" | FontWeight;
-  decoration?: "line-through" | "underline" | "none" | FontDecoration;
+  style?: "italic" | "normal" | "oblique";
+  weight?: "bold" | "bolder" | "lighter" | "normal";
+  decoration?: "line-through" | "underline" | "none";
 }
 
 /**
@@ -62,27 +34,16 @@ export interface IPictureSourced {
 /**
  *
  */
-export const enum SymbolType {
-  SLS = "esriSLS",
-  SMS = "esriSMS",
-  SFS = "esriSFS",
-  PMS = "esriPMS",
-  PFS = "esriPFS",
-  TS = "esriTS"
+export interface ISymbol {
+  type: SymbolType;
+  style?: string;
 }
 
 /**
  *
  */
 export interface ISymbol {
-  type:
-    | "esriSLS"
-    | "esriSMS"
-    | "esriSFS"
-    | "esriPMS"
-    | "esriPFS"
-    | "esriTS"
-    | SymbolType;
+  type: SymbolType;
   style?: string;
 }
 
@@ -99,7 +60,7 @@ export interface IMarkerSymbol extends ISymbol {
  *
  */
 export interface IPictureFillSymbol extends ISymbol, IPictureSourced {
-  type: "esriPFS" | SymbolType.PFS;
+  type: "esriPFS";
   outline?: ISimpleLineSymbol; // if outline has been specified
   xscale?: number;
   yscale?: number;
@@ -109,62 +70,61 @@ export interface IPictureFillSymbol extends ISymbol, IPictureSourced {
  *
  */
 export interface IPictureMarkerSymbol extends IMarkerSymbol, IPictureSourced {
-  type: "esriPMS" | SymbolType.PMS;
+  type: "esriPMS";
 }
 
 /**
  *
  */
-export const enum SimpleMarkerSymbolStyle {
-  Circle = "esriSMSCircle",
-  Cross = "esriSMSCross",
-  Diamond = "esriSMSDiamond",
-  Square = "esriSMSSquare",
-  X = "esriSMSX",
-  Triangle = "esriSMSTriangle"
-}
+export type SimpleMarkerSymbolStyle =
+  | "esriSMSCircle"
+  | "esriSMSCross"
+  | "esriSMSDiamond"
+  | "esriSMSSquare"
+  | "esriSMSX"
+  | "esriSMSTriangle";
 
 /**
  *
  */
-export const enum SimpleLineSymbolStyle {
-  Dash = "esriSLSDash",
-  DashDot = "esriSLSDashDot",
-  DashDotDot = "esriSLSDashDotDot",
-  Dot = "esriSLSDot",
-  Null = "esriSLSNull",
-  Solid = "esriSLSSolid"
-}
+export type SimpleLineSymbolStyle =
+  | "esriSLSDash"
+  | "esriSLSDashDot"
+  | "esriSLSDashDotDot"
+  | "esriSLSDot"
+  | "esriSLSNull"
+  | "esriSLSSolid";
 
 /**
  *
  */
-export const enum SimpleFillSymbolStyle {
-  BackwardDiagonal = "esriSFSBackwardDiagonal",
-  Cross = "esriSFSCross",
-  DiagonalCross = "esriSFSDiagonalCross",
-  ForwardDiagonal = "esriSFSForwardDiagonal",
-  Horizontal = "esriSFSHorizontal",
-  Null = "esriSFSNull",
-  Solid = "esriSFSSolid",
-  Vertical = "esriSFSVertical"
-}
+export type SimpleFillSymbolStyle =
+  | "esriSFSBackwardDiagonal"
+  | "esriSFSCross"
+  | "esriSFSDiagonalCross"
+  | "esriSFSForwardDiagonal"
+  | "esriSFSHorizontal"
+  | "esriSFSNull"
+  | "esriSFSSolid"
+  | "esriSFSVertical";
+
+/**
+ *
+ */
+export type SymbolType =
+  | "esriSLS"
+  | "esriSMS"
+  | "esriSFS"
+  | "esriPMS"
+  | "esriPFS"
+  | "esriTS";
 
 /**
  *
  */
 export interface ISimpleFillSymbol extends ISymbol {
-  type: "esriSFS" | SymbolType.SFS;
-  style?:
-    | "esriSFSBackwardDiagonal"
-    | "esriSFSCross"
-    | "esriSFSDiagonalCross"
-    | "esriSFSForwardDiagonal"
-    | "esriSFSHorizontal"
-    | "esriSFSNull"
-    | "esriSFSSolid"
-    | "esriSFSVertical"
-    | SimpleFillSymbolStyle;
+  type: "esriSFS";
+  style?: SimpleFillSymbolStyle;
   color?: Color;
   outline?: ISimpleLineSymbol; // if outline has been specified
 }
@@ -173,15 +133,8 @@ export interface ISimpleFillSymbol extends ISymbol {
  *
  */
 export interface ISimpleLineSymbol extends ISymbol {
-  type: "esriSLS" | SymbolType.SLS;
-  style?:
-    | "esriSLSDash"
-    | "esriSLSDashDot"
-    | "esriSLSDashDotDot"
-    | "esriSLSDot"
-    | "esriSLSNull"
-    | "esriSLSSolid"
-    | SimpleLineSymbolStyle;
+  type: "esriSLS";
+  style?: SimpleLineSymbolStyle;
   color?: Color;
   width?: number;
 }
@@ -190,15 +143,8 @@ export interface ISimpleLineSymbol extends ISymbol {
  *
  */
 export interface ISimpleMarkerSymbol extends IMarkerSymbol {
-  type: "esriSMS" | SymbolType.SMS;
-  style?:
-    | "esriSMSCircle"
-    | "esriSMSCross"
-    | "esriSMSDiamond"
-    | "esriSMSSquare"
-    | "esriSMSX"
-    | "esriSMSTriangle"
-    | SimpleMarkerSymbolStyle;
+  type: "esriSMS";
+  style?: SimpleMarkerSymbolStyle;
   color?: Color;
   size?: number;
   outline?: ISimpleLineSymbol;
@@ -207,43 +153,16 @@ export interface ISimpleMarkerSymbol extends IMarkerSymbol {
 /**
  *
  */
-export const enum VerticalAlignment {
-  Baseline = "baseline",
-  Top = "top",
-  Middle = "middle",
-  Bottom = "bottom"
-}
-
-export const enum HorizontalAlignment {
-  Left = "left",
-  Right = "right",
-  Center = "center",
-  Justify = "justify"
-}
-
-/**
- *
- */
 export interface ITextSymbol extends IMarkerSymbol {
-  type: "esriTS" | SymbolType.TS;
+  type: "esriTS";
   color?: Color;
   backgroundColor?: Color;
   borderLineSize?: number; // <size>;
   borderLineColor?: Color;
   haloSize?: number; // <size>;
   haloColor?: Color;
-  verticalAlignment?:
-    | "baseline"
-    | "top"
-    | "middle"
-    | "bottom"
-    | VerticalAlignment;
-  horizontalAlignment?:
-    | "left"
-    | "right"
-    | "center"
-    | "justify"
-    | HorizontalAlignment;
+  verticalAlignment?: "baseline" | "top" | "middle" | "bottom";
+  horizontalAlignment?: "left" | "right" | "center" | "justify";
   rightToLeft?: boolean;
   kerning?: boolean;
   font?: IFont;

--- a/packages/arcgis-rest-types/src/webmap.ts
+++ b/packages/arcgis-rest-types/src/webmap.ts
@@ -22,21 +22,20 @@ import {
 /**
  * Field type.
  */
-export const enum FieldType {
-  Blob = "esriFieldTypeBlob",
-  Date = "esriFieldTypeDate",
-  Double = "esriFieldTypeDouble",
-  Geometry = "esriFieldTypeGeometry",
-  GlobalID = "esriFieldTypeGlobalID",
-  GUID = "esriFieldTypeGUID",
-  Integer = "esriFieldTypeInteger",
-  OID = "esriFieldTypeOID",
-  Raster = "esriFieldTypeRaster",
-  Single = "esriFieldTypeSingle",
-  SmallInteger = "esriFieldTypeSmallInteger",
-  String = "esriFieldTypeString",
-  XML = "esriFieldTypeXML"
-}
+export type FieldType =
+  | "esriFieldTypeBlob"
+  | "esriFieldTypeDate"
+  | "esriFieldTypeDouble"
+  | "esriFieldTypeGeometry"
+  | "esriFieldTypeGlobalID"
+  | "esriFieldTypeGUID"
+  | "esriFieldTypeInteger"
+  | "esriFieldTypeOID"
+  | "esriFieldTypeRaster"
+  | "esriFieldTypeSingle"
+  | "esriFieldTypeSmallInteger"
+  | "esriFieldTypeString"
+  | "esriFieldTypeXML";
 
 /**
  * Contains information about an attribute field.
@@ -51,21 +50,7 @@ export interface IField {
   /** A string defining the field name. */
   name: string;
   /** A string defining the field type. */
-  type:
-    | "esriFieldTypeBlob"
-    | "esriFieldTypeDate"
-    | "esriFieldTypeDouble"
-    | "esriFieldTypeGeometry"
-    | "esriFieldTypeGlobalID"
-    | "esriFieldTypeGUID"
-    | "esriFieldTypeInteger"
-    | "esriFieldTypeOID"
-    | "esriFieldTypeRaster"
-    | "esriFieldTypeSingle"
-    | "esriFieldTypeSmallInteger"
-    | "esriFieldTypeString"
-    | "esriFieldTypeXML"
-    | FieldType;
+  type: FieldType;
   /** A string defining the field alias. */
   alias?: string;
   /** The domain objects if applicable. */
@@ -97,28 +82,6 @@ export interface IPagingParams {
 }
 
 /**
- * Date fields types to specify how the date should appear in popup windows
- */
-export const enum DateFormat {
-  ShortDate = "shortDate",
-  ShortDateLE = "shortDateLE",
-  LongMonthDayYear = "longMonthDayYear",
-  DayShortMonthYear = "dayShortMonthYear",
-  LongDate = "longDate",
-  ShortDateShortTime = "shortDateShortTime",
-  ShortDateLEShortTime = "shortDateLEShortTime",
-  ShortDateShortTime24 = "shortDateShortTime24",
-  ShortDateLEShortTime24 = "shortDateLEShortTime24",
-  ShortDateLongTime = "shortDateLongTime",
-  ShortDateLELongTime = "shortDateLELongTime",
-  ShortDateLongTime24 = "shortDateLongTime24",
-  ShortDateLELongTime24 = "shortDateLELongTime24",
-  LongMonthYear = "longMonthYear",
-  ShortMonthYear = "shortMonthYear",
-  Year = "year"
-}
-
-/**
  * The format object can be used with numerical or date fields to provide more detail about how values should be displayed in popup windows.
  */
 export interface IFieldFormat {
@@ -139,8 +102,7 @@ export interface IFieldFormat {
     | "shortDateLELongTime24"
     | "longMonthYear"
     | "shortMonthYear"
-    | "year"
-    | DateFormat;
+    | "year";
 
   /**
    * A Boolean used with numerical fields. A value of true allows the number to have a digit (or thousands) separator when the value appears in popup windows.


### PR DESCRIPTION
This reverts commit f3f856b61b1859eea115540131dd046f6cc1fa97, reversing
changes made to 8a2daacdf4dbf016b0e3127bfbf2f0b0cf24cdbe.

Based on this discussion https://github.com/Esri/arcgis-rest-js/issues/668#issuecomment-607912114

https://github.com/Esri/arcgis-rest-js/issues/668#issuecomment-607815745

Const Enums cannot be used by Bable transpiler.