### PR TITLE
C/clean up item get fns

### DIFF
--- a/packages/arcgis-rest-portal/src/items/get.ts
+++ b/packages/arcgis-rest-portal/src/items/get.ts
@@ -47,36 +47,21 @@ export function getItem(
   return request(url, options);
 }
 
-// /**
-//  * Get the fully qualified URL to the REST end point for an item.
-//  * @param item id (string) or an item object w/ `id` and `access`
-//  * @param portalUrlOrRequestOptions a portal base or API URL, a portal object, or request options containing either of those
-//  * @returns URL to the item's REST end point, defaults to `https://www.arcgis.com/sharing/rest/content/items/{itemId}?f=json`
-//  */
-// export const getItemApiLink = (
-//   itemOrId: IItem | string,
-//   portalUrlOrRequestOptions?: string | IRequestOptions
-// ) => {
-//   const baseUrl = getItemApiUrl(itemOrId, portalUrlOrRequestOptions)
-//   // TODO: append token if supplied and access is not public?
-//   return `${baseUrl}?f=json`
-// }
-
 /**
  * Get the fully qualified base URL to the REST end point for an item.
- * @param item id (string) or an item object w/ `id` and `access`
+ * @param id Item Id
  * @param portalUrlOrRequestOptions a portal URL or request options
- * @returns URL to the item's REST end point, defaults to `https://www.arcgis.com/sharing/rest/content/items/{itemId}`
+ * @returns URL to the item's REST end point, defaults to `https://www.arcgis.com/sharing/rest/content/items/{id}`
  */
 export const getItemBaseUrl = (
-  itemId: IItem | string,
+  id: string,
   portalUrlOrRequestOptions?: string | IRequestOptions
 ) => {
   const portalUrl =
     typeof portalUrlOrRequestOptions === "string"
       ? portalUrlOrRequestOptions
       : getPortalUrl(portalUrlOrRequestOptions);
-  return `${portalUrl}/content/items/${itemId}`;
+  return `${portalUrl}/content/items/${id}`;
 };
 
 /**
@@ -366,10 +351,10 @@ export function getItemInfo(
  * getItemMetadata("ae7", { authentication })
  *   .then(itemMetadataXml) // XML document as a string
  * ```
- * Get an info file for an item. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/item-info-file.htm) for more information. Currently only supports text files.
+ * Get the standard formal metadata XML file for an item (`/info/metadata/metadata.xml`)
  * @param id - Item Id
- * @param requestOptions - Options for the request, optionally including the file name which defaults to `iteminfo.xml`
- * @returns A Promise that will resolve with the contents of the info file for the item.
+ * @param requestOptions - Options for the request
+ * @returns A Promise that will resolve with the contents of the metadata file for the item as a string.
  */
 export function getItemMetadata(
   id: string,

--- a/packages/arcgis-rest-portal/src/items/helpers.ts
+++ b/packages/arcgis-rest-portal/src/items/helpers.ts
@@ -53,6 +53,17 @@ export type ItemRelationshipType =
   | "TrackView2Map"
   | "SurveyAddIn2Data";
 
+/**
+ * Names of methods for reading the body of a fetch response, see:
+ * https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods
+ */
+export type FetchReadMethodName =
+  | "arrayBuffer"
+  | "blob"
+  | "formData"
+  | "json"
+  | "text";
+
 export interface IItemRelationshipOptions extends IRequestOptions {
   /**
    * Unique identifier of the item.
@@ -83,18 +94,6 @@ export interface IItemInfoOptions extends IUserItemOptions {
    * Object to store
    */
   file: any;
-}
-
-export interface IGetItemInfoOptions extends IRequestOptions {
-  /**
-   * Name of the info file, optionally including the folder path
-   */
-  fileName?: string;
-  /**
-   * How the fetch response should be read, see:
-   * https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods
-   */
-  readAs?: "arrayBuffer" | "blob" | "formData" | "json" | "text";
 }
 
 export interface IItemResourceOptions extends IUserItemOptions {

--- a/packages/arcgis-rest-portal/test/items/get.test.ts
+++ b/packages/arcgis-rest-portal/test/items/get.test.ts
@@ -4,6 +4,7 @@
 import * as fetchMock from "fetch-mock";
 
 import {
+  IGetItemInfoOptions,
   getItemBaseUrl,
   getItem,
   getItemData,
@@ -30,7 +31,6 @@ import { GetItemResourcesResponse } from "../mocks/items/resources";
 
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { TOMORROW } from "@esri/arcgis-rest-auth/test/utils";
-import { IGetItemInfoOptions } from "../../src/items/helpers";
 
 describe("get base url", () => {
   it("should return base url when passed a portal url", () => {


### PR DESCRIPTION
The new, private `getItemFile()` function has been refactored out of `getItemInfo()` so that it can be used to support something like `getItemResource('4ef', { fileName: 'folder/file.info', readAs: 'text' })`, similar to the [`getItemInfo()` API](https://esri.github.io/arcgis-rest-js/api/portal/getItemInfo/).