### PR TITLE
Secure token in POST body or auth header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5278,7 +5278,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5302,13 +5303,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5325,19 +5328,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5468,7 +5474,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5482,6 +5489,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5498,6 +5506,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5506,13 +5515,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5533,6 +5544,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5621,7 +5633,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5635,6 +5648,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5730,7 +5744,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5772,6 +5787,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5793,6 +5809,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5841,13 +5858,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -287,8 +287,8 @@ export function request(
       } = {};
       
       if (fetchOptions.method === "GET") {
-        // Prevents token from being passed in query params when secureToken option is used.
-        if (params.token && options.secureToken) {
+        // Prevents token from being passed in query params when hideToken option is used.
+        if (params.token && options.hideToken) {
           requestHeaders["X-Esri-Authorization"] = `Bearer ${params.token}`
           delete params.token;
         }
@@ -307,7 +307,7 @@ export function request(
           fetchOptions.method = "POST";
 
           // Add token back to body with other params instead of header
-          if (token.length && options.secureToken) {
+          if (token.length && options.hideToken) {
             params.token = token;
             delete requestHeaders["X-Esri-Authorization"];
           }

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -287,7 +287,7 @@ export function request(
       } = {};
       
       if (fetchOptions.method === "GET") {
-        // Fetch `mode: "no-cors"` only allows a limited set of headers in the request.
+        // Prevents token from being passed in query params when secureToken option is used.
         if (params.token && options.secureToken) {
           requestHeaders["X-Esri-Authorization"] = `Bearer ${params.token}`
           delete params.token;
@@ -300,7 +300,7 @@ export function request(
 
         if (
           options.maxUrlLength &&
-            urlWithQueryString.length > options.maxUrlLength
+          urlWithQueryString.length > options.maxUrlLength
         ) {
           // the consumer specified a maximum length for URLs
           // and this would exceed it, so use post instead

--- a/packages/arcgis-rest-request/src/utils/FetchMode.ts
+++ b/packages/arcgis-rest-request/src/utils/FetchMode.ts
@@ -1,6 +1,0 @@
-/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
- * Apache-2.0 */
-/**
- * Fetch mode used by the ArcGIS REST API.
- */
-export type FetchMode = "cors" | "no-cors" | "same-origin";

--- a/packages/arcgis-rest-request/src/utils/FetchMode.ts
+++ b/packages/arcgis-rest-request/src/utils/FetchMode.ts
@@ -1,0 +1,6 @@
+/* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+/**
+ * Fetch mode used by the ArcGIS REST API.
+ */
+export type FetchMode = "cors" | "no-cors" | "same-origin";

--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -26,7 +26,7 @@ export interface IRequestOptions {
    * Prevents the token from being passed in a URL Query param that is saved in browser history.
    * Instead, the token will be passed in POST request body or through X-Esri-Authorization header
    */
-  secureToken?: boolean;
+  hideToken?: boolean;
   /**
    * Base url for the portal you want to make the request to. Defaults to 'https://www.arcgis.com/sharing/rest'.
    */

--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -1,7 +1,6 @@
 import { HTTPMethods } from "./HTTPMethods";
 import { IParams } from "./IParams";
 import { IAuthenticationManager } from "./IAuthenticationManager";
-import { FetchMode } from './FetchMode';
 
 /**
  * Options for the `request()` method.
@@ -16,10 +15,6 @@ export interface IRequestOptions {
    */
   httpMethod?: HTTPMethods;
   /**
-   * The fetch mode to send the request with.
-   */
-  fetchMode?: FetchMode;
-  /**
    * Return the raw [response](https://developer.mozilla.org/en-US/docs/Web/API/Response)
    */
   rawResponse?: boolean;
@@ -29,7 +24,7 @@ export interface IRequestOptions {
   authentication?: IAuthenticationManager;
   /**
    * Prevents the token from being passed in a URL Query param that is saved in browser history.
-   * Instead, the token will be passed in POST request body or through X-ESRI-AUTHORIZATION header
+   * Instead, the token will be passed in POST request body or through X-Esri-Authorization header
    */
   secureToken?: boolean;
   /**

--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -1,6 +1,7 @@
 import { HTTPMethods } from "./HTTPMethods";
 import { IParams } from "./IParams";
 import { IAuthenticationManager } from "./IAuthenticationManager";
+import { FetchMode } from './FetchMode';
 
 /**
  * Options for the `request()` method.
@@ -15,6 +16,10 @@ export interface IRequestOptions {
    */
   httpMethod?: HTTPMethods;
   /**
+   * The fetch mode to send the request with.
+   */
+  fetchMode?: FetchMode;
+  /**
    * Return the raw [response](https://developer.mozilla.org/en-US/docs/Web/API/Response)
    */
   rawResponse?: boolean;
@@ -22,6 +27,11 @@ export interface IRequestOptions {
    * The instance of `IAuthenticationManager` to use to authenticate this request.
    */
   authentication?: IAuthenticationManager;
+  /**
+   * Prevents the token from being passed in a URL Query param that is saved in browser history.
+   * Instead, the token will be passed in POST request body or through X-ESRI-AUTHORIZATION header
+   */
+  secureToken?: boolean;
   /**
    * Base url for the portal you want to make the request to. Defaults to 'https://www.arcgis.com/sharing/rest'.
    */

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -184,7 +184,7 @@ describe("request()", () => {
     request("https://www.arcgis.com/sharing/rest/info", {
       authentication: MOCK_AUTH,
       httpMethod: 'GET',
-      secureToken: true
+      hideToken: true
     })
       .then(response => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
@@ -213,7 +213,7 @@ describe("request()", () => {
     request(restInfoUrl, {
       authentication: MOCK_AUTH,
       httpMethod: "GET",
-      secureToken: true,
+      hideToken: true,
       // typically consumers would base maxUrlLength on browser/server limits
       // but for testing, we use an artificially low limit
       // like this one that assumes no parameters will be added


### PR DESCRIPTION
Adds two option to the IRequestOption:
- <s>`fetchMode`: specify the mode to fetch with (cors, no-cors, etc)</s>
- `secureToken`: hides the token of `GET` request in `X-Esri-Authorization` header.

Both options are disabled by default. This could become the default at a major release.

Fixes: #557 