### PR TITLE
Move @esri/arcgis-rest-types from dependencies to devDependencies

### DIFF
--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -13,11 +13,11 @@
     "dist/**"
   ],
   "dependencies": {
-    "@esri/arcgis-rest-types": "^2.17.0",
     "tslib": "^1.13.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-request": "^2.17.0"
+    "@esri/arcgis-rest-request": "^2.17.0",
+    "@esri/arcgis-rest-types": "^2.17.0"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-request": "^2.0.0"


### PR DESCRIPTION
Moves @esri/arcgis-rest-types from `dependencies` to `devDependencies`.