### PR TITLE
FEAT: Add postMessage auth wrappers

### DIFF
--- a/docs/src/guides/embedded-apps.md
+++ b/docs/src/guides/embedded-apps.md
@@ -1,0 +1,95 @@
+---
+title: Passing Authentication to iFramed apps
+navTitle: Embedded Authentication
+description: Learn how to pass authentication into iframe embedded applications.
+order: 50
+group: 2-authentication
+---
+
+**Note** This is a new api feature, and currently there are *no* platform applications that support the authentication flows discussed in this guide. However, this guide exists to help other platform app teams add this functionality to their apps.
+
+# Authentication with Embedded Applications
+
+Sometimes an application will need to embed another application using an `<iframe>`. If both applications are backed by items that are publicly accessible, things will just work.
+
+But, if the "Host" application is not public and the embedded application is not public, we then run into the question of how to pass authentication from the "Host" to the embedded application.
+
+### Cross Origin Embedding
+Cross-Origin embedding occurs when the "host" app and the "embedded" application are served from different locations. This is only supported for ArcGIS Platform apps that support embedding.
+
+
+For example, you can build a custom app, hosted at `http://myapp.com` and iframe in a "platform app" that supports embedding. However, you can not embed your custom app into a storymap, and expect the storymap to pass authentication to your app. This is done for security reasons.
+
+
+## Using `postMessage` 
+The browser's `postMessage` api is designed to allow communication between various "frames" in a page, and it is how this works internally. You can read more about [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) at the Mozilla Developer Network.
+
+# Authentication Flow
+We will walk through the flows at a high-level
+
+## 1 Host App uses oAuth
+
+The application acting as the host, should use oAuth to autentication the user, and *before* rendering the iframe with the embedded application it must call `session.enablePostMessageAuth(validOrigins)`. This sets up an event handler that will process the requests from the embedded applications.
+
+The `validOrigins` argument is an array of "orgins" your app expects to get auth requests from. **NOTE** This should be a constrained list of just the domains this particular application will actually be embedding.
+
+```js
+  // register your own app to create a unique clientId
+  const clientId = "abc123"
+
+  UserSession.beginOAuth2({
+    clientId,
+    redirectUri: 'https://yourapp.com/authenticate.html'
+  })
+  .then(session => {
+    // for this example we will only send auth to embeds hosted on storymaps.arcgis.com
+    const validOrigins = ['https://storymaps.arcgis.com'];
+    session.enablePostMessageAuth(validOrigins);
+  })
+```
+
+#### 2  Host App adds params to embed url
+Let's suppose the host app is embedding `https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd`. To tell the embedded app that it should request authentication from the parent we need to add two url parameters:
+
+- `embed=iframe` - tells the app it's embedded in an iframe. This allows the app to make ui changes like hiding headers etc
+- `parentOrigin=https://myapp.com` - this tells the app what 'origin' to expect messages from, and also to ignore other origins. **note** this should be uri encoded
+
+```js
+const originalUrl = 'https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd';
+const embedUrl = `${originalurl}?embed=true&parentOrigin=${encodeURIComponent(window.location.origin)}`;
+// then use embedUrl in your component that renders the <iframe>
+```
+
+#### 3 Embed App boots and Requests Auth
+In the embedded application, early in it's boot sequence it should read the query string parameters and make the determintation that it is running inside an iframe, and that it can request authentication information from the parent. 
+
+```js
+  // Parse up any url params
+  let params = new URLSearchParams(document.location.search.substring(1));
+  const embedStyle = params.get('embed');
+  const parentOrigin = params.get('parentOrigin'); 
+  if (embedStyle === 'iframe' && parentOrigin) {
+    UserSession.fromParent(parentOrigin)
+    .then((session) => {
+      // session is a UserSession instance, populated from the parent app
+      // the embeded app should exchange this token for one specific to the application
+    })
+    .catch((ex) => {
+      // if the origin of the embedded app is not in the parent's validOrigin array
+      // this will throw with a message "Rejected authentication request."
+    })
+  }
+```
+
+#### 4 Parent App Transitions Away
+If the parent app has the ability to transition to another route (i.e. an Angular, Ember, React etc app with a router) then **before** the transition occurs, the postMessage event listener must be disposed of. Unfortuately we can't automate this inside ArcGIS Rest Js as it will require using the life-cycle hooks of your application framework. The example below uses the `disconnectedCallback` that is part of the Stenci.js component life-cycle.
+
+```js
+  // Use your framework's hooks...
+  disconnectedCallback () {
+    // stop listening for requests from children
+    state.session.disablePostMessageAuth();
+  }
+```
+
+

