### PR TITLE
Adding support for ISpatialReference to exportItem

### DIFF
--- a/packages/arcgis-rest-portal/src/items/export.ts
+++ b/packages/arcgis-rest-portal/src/items/export.ts
@@ -1,6 +1,7 @@
 import { request } from "@esri/arcgis-rest-request";
 import { determineOwner, IUserItemOptions } from './helpers';
 import { getPortalUrl } from "../util/get-portal-url";
+import { ISpatialReference } from '@esri/arcgis-rest-types';
 
 type ExportFormat = 'Shapefile' | 'CSV' | 'File Geodatabase' | 'Feature Collection' | 'GeoJson' | 'Scene Package' | 'KML' | 'Excel';
 
@@ -14,7 +15,7 @@ export interface IExportLayerInfo {
 
 export interface IExportParameters {
   layers: IExportLayerInfo[];
-  targetSR?: string;
+  targetSR?: ISpatialReference | string;
 }
 
 export interface IExportItemRequestOptions extends IUserItemOptions {

--- a/packages/arcgis-rest-portal/test/items/export.test.ts
+++ b/packages/arcgis-rest-portal/test/items/export.test.ts
@@ -48,7 +48,10 @@ describe("exportItem", () => {
           layers: [
             { id: 0 },
             { id: 1, where: 'POP1999 > 100000' }
-          ]
+          ],
+          targetSR: {
+            wkid: 102100
+          }
         },
         authentication
       };


### PR DESCRIPTION
This was an oversight when originally adding exportItem. This method should allow `targetSR` to be either a `string` or an instance of `ISpatialReference`.