### PR TITLE
fix(arcgis-rest-portal): do not do any membership adjustments if the …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1667,7 +1667,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "backo2": {
@@ -2429,7 +2429,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
@@ -2985,7 +2985,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -3585,7 +3585,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "conventional-changelog": {
@@ -5034,7 +5034,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -5478,7 +5478,7 @@
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
     "domelementtype": {
@@ -5949,7 +5949,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -7515,7 +7515,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
@@ -7649,7 +7649,7 @@
     "has-binary2": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-      "integrity": "sha1-d3asYn8+p3JQz8My2rfd9eT10R0=",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
       "dev": true,
       "requires": {
         "isarray": "2.0.1"
@@ -8890,7 +8890,7 @@
     "is-number-like": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
-      "integrity": "sha1-LhKWILUIkQQuROm7uzBZPnXPu+M=",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "dev": true,
       "requires": {
         "lodash.isfinite": "^3.3.2"
@@ -10997,7 +10997,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -13037,7 +13037,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
     "process": {
@@ -13142,7 +13142,7 @@
     "qjobs": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
-      "integrity": "sha1-xF6cYYAL0IfviNfiVkI73Unl0HE=",
+      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
       "dev": true
     },
     "qs": {
@@ -13210,7 +13210,7 @@
     "randomfill": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
@@ -13406,7 +13406,7 @@
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.18.0",
@@ -13502,7 +13502,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "through2": {
@@ -14156,7 +14156,7 @@
     "send": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -14204,7 +14204,7 @@
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY=",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
           "dev": true
         },
         "ms": {
@@ -14222,7 +14222,7 @@
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic=",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -14298,7 +14298,7 @@
     "serve-static": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha1-CV6Ecv1bRiN9tQzkhqQ/S4bGzsE=",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
@@ -16396,7 +16396,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wordwrap": {

--- a/packages/arcgis-rest-portal/test/sharing/share-item-with-group.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/share-item-with-group.test.ts
@@ -1027,7 +1027,7 @@ describe("shareItemWithGroup() ::", () => {
           "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/removeUsers",
           { notRemoved: [] }
         );
-  
+
       return shareItemWithGroup({
         authentication: MOCK_USER_SESSION,
         id: "n3v",
@@ -1044,7 +1044,7 @@ describe("shareItemWithGroup() ::", () => {
           );
           expect(shareOptions.body).toContain("groups=t6b");
           expect(shareOptions.body).toContain("confirmItemControl=true");
-  
+
           done();
         })
         .catch(e => {
@@ -1095,7 +1095,7 @@ describe("shareItemWithGroup() ::", () => {
           "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/removeUsers",
           { throws: true }
         );
-  
+
       return shareItemWithGroup({
         authentication: MOCK_USER_SESSION,
         id: "n3v",
@@ -1112,7 +1112,7 @@ describe("shareItemWithGroup() ::", () => {
           );
           expect(shareOptions.body).toContain("groups=t6b");
           expect(shareOptions.body).toContain("confirmItemControl=true");
-  
+
           done();
         })
         .catch(e => {
@@ -1261,6 +1261,60 @@ describe("shareItemWithGroup() ::", () => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
+          done();
+        })
+        .catch(e => {
+          fail();
+        });
+    });
+  });
+  describe("share item to admin user's favorites group ::", () => {
+    it("should share item", done => {
+      fetchMock
+        .once(
+          "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
+          {
+            ...OrgAdminUserResponse,
+            favGroupId: "t6b"
+          }
+        )
+        .once(
+          "https://myorg.maps.arcgis.com/sharing/rest/search",
+          NoResultsSearchResponse
+        )
+        .get(
+          "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b?f=json&token=fake-token",
+          GroupOwnerResponse
+        )
+        .once(
+          "https://myorg.maps.arcgis.com/sharing/rest/community/users/casey?f=json&token=fake-token",
+          {
+            username: "casey",
+            orgId: "qWAReEOCnD7eTxOe",
+            groups: [] as any[]
+          }
+        )
+        .post(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+          { notSharedWith: [], itemId: "n3v" }
+        );
+
+      shareItemWithGroup({
+        authentication: MOCK_USER_SESSION,
+        id: "n3v",
+        groupId: "t6b",
+        owner: "casey"
+      })
+        .then(result => {
+          expect(fetchMock.done()).toBeTruthy(
+            "All fetchMocks should have been called"
+          );
+          // verify we shared the item
+          const shareOptions: RequestInit = fetchMock.lastOptions(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+          );
+          expect(shareOptions.body).toContain("groups=t6b");
+
           done();
         })
         .catch(e => {


### PR DESCRIPTION
…group is the user's favorites group

I discovered that if an org admin attempted to share an item they do not own with their own favorites group, it will fail. This is because we are expecting all of a user's groups to be in the groups array on the user. However, it seems that the user's favorites group is not in the groups array.

AFFECTS PACKAGES:
@esri/arcgis-rest-portal