--- a/docs/src/guides/embedded-apps.md
+++ b/docs/src/guides/embedded-apps.md
@@ -68,7 +68,7 @@ In the embedded application, early in it's boot sequence it should read the quer
   let params = new URLSearchParams(document.location.search.substring(1));
   const useEmbedAuth = params.get('arcgis-auth-embed');
   const parentOrigin = params.get('parentOrigin'); 
-  if (useEmbedAuth && parentOrigin) {
+  if (useEmbedAuth === "true" && parentOrigin) {
     UserSession.fromParent(parentOrigin)
     .then((session) => {
       // session is a UserSession instance, populated from the parent app
@@ -91,4 +91,3 @@ If the parent app has the ability to transition to another route (i.e. an Angula
     state.session.disablePostMessageAuth();
   }
 ```
-

--- a/docs/src/guides/embedded-apps.md
+++ b/docs/src/guides/embedded-apps.md
@@ -12,7 +12,7 @@ group: 2-authentication
 
 Sometimes an application will need to embed another application using an `<iframe>`. If both applications are backed by items that are publicly accessible, things will just work.
 
-But, if the "Host" application is not public and the embedded application is not public, we then run into the question of how to pass authentication from the "Host" to the embedded application.
+However, if the embedded application is not public and the user has already logged into the "Host" application, we then run into the question of how to pass authentication from the "Host" to the embedded application.
 
 ### Cross Origin Embedding
 Cross-Origin embedding occurs when the "host" app and the "embedded" application are served from different locations. This is only supported for ArcGIS Platform apps that support embedding.

--- a/docs/src/guides/embedded-apps.md
+++ b/docs/src/guides/embedded-apps.md
@@ -51,12 +51,11 @@ The `validOrigins` argument is an array of "orgins" your app expects to get auth
 #### 2  Host App adds params to embed url
 Let's suppose the host app is embedding `https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd`. To tell the embedded app that it should request authentication from the parent we need to add two url parameters:
 
-- `arcgis-auth-embed=true` - tells the app it's embedded in an iframe and should request auth from the parent. This allows the app to make ui changes like hiding headers etc
-- `parentOrigin=https://myapp.com` - this tells the app what 'origin' to expect messages from, what origin to post messages to, and also to ignore other origins. **note** this should be uri encoded
+- `arcgis-auth-origin=https://myapp.com` - this tells the app what 'origin' to expect messages from, what origin to post messages to, and also to ignore other origins. **note** this should be uri encoded
 
 ```js
 const originalUrl = 'https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd';
-const embedUrl = `${originalurl}?arcgis-auth-embed=true&parentOrigin=${encodeURIComponent(window.location.origin)}`;
+const embedUrl = `${originalurl}?arcgis-auth-origin=${encodeURIComponent(window.location.origin)}`;
 // then use embedUrl in your component that renders the <iframe>
 ```
 
@@ -66,10 +65,9 @@ In the embedded application, early in it's boot sequence it should read the quer
 ```js
   // Parse up any url params
   let params = new URLSearchParams(document.location.search.substring(1));
-  const useEmbedAuth = params.get('arcgis-auth-embed');
-  const parentOrigin = params.get('parentOrigin'); 
-  if (useEmbedAuth === "true" && parentOrigin) {
-    UserSession.fromParent(parentOrigin)
+  const arcgisAuthOrigin = params.get('arcgis-auth-origin'); 
+  if (arcgisAuthOrigin) {
+    UserSession.fromParent(arcgisAuthOrigin)
     .then((session) => {
       // session is a UserSession instance, populated from the parent app
       // the embeded app should exchange this token for one specific to the application

--- a/docs/src/guides/embedded-apps.md
+++ b/docs/src/guides/embedded-apps.md
@@ -66,9 +66,9 @@ In the embedded application, early in it's boot sequence it should read the quer
 ```js
   // Parse up any url params
   let params = new URLSearchParams(document.location.search.substring(1));
-  const embedStyle = params.get('embed');
+  const useEmbedAuth = params.get('arcgis-auth-embed');
   const parentOrigin = params.get('parentOrigin'); 
-  if (embedStyle === 'iframe' && parentOrigin) {
+  if (useEmbedAuth && parentOrigin) {
     UserSession.fromParent(parentOrigin)
     .then((session) => {
       // session is a UserSession instance, populated from the parent app

--- a/docs/src/guides/embedded-apps.md
+++ b/docs/src/guides/embedded-apps.md
@@ -51,12 +51,12 @@ The `validOrigins` argument is an array of "orgins" your app expects to get auth
 #### 2  Host App adds params to embed url
 Let's suppose the host app is embedding `https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd`. To tell the embedded app that it should request authentication from the parent we need to add two url parameters:
 
-- `embed=iframe` - tells the app it's embedded in an iframe. This allows the app to make ui changes like hiding headers etc
+- `arcgis-auth-embed=true` - tells the app it's embedded in an iframe and should request auth from the parent. This allows the app to make ui changes like hiding headers etc
 - `parentOrigin=https://myapp.com` - this tells the app what 'origin' to expect messages from, what origin to post messages to, and also to ignore other origins. **note** this should be uri encoded
 
 ```js
 const originalUrl = 'https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd';
-const embedUrl = `${originalurl}?embed=true&parentOrigin=${encodeURIComponent(window.location.origin)}`;
+const embedUrl = `${originalurl}?arcgis-auth-embed=true&parentOrigin=${encodeURIComponent(window.location.origin)}`;
 // then use embedUrl in your component that renders the <iframe>
 ```
 

--- a/docs/src/guides/embedded-apps.md
+++ b/docs/src/guides/embedded-apps.md
@@ -29,7 +29,7 @@ We will walk through the flows at a high-level
 
 ## 1 Host App uses oAuth
 
-The application acting as the host, should use oAuth to authenticate the user, and *before* rendering the iframe with the embedded application it must call `session.enablePostMessageAuth(validOrigins)`. This sets up an event handler that will process the requests from the embedded applications.
+The application acting as the host, should use oAuth to authenticate the user, and *before* rendering the iframe with the embedded application it must call `session.enablePostMessageAuth(validOrigins)`. This sets up a listener that will process the requests from the embedded application(s).
 
 The `validOrigins` argument is an array of "orgins" your app expects to get auth requests from. **NOTE** This should be a constrained list of just the domains this particular application will actually be embedding.
 

--- a/docs/src/guides/embedded-apps.md
+++ b/docs/src/guides/embedded-apps.md
@@ -29,7 +29,7 @@ We will walk through the flows at a high-level
 
 ## 1 Host App uses oAuth
 
-The application acting as the host, should use oAuth to autentication the user, and *before* rendering the iframe with the embedded application it must call `session.enablePostMessageAuth(validOrigins)`. This sets up an event handler that will process the requests from the embedded applications.
+The application acting as the host, should use oAuth to authenticate the user, and *before* rendering the iframe with the embedded application it must call `session.enablePostMessageAuth(validOrigins)`. This sets up an event handler that will process the requests from the embedded applications.
 
 The `validOrigins` argument is an array of "orgins" your app expects to get auth requests from. **NOTE** This should be a constrained list of just the domains this particular application will actually be embedding.
 
@@ -52,7 +52,7 @@ The `validOrigins` argument is an array of "orgins" your app expects to get auth
 Let's suppose the host app is embedding `https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd`. To tell the embedded app that it should request authentication from the parent we need to add two url parameters:
 
 - `embed=iframe` - tells the app it's embedded in an iframe. This allows the app to make ui changes like hiding headers etc
-- `parentOrigin=https://myapp.com` - this tells the app what 'origin' to expect messages from, and also to ignore other origins. **note** this should be uri encoded
+- `parentOrigin=https://myapp.com` - this tells the app what 'origin' to expect messages from, what origin to post messages to, and also to ignore other origins. **note** this should be uri encoded
 
 ```js
 const originalUrl = 'https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd';
@@ -91,5 +91,4 @@ If the parent app has the ability to transition to another route (i.e. an Angula
     state.session.disablePostMessageAuth();
   }
 ```
-
 

--- a/docs/src/guides/embedded-apps.md
+++ b/docs/src/guides/embedded-apps.md
@@ -51,7 +51,7 @@ The `validOrigins` argument is an array of "orgins" your app expects to get auth
 #### 2  Host App adds params to embed url
 Let's suppose the host app is embedding `https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd`. To tell the embedded app that it should request authentication from the parent we need to add two url parameters:
 
-- `arcgis-auth-origin=https://myapp.com` - this tells the app what 'origin' to expect messages from, what origin to post messages to, and also to ignore other origins. **note** this should be uri encoded
+- `arcgis-auth-origin=https://myapp.com` - This tells the app it's embedded in an iframe and should request auth from the parent, and what 'origin' to expect messages from, what origin to post messages to, and also to ignore other origins. **note** this should be uri encoded
 
 ```js
 const originalUrl = 'https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd';
@@ -79,8 +79,10 @@ In the embedded application, early in it's boot sequence it should read the quer
   }
 ```
 
-#### 4 Parent App Transitions Away
-If the parent app has the ability to transition to another route (i.e. an Angular, Ember, React etc app with a router) then **before** the transition occurs, the postMessage event listener must be disposed of. Unfortuately we can't automate this inside ArcGIS Rest Js as it will require using the life-cycle hooks of your application framework. The example below uses the `disconnectedCallback` that is part of the Stenci.js component life-cycle.
+#### Clean up
+While rest-js will attempt to clean up the listeners automatically, if the host application is no longer going to render the iframe before the embedded app has had a chance to request the authentication, then the app should manually clean up the listener by calling `session.disablePostMessageAuth()`
+
+Typically you would make this call in the life-cycle hooks of your application framework (i.e. an Angular, Ember, React etc app with a router). The example below uses the `disconnectedCallback` that is part of the Stenci.js component life-cycle.
 
 ```js
   // Use your framework's hooks...

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -257,6 +257,34 @@ export interface IUserSessionOptions {
  * Used to authenticate both ArcGIS Online and ArcGIS Enterprise users. `UserSession` includes helper methods for [OAuth 2.0](/arcgis-rest-js/guides/browser-authentication/) in both browser and server applications.
  */
 export class UserSession implements IAuthenticationManager {
+
+  /**
+   * The current ArcGIS Online or ArcGIS Enterprise `token`.
+   */
+  get token() {
+    return this._token;
+  }
+
+  /**
+   * The expiration time of the current `token`.
+   */
+  get tokenExpires() {
+    return this._tokenExpires;
+  }
+
+  /**
+   * The current token to ArcGIS Online or ArcGIS Enterprise.
+   */
+  get refreshToken() {
+    return this._refreshToken;
+  }
+
+  /**
+   * The expiration time of the current `refreshToken`.
+   */
+  get refreshTokenExpires() {
+    return this._refreshTokenExpires;
+  }
   /**
    * Begins a new browser-based OAuth 2.0 sign in. If `options.popup` is `true` the
    * authentication window will open in a new tab/window otherwise the user will
@@ -484,21 +512,6 @@ export class UserSession implements IAuthenticationManager {
   }
 
   /**
-   * Handle the response from the parent
-   * @param event DOM Event
-   */
-  private static parentMessageHandler (event:any):UserSession {
-    if (event.data.type === 'arcgis:auth:credential') {
-      return UserSession.fromCredential(event.data.credential);
-    }
-    if (event.data.type === 'arcgis:auth:rejected') {
-      throw new Error(event.data.message);
-    } else {
-      throw new Error('Unknown message type.');
-    }
-  }
-
-  /**
    * Begins a new server-based OAuth 2.0 sign in. This will redirect the user to
    * the ArcGIS Online or ArcGIS Enterprise authorization page.
    *
@@ -608,6 +621,21 @@ export class UserSession implements IAuthenticationManager {
   }
 
   /**
+   * Handle the response from the parent
+   * @param event DOM Event
+   */
+  private static parentMessageHandler (event:any):UserSession {
+    if (event.data.type === 'arcgis:auth:credential') {
+      return UserSession.fromCredential(event.data.credential);
+    }
+    if (event.data.type === 'arcgis:auth:rejected') {
+      throw new Error(event.data.message);
+    } else {
+      throw new Error('Unknown message type.');
+    }
+  }
+
+  /**
    * Client ID being used for authentication if provided in the `constructor`.
    */
   public readonly clientId: string;
@@ -694,33 +722,7 @@ export class UserSession implements IAuthenticationManager {
     };
   };
 
-  /**
-   * The current ArcGIS Online or ArcGIS Enterprise `token`.
-   */
-  get token() {
-    return this._token;
-  }
-
-  /**
-   * The expiration time of the current `token`.
-   */
-  get tokenExpires() {
-    return this._tokenExpires;
-  }
-
-  /**
-   * The current token to ArcGIS Online or ArcGIS Enterprise.
-   */
-  get refreshToken() {
-    return this._refreshToken;
-  }
-
-  /**
-   * The expiration time of the current `refreshToken`.
-   */
-  get refreshTokenExpires() {
-    return this._refreshTokenExpires;
-  }
+  private hostHandler: any;
 
   constructor(options: IUserSessionOptions) {
     this.clientId = options.clientId;
@@ -869,31 +871,6 @@ export class UserSession implements IAuthenticationManager {
   public serialize() {
     return JSON.stringify(this);
   }
-
-  private hostHandler: any;
-  /**
-   * Return a function that closes over the validOrigins array and 
-   * can be used as an event handler for the `message` event
-   * 
-   * @param validOrigins Array of valid origins
-   */
-  private createPostMessageHandler (
-    validOrigins: string[]
-  ): (event:any) => void {
-    // return a function that closes over the validOrigins and
-    // has access to the credential
-    return (event:any) => {
-      // Note: do not use regex's here. validOrigins is an array so we're checking that the event's origin
-      // is in the array via exact match. More info about avoiding postMessave xss issues here
-      // https://jlajara.gitlab.io/web/2020/07/17/Dom_XSS_PostMessage_2.html#tipsbypasses-in-postmessage-vulnerabilities
-      if (validOrigins.indexOf(event.origin) > -1) {
-        const credential = this.toCredential();
-        event.source.postMessage({type: 'arcgis:auth:credential', credential}, event.origin);
-      } else {
-        event.source.postMessage({type: 'arcgis:auth:rejected', message: `Rejected authentication request.`}, event.origin);
-      }
-    }
-  }
   /**
    * For a "Host" app that embeds other platform apps via iframes, after authenticating the user
    * and creating a UserSession, the app can then enable "post message" style authentication by calling
@@ -960,6 +937,29 @@ export class UserSession implements IAuthenticationManager {
     // only the domain is lowercased becasue in some cases an org id might be
     // in the path which cannot be lowercased.
     return `${protocol}${domain.toLowerCase()}/${path.join("/")}`;
+  }
+  /**
+   * Return a function that closes over the validOrigins array and 
+   * can be used as an event handler for the `message` event
+   * 
+   * @param validOrigins Array of valid origins
+   */
+  private createPostMessageHandler (
+    validOrigins: string[]
+  ): (event:any) => void {
+    // return a function that closes over the validOrigins and
+    // has access to the credential
+    return (event:any) => {
+      // Note: do not use regex's here. validOrigins is an array so we're checking that the event's origin
+      // is in the array via exact match. More info about avoiding postMessave xss issues here
+      // https://jlajara.gitlab.io/web/2020/07/17/Dom_XSS_PostMessage_2.html#tipsbypasses-in-postmessage-vulnerabilities
+      if (validOrigins.indexOf(event.origin) > -1) {
+        const credential = this.toCredential();
+        event.source.postMessage({type: 'arcgis:auth:credential', credential}, event.origin);
+      } else {
+        event.source.postMessage({type: 'arcgis:auth:rejected', message: `Rejected authentication request.`}, event.origin);
+      }
+    }
   }
 
   /**

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -470,7 +470,8 @@ export class UserSession implements IAuthenticationManager {
             return reject(err);
           }
         } else {
-          return reject(new Error('Rejected authentication request.'));
+          // just resolve, but do nothing
+          return resolve(null);
         }
       };
       // add listener

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -458,20 +458,19 @@ export class UserSession implements IAuthenticationManager {
     }
     // Declar handler outside of promise scope so we can detach it
     let handler: (event: any) => void;
-    // return a promise...
+    // return a promise that will resolve when the handler recieves
+    // session information from the correct origin
     return new Promise((resolve, reject) => {
       // create an event handler that just wraps the parentMessageHandler
       handler = (event:any) => {
         // ensure we only listen to events from the specified parent
+        // if the origin is not the parent origin, we don't send any response
         if (event.origin === parentOrigin){
           try {
             return resolve(UserSession.parentMessageHandler(event));
           } catch (err) {
             return reject(err);
           }
-        } else {
-          // just resolve, but do nothing
-          return resolve(null);
         }
       };
       // add listener

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -722,7 +722,7 @@ export class UserSession implements IAuthenticationManager {
     };
   };
 
-  private hostHandler: any;
+  private _hostHandler: any;
 
   constructor(options: IUserSessionOptions) {
     this.clientId = options.clientId;
@@ -885,8 +885,8 @@ export class UserSession implements IAuthenticationManager {
     if (!win && window) {
       win = window;
     }
-    this.hostHandler = this.createPostMessageHandler(validChildOrigins);
-    win.addEventListener('message',this.hostHandler , false);
+    this._hostHandler = this.createPostMessageHandler(validChildOrigins);
+    win.addEventListener('message',this._hostHandler , false);
   }
 
   /**
@@ -899,7 +899,7 @@ export class UserSession implements IAuthenticationManager {
     if (!win && window) {
       win = window;
     }
-    win.removeEventListener('message', this.hostHandler, false);
+    win.removeEventListener('message', this._hostHandler, false);
   }
 
   /**

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1185,7 +1185,7 @@ describe("UserSession", () => {
       });
     });
 
-    it('.fromParent rejects if not parentOrigin', () => { 
+    it('.fromParent resolves with nothing if not parentOrigin', () => { 
       // create a mock window that will fire the handler
       const Win = {
         _fn: (evt:any) => {},
@@ -1201,9 +1201,12 @@ describe("UserSession", () => {
       }
 
       return UserSession.fromParent('https://origin.com', Win)
-      .catch((err) => {
-        expect(err.message).toBe('Rejected authentication request.', 'Should reject');
+      .then((resp) => {
+        expect(resp).toBe(null, 'should resolve with null');
       })
+      // .catch((err) => {
+      //   expect(err.message).toBe('Rejected authentication request.', 'Should reject');
+      // })
     });
 
     it('.fromParent rejects if invlid cred', () => { 

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1185,27 +1185,6 @@ describe("UserSession", () => {
       });
     });
 
-    xit('.fromParent resolves with nothing if not parentOrigin', () => { 
-      // create a mock window that will fire the handler
-      const Win = {
-        _fn: (evt:any) => {},
-        addEventListener: function (evt:any, fn:any) {
-          Win._fn = fn;
-        },
-        removeEventListener: function () {},
-        parent: {
-          postMessage: function (msg: any, origin:string) {
-            Win._fn({origin: 'https://notorigin.com', data: {type: 'arcgis:auth:credential', credential: cred }});
-          }
-        }
-      }
-
-      return UserSession.fromParent('https://origin.com', Win)
-      .then((resp) => {
-        expect(resp).toBe(null, 'should resolve with null');
-      });
-    });
-
     it('.fromParent ignores other messages, then intercepts the correct one', async () => { 
       // create a mock window that will fire the handler
       const Win = {

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1203,10 +1203,7 @@ describe("UserSession", () => {
       return UserSession.fromParent('https://origin.com', Win)
       .then((resp) => {
         expect(resp).toBe(null, 'should resolve with null');
-      })
-      // .catch((err) => {
-      //   expect(err.message).toBe('Rejected authentication request.', 'Should reject');
-      // })
+      });
     });
 
     it('.fromParent rejects if invlid cred', () => { 

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1,6 +1,8 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+
+/* tslint:disable:no-empty */
 import { UserSession } from "../src/index";
 import { ICredential } from "../src/UserSession";
 
@@ -1092,7 +1094,7 @@ describe("UserSession", () => {
   });
 
   describe('postmessage auth :: ', () => { 
-    let MockWindow = {
+    const MockWindow = {
       addEventListener: () => {},
       removeEventListener: () => {},
       parent: {
@@ -1128,11 +1130,11 @@ describe("UserSession", () => {
       // that will hold the passed in event handler so we can fire it manually
       const Win = {
         _fn: (evt:any) => {},
-        addEventListener: function (evt:any, fn:any) {
+        addEventListener (evt:any, fn:any) {
           // enablePostMessageAuth passes in the handler, which is what we're actually testing
           Win._fn = fn;
         },
-        removeEventListener: function () {},
+        removeEventListener () {},
       }
       // Create the session
       const session = UserSession.fromCredential(cred);
@@ -1140,25 +1142,25 @@ describe("UserSession", () => {
       session.enablePostMessageAuth(['https://storymaps.arcgis.com'], Win);
       // create an event object, with a matching origin
       // an a source.postMessage fn that we can spy on
-      const evt = {
+      const event = {
         origin: 'https://storymaps.arcgis.com',
         source: {
-          postMessage: function (msg: any, origin: string) {}
+          postMessage (msg: any, origin: string) {}
         }
       }
       // create the spy
-      const sourceSpy = spyOn(evt.source, 'postMessage');
+      const sourceSpy = spyOn(event.source, 'postMessage');
       // Now, fire the handler, simulating what happens when a postMessage event comes
       // from an embedded iframe
-      Win._fn(evt);
+      Win._fn(event);
       // Expectations...
       expect(sourceSpy.calls.count()).toBe(1, 'souce.postMessage should be called in handler');
       const args = sourceSpy.calls.argsFor(0);
       expect(args[0].type).toBe('arcgis:auth:credential', 'should send credential type');
       expect(args[0].credential.userId).toBe('jsmith', 'should send credential');
       // now the case where it's not a valid origin
-      evt.origin = 'https://evil.com';
-      Win._fn(evt);
+      event.origin = 'https://evil.com';
+      Win._fn(event);
       expect(sourceSpy.calls.count()).toBe(2, 'souce.postMessage should be called in handler');
       const args2 = sourceSpy.calls.argsFor(1);
       expect(args2[0].type).toBe('arcgis:auth:rejected', 'should send reject');
@@ -1168,12 +1170,12 @@ describe("UserSession", () => {
       // create a mock window that will fire the handler
       const Win = {
         _fn: (evt:any) => {},
-        addEventListener: function (evt:any, fn:any) {
+        addEventListener (evt:any, fn:any) {
           Win._fn = fn;
         },
-        removeEventListener: function () {},
+        removeEventListener () {},
         parent: {
-          postMessage: function (msg: any, origin:string) {
+          postMessage (msg: any, origin:string) {
             Win._fn({origin: 'https://origin.com', data: {type: 'arcgis:auth:credential', credential: cred }});
           }
         }
@@ -1189,12 +1191,12 @@ describe("UserSession", () => {
       // create a mock window that will fire the handler
       const Win = {
         _fn: (evt:any) => {},
-        addEventListener: function (evt:any, fn:any) {
+        addEventListener (evt:any, fn:any) {
           Win._fn = fn;
         },
-        removeEventListener: function () {},
+        removeEventListener () {},
         parent: {
-          postMessage: function (msg: any, origin:string) {
+          postMessage (msg: any, origin:string) {
             // fire one we intend to ignore
             Win._fn({origin: 'https://notorigin.com', data: {type: 'other:random', foo: {bar:"baz"} }});
             // fire a second we want to intercept
@@ -1213,12 +1215,12 @@ describe("UserSession", () => {
       // create a mock window that will fire the handler
       const Win = {
         _fn: (evt:any) => {},
-        addEventListener: function (evt:any, fn:any) {
+        addEventListener (evt:any, fn:any) {
           Win._fn = fn;
         },
-        removeEventListener: function () {},
+        removeEventListener () {},
         parent: {
-          postMessage: function (msg: any, origin:string) {
+          postMessage (msg: any, origin:string) {
             Win._fn({origin: 'https://origin.com', data: {type: 'arcgis:auth:credential', credential: {foo:"bar"} }});
           }
         }
@@ -1234,12 +1236,12 @@ describe("UserSession", () => {
       // create a mock window that will fire the handler
       const Win = {
         _fn: (evt:any) => {},
-        addEventListener: function (evt:any, fn:any) {
+        addEventListener (evt:any, fn:any) {
           Win._fn = fn;
         },
-        removeEventListener: function () {},
+        removeEventListener () {},
         parent: {
-          postMessage: function (msg: any, origin:string) {
+          postMessage (msg: any, origin:string) {
             Win._fn({origin: 'https://origin.com', data: {type: 'arcgis:auth:rejected', message: 'Rejected authentication request.'}});
           }
         }
@@ -1255,12 +1257,12 @@ describe("UserSession", () => {
       // create a mock window that will fire the handler
       const Win = {
         _fn: (evt:any) => {},
-        addEventListener: function (evt:any, fn:any) {
+        addEventListener (evt:any, fn:any) {
           Win._fn = fn;
         },
-        removeEventListener: function () {},
+        removeEventListener () {},
         parent: {
-          postMessage: function (msg: any, origin:string) {
+          postMessage (msg: any, origin:string) {
             Win._fn({origin: 'https://origin.com', data: {type: 'arcgis:auth:other'}});
           }
         }

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1228,7 +1228,7 @@ describe("UserSession", () => {
 
       return UserSession.fromParent('https://origin.com', Win)
       .catch((err) => {
-        expect(err.message).toBe("Cannot read property 'includes' of undefined", 'Should reject');
+        expect(err).toBeDefined('Should reject');
       })
     });
 

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1249,7 +1249,7 @@ describe("UserSession", () => {
 
       return UserSession.fromParent('https://origin.com', Win)
       .catch((err) => {
-        expect(err.message).toBe("Rejected authentication request.", 'Should reject');
+        expect(err).toBeDefined('Should reject');
       })
     });
 


### PR DESCRIPTION
Adds static and instance methods to UserSession to support `postMessage` based authentication.

Adds a Guide to docs re: how to work with this

Note: The message types and payloads have been reviewed in internal meetings