### PR TITLE
fix(arcgis-rest-portal): use deleteRelationship not removeRelationship

### DIFF
--- a/packages/arcgis-rest-portal/src/items/remove.ts
+++ b/packages/arcgis-rest-portal/src/items/remove.ts
@@ -60,7 +60,7 @@ export function removeItemRelationship(
   return determineOwner(requestOptions).then(owner => {
     const url = `${getPortalUrl(
       requestOptions
-    )}/content/users/${owner}/removeRelationship`;
+    )}/content/users/${owner}/deleteRelationship`;
 
     const options = appendCustomParams<IManageItemRelationshipOptions>(
       requestOptions,

--- a/packages/arcgis-rest-portal/test/items/remove.test.ts
+++ b/packages/arcgis-rest-portal/test/items/remove.test.ts
@@ -96,7 +96,7 @@ describe("search", () => {
           expect(fetchMock.called()).toEqual(true);
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/removeRelationship"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/deleteRelationship"
           );
           expect(options.method).toBe("POST");
           expect(options.body).toContain("originItemId=3ef");


### PR DESCRIPTION
Previous implementation used non-existant /removeRelationship end-point. 
Changed to the correct /deleteRelationship url

AFFECTS PACKAGES:
@esri/arcgis-rest-portal

ISSUES CLOSED: #739