### PR TITLE
feat(auth): add functions to help with removal of esri_auth cookie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ notifications:
   slack:
     secure: KghYpsaoCZB1sPOqk1d+JhfBOkg76Cq8eMK665ozdf484RdPvObqLrxyrt9i+sDMDv/oZT+VuvGXsbHj6R+TUh87r2Yhfizcwvdotc4VTHei4y/oNX6cRhV8ryQox/0j6GClqI43A4kIsuOcUm8pI4FTGOhDQOK7+UDcuvcSa5VR7N7GJ97zfzC9gQtRsbfD5WKY4BEr+KlcWt0KCCbp1+Jh7craEO30ztUl38BuUuW7F1/AykrTX6kgS5E5ssUQ0pJPBlzpjb3G5UEeodzOD9wUBVLIBAbgQsofAPLi0pHeyCCeEOuTxXEo7SD8fG+kBstPlncR+V8goCEBnAJysIvBznUxLjrnxcU7V40g+iTENKwhVTIiZzZN3Z9buJd001MRaWjOTCWX80Ig6oraH8WJk7W1qtKzsDK9Lsp2N9pxNTPASbAQoFDlMCGcWYGixq6IhIAwsk1Pkb689F67vHaES8qMXkIHifB0j7yRMwrHinYFqUYASQOECPNEMJv3iqByXntmMP8X/r3VBujMehGodZ1dnbWvAOdWdEmG3KCVpn42ocKCj6k4WZL62nSxs3W00E1UVPnXujT3ENk/3L/VJE3tRWFCSbR9HnfBSDVA6WaFu4EFDg8WV6fn2T0FHKTBgCtTugQo8bsoyReYZvEU/27O/B+d5/9nqMHqyy4=
 node_js:
-  - "node"
+  # Currently `npm ci` fails when installing a GH repo dep that has a prepare script that uses a command from a devDependency
+  # https://github.com/npm/cli/issues/2084 is the issue, it's closed but node has not cut a release yet 11/9/2020
+  # Will return this once it's resolved
+  # - "node"
   - "lts/*"
   - 10
 cache: npm

--- a/packages/arcgis-rest-auth/src/app-tokens.ts
+++ b/packages/arcgis-rest-auth/src/app-tokens.ts
@@ -1,0 +1,77 @@
+/* Copyright (c) 2018-2020 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { IRequestOptions, request } from "@esri/arcgis-rest-request";
+
+/**
+ * Request token for a specific app, passing in the token for the current app.
+ *
+ * This call returns a token after performing the same checks made by validateAppAccess.
+ * It returns an app-specific token of the signed-in user only if the user has access
+ * to the app and the encrypted platform cookie is valid.
+ *
+ * The token returned has the same expiration as the encrypted platform cookie.
+ *
+ * @param token
+ * @param clientId application
+ * @param portal
+ */
+export function exchangeToken(
+  token: string,
+  clientId: string,
+  portal: string = "https://www.arcgis.com/sharing/rest"
+): Promise<string> {
+  const url = `${portal}/oauth2/exchangeToken`;
+  const ro = {
+    method: "POST",
+    params: {
+      f: "json",
+      client_id: clientId,
+      token,
+    },
+  } as IRequestOptions;
+  // make the request and return the token
+  return request(url, ro).then((response) => response.token);
+}
+
+export interface IPlatformSelfResponse {
+  username: string;
+  token: string;
+}
+
+/**
+ * Request a token for a specific application using the esri_aopc encrypted cookie
+ *
+ * When a client app boots up, it will know it's clientId and the redirectUri for use
+ * in the normal /oauth/authorize pop-out oAuth flow.
+ *
+ * If the app sees an `esri_aopc` cookie, it can call the /oauth2/platformSelf end-point
+ * passing in the clientId and redirectUri in headers, and it will recieve back an
+ * app-specific token, assuming the user has access to the app.
+ *
+ * Since there are scenarios where an app can boot using credintials/token from localstorage
+ * but those creds are not for the same user as the esri_aopc cookie, it is recommended that
+ * an app check the returned username against any existing identity they may have loaded
+ *
+ * Note: This is only usable by Esri applications hosted on *arcgis.com, *esri.com or within
+ * an ArcGIS Enterprise installation. Custom applications can not use this.
+ * @param clientId
+ * @param redirectUri
+ * @param portal
+ */
+export function platformSelf(
+  clientId: string,
+  redirectUri: string,
+  portal: string = "https://www.arcgis.com/sharing/rest"
+): Promise<IPlatformSelfResponse> {
+  const url = `${portal}/oauth2/platformSelf`;
+  const ro = {
+    method: "POST",
+    headers: {
+      "X-Esri-Auth-Client-Id": clientId,
+      "X-Esri-Auth-Redirect-Uri": redirectUri,
+    },
+  } as IRequestOptions;
+  // make the request and return the token
+  return request(url, ro);
+}

--- a/packages/arcgis-rest-auth/src/app-tokens.ts
+++ b/packages/arcgis-rest-auth/src/app-tokens.ts
@@ -4,13 +4,19 @@
 import { IRequestOptions, request } from "@esri/arcgis-rest-request";
 
 /**
- * Request token for a specific app, passing in the token for the current app.
+ * Request app-specific token, passing in the token for the current app.
  *
  * This call returns a token after performing the same checks made by validateAppAccess.
  * It returns an app-specific token of the signed-in user only if the user has access
  * to the app and the encrypted platform cookie is valid.
  *
- * The token returned has the same expiration as the encrypted platform cookie.
+ * A scenario where an app would use this is if it is iframed into another platform app
+ * and recieves credentials via postMessage. Those credentials contain a token that is
+ * specific to the host app, so the embedded app would use `exchangeToken` to get one
+ * that is specific to itself.
+ *
+ * Note: This is only usable by Esri applications hosted on *arcgis.com, *esri.com or within
+ * an ArcGIS Enterprise installation. Custom applications can not use this.
  *
  * @param token
  * @param clientId application
@@ -45,13 +51,14 @@ export interface IPlatformSelfResponse {
  * When a client app boots up, it will know it's clientId and the redirectUri for use
  * in the normal /oauth/authorize pop-out oAuth flow.
  *
- * If the app sees an `esri_aopc` cookie, it can call the /oauth2/platformSelf end-point
- * passing in the clientId and redirectUri in headers, and it will recieve back an
- * app-specific token, assuming the user has access to the app.
+ * If the app sees an `esri_aopc` cookie (only set if the app is hosted on *.arcgis.com),
+ * it can call the /oauth2/platformSelf end-point passing in the clientId and redirectUri
+ * in headers, and it will recieve back an app-specific token, assuming the user has
+ * access to the app.
  *
  * Since there are scenarios where an app can boot using credintials/token from localstorage
  * but those creds are not for the same user as the esri_aopc cookie, it is recommended that
- * an app check the returned username against any existing identity they may have loaded
+ * an app check the returned username against any existing identity they may have loaded.
  *
  * Note: This is only usable by Esri applications hosted on *arcgis.com, *esri.com or within
  * an ArcGIS Enterprise installation. Custom applications can not use this.

--- a/packages/arcgis-rest-auth/src/validate-app-access.ts
+++ b/packages/arcgis-rest-auth/src/validate-app-access.ts
@@ -43,6 +43,9 @@ export interface IAppAccess {
  * })
  * ```
  *
+ * Note: This is only usable by Esri applications hosted on *arcgis.com, *esri.com or within
+ * an ArcGIS Enterprise installation. Custom applications can not use this.
+ *
  * @param token platform token
  * @param clientId application client id
  * @param portal Optional

--- a/packages/arcgis-rest-auth/src/validate-app-access.ts
+++ b/packages/arcgis-rest-auth/src/validate-app-access.ts
@@ -1,0 +1,65 @@
+/* Copyright (c) 2018-2020 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import { IRequestOptions, request } from "@esri/arcgis-rest-request";
+
+export interface IAppAccess {
+  /**
+   * Verifies that the token is valid and the user has access to
+   * the specified app (clientId)
+   */
+  valid: boolean;
+  /**
+   * Should the app present the current user with a "View Only" mode
+   */
+  viewOnlyUserTypeApp: boolean;
+}
+
+/**
+ * Validates that the user has access to the application
+ * and if they user should be presented a "View Only" mode
+ *
+ * This is only needed/valid for Esri applications that are "licensed"
+ * and shipped in ArcGIS Online or ArcGIS Enterprise. Most custom applications
+ * should not need or use this.
+ *
+ * ```js
+ * import { validateAppAccess } from '@esri/arcgis-rest-auth';
+ *
+ * return validateAppAccess('your-token', 'theClientId')
+ * .then((result) => {
+ *    if (!result.valud) {
+ *      // redirect or show some other ui
+ *    } else {
+ *      if (result.viewOnlyUserTypeApp) {
+ *        // use this to inform your app to show a "View Only" mode
+ *      }
+ *    }
+ * })
+ * .catch((err) => {
+ *  // two possible errors
+ *  // invalid clientId: {"error":{"code":400,"messageCode":"GWM_0007","message":"Invalid request","details":[]}}
+ *  // invalid token: {"error":{"code":498,"message":"Invalid token.","details":[]}}
+ * })
+ * ```
+ *
+ * @param token platform token
+ * @param clientId application client id
+ * @param portal Optional
+ */
+export function validateAppAccess(
+  token: string,
+  clientId: string,
+  portal: string = "https://www.arcgis.com/sharing/rest"
+): Promise<IAppAccess> {
+  const url = `${portal}/oauth2/validateAppAccess`;
+  const ro = {
+    method: "POST",
+    params: {
+      f: "json",
+      client_id: clientId,
+      token,
+    },
+  } as IRequestOptions;
+  return request(url, ro);
+}

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1,7 +1,6 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-
 /* tslint:disable:no-empty */
 import { UserSession } from "../src/index";
 import { ICredential } from "../src/UserSession";
@@ -10,7 +9,7 @@ import {
   request,
   ArcGISRequestError,
   ArcGISAuthError,
-  ErrorTypes
+  ErrorTypes,
 } from "@esri/arcgis-rest-request";
 import * as fetchMock from "fetch-mock";
 import { YESTERDAY, TOMORROW } from "./utils";
@@ -28,7 +27,7 @@ describe("UserSession", () => {
       refreshTokenExpires: TOMORROW,
       refreshTokenTTL: 1440,
       username: "c@sey",
-      password: "123456"
+      password: "123456",
     });
 
     const session2 = UserSession.deserialize(session.serialize());
@@ -49,132 +48,132 @@ describe("UserSession", () => {
   });
 
   describe(".getToken()", () => {
-    it("should return unexpired tokens for trusted arcgis.com domains", done => {
+    it("should return unexpired tokens for trusted arcgis.com domains", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
-        tokenExpires: TOMORROW
+        tokenExpires: TOMORROW,
       });
 
       Promise.all([
         session.getToken("https://www.arcgis.com/sharing/rest/portals/self"),
         session.getToken(
           "https://services1.arcgis.com/MOCK_ORG/arcgis/rest/services/Private_Service/FeatureServer"
-        )
+        ),
       ])
         .then(([token1, token2]) => {
           expect(token1).toBe("token");
           expect(token2).toBe("token");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should return unexpired tokens when an org url is passed", done => {
+    it("should return unexpired tokens when an org url is passed", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         tokenExpires: TOMORROW,
-        portal: "https://custom.maps.arcgis.com/sharing/rest"
+        portal: "https://custom.maps.arcgis.com/sharing/rest",
       });
 
       session
         .getToken(
           "https://services1.arcgis.com/MOCK_ORG/arcgis/rest/services/Private_Service/FeatureServer"
         )
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("token");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should return unexpired tokens when an org url is passed on other ArcGIS Online environments", done => {
+    it("should return unexpired tokens when an org url is passed on other ArcGIS Online environments", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         tokenExpires: TOMORROW,
-        portal: "https://custom.mapsdev.arcgis.com/sharing/rest"
+        portal: "https://custom.mapsdev.arcgis.com/sharing/rest",
       });
 
       session
         .getToken(
           "https://services1dev.arcgis.com/MOCK_ORG/arcgis/rest/services/Private_Service/FeatureServer"
         )
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("token");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should return unexpired tokens when there is an http/https mismatch", done => {
+    it("should return unexpired tokens when there is an http/https mismatch", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         tokenExpires: TOMORROW,
-        portal: "http://custom.mapsdev.arcgis.com/sharing/rest"
+        portal: "http://custom.mapsdev.arcgis.com/sharing/rest",
       });
 
       session
         .getToken(
           "https://services1dev.arcgis.com/MOCK_ORG/arcgis/rest/services/Private_Service/FeatureServer"
         )
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("token");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should return unexpired tokens for the configured portal domain", done => {
+    it("should return unexpired tokens for the configured portal domain", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         tokenExpires: TOMORROW,
-        portal: "https://gis.city.gov/sharing/rest"
+        portal: "https://gis.city.gov/sharing/rest",
       });
 
       session
         .getToken("https://gis.city.gov/sharing/rest/portals/self")
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("token");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should return unexpired tokens for the configured portal domain, regardless of CASING", done => {
+    it("should return unexpired tokens for the configured portal domain, regardless of CASING", (done) => {
       // This was a real configuration discovered on a portal instance
       const session = new UserSession({
         clientId: "id",
         token: "token",
         tokenExpires: TOMORROW,
-        portal: "https://pnp00035.esri.com/sharing/rest"
+        portal: "https://pnp00035.esri.com/sharing/rest",
       });
 
       session
         .getToken("https://PNP00035.esri.com/sharing/rest/portals/self")
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("token");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should fetch token when contacting a server that is federated, even if on same domain, regardless of domain casing", done => {
+    it("should fetch token when contacting a server that is federated, even if on same domain, regardless of domain casing", (done) => {
       // This was a real configuration discovered on a portal instance
       // apparently when federating servers, the UI does not force the
       // server url to lowercase, and this any feature service items generated
@@ -186,7 +185,7 @@ describe("UserSession", () => {
         token: "existing-session-token",
         refreshToken: "refresh",
         tokenExpires: TOMORROW,
-        portal: "https://pnp00035.esri.com/portal/sharing/rest"
+        portal: "https://pnp00035.esri.com/portal/sharing/rest",
       });
 
       fetchMock.postOnce("https://pnp00035.esri.com/server/rest/info", {
@@ -196,8 +195,8 @@ describe("UserSession", () => {
         authInfo: {
           isTokenBasedSecurity: true,
           tokenServicesUrl:
-            "https://pnp00035.esri.com/portal/sharing/rest/generateToken"
-        }
+            "https://pnp00035.esri.com/portal/sharing/rest/generateToken",
+        },
       });
 
       fetchMock.postOnce("https://pnp00035.esri.com/portal/sharing/rest/info", {
@@ -205,15 +204,15 @@ describe("UserSession", () => {
         authInfo: {
           tokenServicesUrl:
             "https://pnp00035.esri.com/portal/sharing/rest/generateToken",
-          isTokenBasedSecurity: true
-        }
+          isTokenBasedSecurity: true,
+        },
       });
 
       fetchMock.postOnce(
         "https://pnp00035.esri.com/portal/sharing/rest/generateToken",
         {
           token: "new-server-token",
-          expires: TOMORROW
+          expires: TOMORROW,
         }
       );
 
@@ -223,27 +222,27 @@ describe("UserSession", () => {
         .getToken(
           "https://PNP00035.esri.com/server/rest/services/Hosted/perimeters_dd83/FeatureServer"
         )
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("new-server-token");
           return session.getToken(
             "https://pnp00035.esri.com/server/rest/services/Hosted/otherService/FeatureServer"
           );
         })
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("new-server-token");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should fetch new tokens when tokens for trusted arcgis.com domains are expired", done => {
+    it("should fetch new tokens when tokens for trusted arcgis.com domains are expired", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         refreshToken: "refresh",
-        tokenExpires: YESTERDAY
+        tokenExpires: YESTERDAY,
       });
 
       fetchMock.mock(
@@ -251,7 +250,7 @@ describe("UserSession", () => {
         {
           access_token: "new",
           expires_in: 1800,
-          username: "c@sey"
+          username: "c@sey",
         },
         { repeat: 2, method: "POST" }
       );
@@ -260,41 +259,41 @@ describe("UserSession", () => {
         session.getToken("https://www.arcgis.com/sharing/rest/portals/self"),
         session.getToken(
           "https://services1.arcgis.com/MOCK_ORG/arcgis/rest/services/Private_Service/FeatureServer"
-        )
+        ),
       ])
         .then(([token1, token2]) => {
           expect(token1).toBe("new");
           expect(token2).toBe("new");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should pass through a token when no token expiration is present", done => {
+    it("should pass through a token when no token expiration is present", (done) => {
       const session = new UserSession({
-        token: "token"
+        token: "token",
       });
 
       session
         .getToken("https://www.arcgis.com/sharing/rest/portals/self")
-        .then(token1 => {
+        .then((token1) => {
           expect(token1).toBe("token");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should generate a token for an untrusted, federated server", done => {
+    it("should generate a token for an untrusted, federated server", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         refreshToken: "refresh",
         tokenExpires: TOMORROW,
-        portal: "https://gis.city.gov/sharing/rest"
+        portal: "https://gis.city.gov/sharing/rest",
       });
 
       fetchMock.postOnce("https://gisservices.city.gov/public/rest/info", {
@@ -303,49 +302,49 @@ describe("UserSession", () => {
         owningSystemUrl: "https://gis.city.gov",
         authInfo: {
           isTokenBasedSecurity: true,
-          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken"
-        }
+          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken",
+        },
       });
 
       fetchMock.postOnce("https://gis.city.gov/sharing/rest/info", {
         owningSystemUrl: "http://gis.city.gov",
         authInfo: {
           tokenServicesUrl: "https://gis.city.gov/sharing/generateToken",
-          isTokenBasedSecurity: true
-        }
+          isTokenBasedSecurity: true,
+        },
       });
 
       fetchMock.postOnce("https://gis.city.gov/sharing/generateToken", {
         token: "serverToken",
-        expires: TOMORROW
+        expires: TOMORROW,
       });
 
       session
         .getToken(
           "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query"
         )
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("serverToken");
           return session.getToken(
             "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query"
           );
         })
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("serverToken");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should generate a token for an untrusted, federated server admin call", done => {
+    it("should generate a token for an untrusted, federated server admin call", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         refreshToken: "refresh",
         tokenExpires: TOMORROW,
-        portal: "https://gis.city.gov/sharing/rest"
+        portal: "https://gis.city.gov/sharing/rest",
       });
 
       fetchMock.postOnce("https://gisservices.city.gov/public/rest/info", {
@@ -354,47 +353,47 @@ describe("UserSession", () => {
         owningSystemUrl: "https://gis.city.gov",
         authInfo: {
           isTokenBasedSecurity: true,
-          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken"
-        }
+          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken",
+        },
       });
 
       fetchMock.postOnce("https://gis.city.gov/sharing/rest/info", {
         owningSystemUrl: "http://gis.city.gov",
         authInfo: {
           tokenServicesUrl: "https://gis.city.gov/sharing/generateToken",
-          isTokenBasedSecurity: true
-        }
+          isTokenBasedSecurity: true,
+        },
       });
 
       fetchMock.postOnce("https://gis.city.gov/sharing/generateToken", {
         token: "serverToken",
-        expires: TOMORROW
+        expires: TOMORROW,
       });
 
       session
         .getToken(
           "https://gisservices.city.gov/public/rest/admin/services/trees/FeatureServer/addToDefinition"
         )
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("serverToken");
           return session.getToken(
             "https://gisservices.city.gov/public/rest/admin/services/trees/FeatureServer/addToDefinition"
           );
         })
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("serverToken");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should generate a token for an untrusted, federated server with user credentials", done => {
+    it("should generate a token for an untrusted, federated server with user credentials", (done) => {
       const session = new UserSession({
         username: "c@sey",
         password: "jones",
-        portal: "https://gis.city.gov/sharing/rest"
+        portal: "https://gis.city.gov/sharing/rest",
       });
 
       fetchMock.postOnce("https://gisservices.city.gov/public/rest/info", {
@@ -403,43 +402,43 @@ describe("UserSession", () => {
         owningSystemUrl: "https://gis.city.gov",
         authInfo: {
           isTokenBasedSecurity: true,
-          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken"
-        }
+          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken",
+        },
       });
 
       fetchMock.postOnce("https://gis.city.gov/sharing/rest/info", {
         owningSystemUrl: "http://gis.city.gov",
         authInfo: {
           tokenServicesUrl: "https://gis.city.gov/sharing/generateToken",
-          isTokenBasedSecurity: true
-        }
+          isTokenBasedSecurity: true,
+        },
       });
 
       fetchMock.postOnce("https://gis.city.gov/sharing/generateToken", {
         token: "serverToken",
-        expires: TOMORROW
+        expires: TOMORROW,
       });
 
       session
         .getToken(
           "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query"
         )
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("serverToken");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should only make 1 token request to an untrusted portal for similar URLs", done => {
+    it("should only make 1 token request to an untrusted portal for similar URLs", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         refreshToken: "refresh",
         tokenExpires: TOMORROW,
-        portal: "https://gis.city.gov/sharing/rest"
+        portal: "https://gis.city.gov/sharing/rest",
       });
 
       fetchMock.mock(
@@ -450,8 +449,8 @@ describe("UserSession", () => {
           owningSystemUrl: "https://gis.city.gov",
           authInfo: {
             isTokenBasedSecurity: true,
-            tokenServicesUrl: "https://gis.city.gov/sharing/generateToken"
-          }
+            tokenServicesUrl: "https://gis.city.gov/sharing/generateToken",
+          },
         },
         { repeat: 1, method: "POST" }
       );
@@ -462,8 +461,8 @@ describe("UserSession", () => {
           owningSystemUrl: "http://gis.city.gov",
           authInfo: {
             tokenServicesUrl: "https://gis.city.gov/sharing/generateToken",
-            isTokenBasedSecurity: true
-          }
+            isTokenBasedSecurity: true,
+          },
         },
         { repeat: 1, method: "POST" }
       );
@@ -472,7 +471,7 @@ describe("UserSession", () => {
         "https://gis.city.gov/sharing/generateToken",
         {
           token: "serverToken",
-          expires: TOMORROW
+          expires: TOMORROW,
         },
         { repeat: 1, method: "POST" }
       );
@@ -483,7 +482,7 @@ describe("UserSession", () => {
         ),
         session.getToken(
           "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query"
-        )
+        ),
       ])
         .then(([token1, token2]) => {
           expect(token1).toBe("serverToken");
@@ -493,17 +492,17 @@ describe("UserSession", () => {
           ).toBe(1);
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should throw an ArcGISAuthError when the owning system doesn't match", done => {
+    it("should throw an ArcGISAuthError when the owning system doesn't match", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         refreshToken: "refresh",
-        tokenExpires: YESTERDAY
+        tokenExpires: YESTERDAY,
       });
 
       fetchMock.post("https://gisservices.city.gov/public/rest/info", {
@@ -512,15 +511,15 @@ describe("UserSession", () => {
         owningSystemUrl: "https://gis.city.gov",
         authInfo: {
           isTokenBasedSecurity: true,
-          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken"
-        }
+          tokenServicesUrl: "https://gis.city.gov/sharing/generateToken",
+        },
       });
 
       session
         .getToken(
           "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query"
         )
-        .catch(e => {
+        .catch((e) => {
           expect(e.name).toEqual(ErrorTypes.ArcGISAuthError);
           expect(e.code).toEqual("NOT_FEDERATED");
           expect(e.message).toEqual(
@@ -530,17 +529,17 @@ describe("UserSession", () => {
         });
     });
 
-    it("should throw a fully hydrated ArcGISAuthError when no owning system is advertised", done => {
+    it("should throw a fully hydrated ArcGISAuthError when no owning system is advertised", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         refreshToken: "refresh",
-        tokenExpires: YESTERDAY
+        tokenExpires: YESTERDAY,
       });
 
       fetchMock.post("https://gisservices.city.gov/public/rest/info", {
         currentVersion: 10.51,
-        fullVersion: "10.5.1.120"
+        fullVersion: "10.5.1.120",
       });
 
       fetchMock.post(
@@ -549,8 +548,8 @@ describe("UserSession", () => {
           error: {
             code: 499,
             message: "Token Required",
-            details: []
-          }
+            details: [],
+          },
         }
       );
 
@@ -559,10 +558,10 @@ describe("UserSession", () => {
         {
           authentication: session,
           params: {
-            foo: "bar"
-          }
+            foo: "bar",
+          },
         }
-      ).catch(e => {
+      ).catch((e) => {
         expect(e.name).toEqual(ErrorTypes.ArcGISAuthError);
         expect(e.code).toEqual("NOT_FEDERATED");
         expect(e.message).toEqual(
@@ -576,23 +575,23 @@ describe("UserSession", () => {
       });
     });
 
-    it("should not throw an ArcGISAuthError when the unfederated service is public", done => {
+    it("should not throw an ArcGISAuthError when the unfederated service is public", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         refreshToken: "refresh",
-        tokenExpires: YESTERDAY
+        tokenExpires: YESTERDAY,
       });
 
       fetchMock.post("https://gisservices.city.gov/public/rest/info", {
         currentVersion: 10.51,
-        fullVersion: "10.5.1.120"
+        fullVersion: "10.5.1.120",
       });
 
       fetchMock.post(
         "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query",
         {
-          count: 123
+          count: 123,
         }
       );
 
@@ -601,111 +600,111 @@ describe("UserSession", () => {
         {
           authentication: session,
           params: {
-            returnCount: true
-          }
+            returnCount: true,
+          },
         }
       )
-        .then(res => {
+        .then((res) => {
           expect(res.count).toEqual(123);
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
   });
 
   describe(".refreshSession()", () => {
-    it("should refresh with a username and password if expired", done => {
+    it("should refresh with a username and password if expired", (done) => {
       const session = new UserSession({
         username: "c@sey",
-        password: "123456"
+        password: "123456",
       });
 
       fetchMock.postOnce("https://www.arcgis.com/sharing/rest/generateToken", {
         token: "token",
         expires: TOMORROW.getTime(),
-        username: " c@sey"
+        username: " c@sey",
       });
 
       session
         .refreshSession()
-        .then(s => {
+        .then((s) => {
           expect(s.token).toBe("token");
           expect(s.tokenExpires).toEqual(TOMORROW);
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should refresh with an unexpired refresh token", done => {
+    it("should refresh with an unexpired refresh token", (done) => {
       const session = new UserSession({
         clientId: "clientId",
         token: "token",
         username: "c@sey",
         refreshToken: "refreshToken",
-        refreshTokenExpires: TOMORROW
-      });
-
-      fetchMock.postOnce("https://www.arcgis.com/sharing/rest/oauth2/token", {
-        access_token: "newToken",
-        expires_in: 60,
-        username: " c@sey"
-      });
-
-      session
-        .refreshSession()
-        .then(s => {
-          expect(s.token).toBe("newToken");
-          expect(s.tokenExpires.getTime()).toBeGreaterThan(Date.now());
-          done();
-        })
-        .catch(e => {
-          fail(e);
-        });
-    });
-
-    it("should refresh with an expired refresh token", done => {
-      const session = new UserSession({
-        clientId: "clientId",
-        token: "token",
-        username: "c@sey",
-        refreshToken: "refreshToken",
-        refreshTokenExpires: YESTERDAY,
-        redirectUri: "https://example-app.com/redirect-uri"
+        refreshTokenExpires: TOMORROW,
       });
 
       fetchMock.postOnce("https://www.arcgis.com/sharing/rest/oauth2/token", {
         access_token: "newToken",
         expires_in: 60,
         username: " c@sey",
-        refresh_token: "newRefreshToken"
       });
 
       session
         .refreshSession()
-        .then(s => {
+        .then((s) => {
+          expect(s.token).toBe("newToken");
+          expect(s.tokenExpires.getTime()).toBeGreaterThan(Date.now());
+          done();
+        })
+        .catch((e) => {
+          fail(e);
+        });
+    });
+
+    it("should refresh with an expired refresh token", (done) => {
+      const session = new UserSession({
+        clientId: "clientId",
+        token: "token",
+        username: "c@sey",
+        refreshToken: "refreshToken",
+        refreshTokenExpires: YESTERDAY,
+        redirectUri: "https://example-app.com/redirect-uri",
+      });
+
+      fetchMock.postOnce("https://www.arcgis.com/sharing/rest/oauth2/token", {
+        access_token: "newToken",
+        expires_in: 60,
+        username: " c@sey",
+        refresh_token: "newRefreshToken",
+      });
+
+      session
+        .refreshSession()
+        .then((s) => {
           expect(s.token).toBe("newToken");
           expect(s.tokenExpires.getTime()).toBeGreaterThan(Date.now());
           expect(s.refreshToken).toBe("newRefreshToken");
           expect(s.refreshTokenExpires.getTime()).toBeGreaterThan(Date.now());
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should reject if we cannot refresh the token", done => {
+    it("should reject if we cannot refresh the token", (done) => {
       const session = new UserSession({
         clientId: "clientId",
         token: "token",
-        username: "c@sey"
+        username: "c@sey",
       });
 
-      session.refreshSession().catch(e => {
+      session.refreshSession().catch((e) => {
         expect(e instanceof ArcGISAuthError).toBeTruthy();
         expect(e.name).toBe("ArcGISAuthError");
         expect(e.message).toBe("Unable to refresh token.");
@@ -713,12 +712,12 @@ describe("UserSession", () => {
       });
     });
 
-    it("should only make 1 token request to the portal for similar URLs", done => {
+    it("should only make 1 token request to the portal for similar URLs", (done) => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
         refreshToken: "refresh",
-        tokenExpires: YESTERDAY
+        tokenExpires: YESTERDAY,
       });
 
       fetchMock.mock(
@@ -726,14 +725,14 @@ describe("UserSession", () => {
         {
           access_token: "new",
           expires_in: 1800,
-          username: "c@sey"
+          username: "c@sey",
         },
         { repeat: 1, method: "POST" }
       );
 
       Promise.all([
         session.getToken("https://www.arcgis.com/sharing/rest/portals/self"),
-        session.getToken("https://www.arcgis.com/sharing/rest/portals/self")
+        session.getToken("https://www.arcgis.com/sharing/rest/portals/self"),
       ])
         .then(([token1, token2]) => {
           expect(token1).toBe("new");
@@ -744,34 +743,34 @@ describe("UserSession", () => {
           ).toBe(1);
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
   });
 
   describe(".beginOAuth2()", () => {
-    it("should authorize via a popup", done => {
+    it("should authorize via a popup", (done) => {
       const MockWindow: any = {
-        open: jasmine.createSpy("spy")
+        open: jasmine.createSpy("spy"),
       };
 
       UserSession.beginOAuth2(
         {
           clientId: "clientId123",
           redirectUri: "http://example-app.com/redirect",
-          state: "abc123"
+          state: "abc123",
         },
         MockWindow
       )
-        .then(session => {
+        .then((session) => {
           expect(session.token).toBe("token");
           expect(session.username).toBe("c@sey");
           expect(session.ssl).toBe(true);
           expect(session.tokenExpires).toEqual(TOMORROW);
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
 
@@ -787,24 +786,24 @@ describe("UserSession", () => {
           token: "token",
           expires: TOMORROW,
           username: "c@sey",
-          ssl: true
+          ssl: true,
         })
       );
     });
 
-    it("should reject the promise if there is an error", done => {
+    it("should reject the promise if there is an error", (done) => {
       const MockWindow: any = {
-        open: jasmine.createSpy("spy")
+        open: jasmine.createSpy("spy"),
       };
 
       UserSession.beginOAuth2(
         {
           clientId: "clientId123",
           redirectUri: "http://example-app.com/redirect",
-          locale: "fr"
+          locale: "fr",
         },
         MockWindow
-      ).catch(e => {
+      ).catch((e) => {
         done();
       });
 
@@ -817,7 +816,7 @@ describe("UserSession", () => {
       MockWindow.__ESRI_REST_AUTH_HANDLER_clientId123(
         JSON.stringify({
           errorMessage: "unable to sign in",
-          error: "SIGN_IN_FAILED"
+          error: "SIGN_IN_FAILED",
         })
       );
     });
@@ -825,8 +824,8 @@ describe("UserSession", () => {
     it("should authorize in the same window/tab", () => {
       const MockWindow: any = {
         location: {
-          href: ""
-        }
+          href: "",
+        },
       };
 
       // https://github.com/palantir/tslint/issues/3056
@@ -834,7 +833,7 @@ describe("UserSession", () => {
         {
           clientId: "clientId123",
           redirectUri: "http://example-app.com/redirect",
-          popup: false
+          popup: false,
         },
         MockWindow
       );
@@ -847,8 +846,8 @@ describe("UserSession", () => {
     it("should authorize using a social media provider", () => {
       const MockWindow: any = {
         location: {
-          href: ""
-        }
+          href: "",
+        },
       };
 
       // https://github.com/palantir/tslint/issues/3056
@@ -857,7 +856,7 @@ describe("UserSession", () => {
           clientId: "clientId123",
           redirectUri: "http://example-app.com/redirect",
           popup: false,
-          provider: "facebook"
+          provider: "facebook",
         },
         MockWindow
       );
@@ -870,8 +869,8 @@ describe("UserSession", () => {
     it("should authorize using the other social media provider", () => {
       const MockWindow: any = {
         location: {
-          href: ""
-        }
+          href: "",
+        },
       };
 
       // https://github.com/palantir/tslint/issues/3056
@@ -880,7 +879,7 @@ describe("UserSession", () => {
           clientId: "clientId123",
           redirectUri: "http://example-app.com/redirect",
           popup: false,
-          provider: "google"
+          provider: "google",
         },
         MockWindow
       );
@@ -896,17 +895,17 @@ describe("UserSession", () => {
       const MockWindow = {
         location: {
           hash:
-            "#access_token=token&expires_in=1209600&username=c%40sey&ssl=true&persist=true"
+            "#access_token=token&expires_in=1209600&username=c%40sey&ssl=true&persist=true",
         },
         get parent() {
           return this;
-        }
+        },
       };
 
       const session = UserSession.completeOAuth2(
         {
           clientId: "clientId",
-          redirectUri: "https://example-app.com/redirect-uri"
+          redirectUri: "https://example-app.com/redirect-uri",
         },
         MockWindow
       );
@@ -921,24 +920,24 @@ describe("UserSession", () => {
       const MockWindow = {
         location: {
           hash:
-            "#access_token=token&expires_in=1209600&username=c%40sey&persist=true"
+            "#access_token=token&expires_in=1209600&username=c%40sey&persist=true",
         },
         get parent() {
           return this;
-        }
+        },
       };
 
       const session = UserSession.completeOAuth2(
         {
           clientId: "clientId",
-          redirectUri: "https://example-app.com/redirect-uri"
+          redirectUri: "https://example-app.com/redirect-uri",
         },
         MockWindow
       );
       expect(session.ssl).toBe(false);
     });
 
-    it("should callback to create a new user session if finds a valid opener.parent", done => {
+    it("should callback to create a new user session if finds a valid opener.parent", (done) => {
       const MockWindow = {
         opener: {
           parent: {
@@ -953,28 +952,28 @@ describe("UserSession", () => {
               expect(new Date(oauthInfo.expires).getTime()).toBeGreaterThan(
                 Date.now()
               );
-            }
-          }
+            },
+          },
         },
         close() {
           done();
         },
         location: {
           hash:
-            "#access_token=token&expires_in=1209600&username=c%40sey&ssl=true"
-        }
+            "#access_token=token&expires_in=1209600&username=c%40sey&ssl=true",
+        },
       };
 
       UserSession.completeOAuth2(
         {
           clientId: "clientId",
-          redirectUri: "https://example-app.com/redirect-uri"
+          redirectUri: "https://example-app.com/redirect-uri",
         },
         MockWindow
       );
     });
 
-    it("should callback to create a new user session if finds a valid opener (Iframe support)", done => {
+    it("should callback to create a new user session if finds a valid opener (Iframe support)", (done) => {
       const MockWindow = {
         opener: {
           __ESRI_REST_AUTH_HANDLER_clientId(
@@ -988,27 +987,27 @@ describe("UserSession", () => {
             expect(new Date(oauthInfo.expires).getTime()).toBeGreaterThan(
               Date.now()
             );
-          }
+          },
         },
         close() {
           done();
         },
         location: {
           hash:
-            "#access_token=token&expires_in=1209600&username=c%40sey&ssl=true"
-        }
+            "#access_token=token&expires_in=1209600&username=c%40sey&ssl=true",
+        },
       };
 
       UserSession.completeOAuth2(
         {
           clientId: "clientId",
-          redirectUri: "https://example-app.com/redirect-uri"
+          redirectUri: "https://example-app.com/redirect-uri",
         },
         MockWindow
       );
     });
 
-    it("should callback to create a new user session if finds a valid parent", done => {
+    it("should callback to create a new user session if finds a valid parent", (done) => {
       const MockWindow = {
         parent: {
           __ESRI_REST_AUTH_HANDLER_clientId(
@@ -1022,21 +1021,21 @@ describe("UserSession", () => {
             expect(new Date(oauthInfo.expires).getTime()).toBeGreaterThan(
               Date.now()
             );
-          }
+          },
         },
         close() {
           done();
         },
         location: {
           hash:
-            "#access_token=token&expires_in=1209600&username=c%40sey&ssl=true"
-        }
+            "#access_token=token&expires_in=1209600&username=c%40sey&ssl=true",
+        },
       };
 
       UserSession.completeOAuth2(
         {
           clientId: "clientId",
-          redirectUri: "https://example-app.com/redirect-uri"
+          redirectUri: "https://example-app.com/redirect-uri",
         },
         MockWindow
       );
@@ -1045,18 +1044,18 @@ describe("UserSession", () => {
     it("should throw an error from the authorization window", () => {
       const MockWindow = {
         location: {
-          hash: "#error=Invalid_Signin&error_description=Invalid_Signin"
+          hash: "#error=Invalid_Signin&error_description=Invalid_Signin",
         },
         get parent() {
           return this;
-        }
+        },
       };
 
       expect(function() {
         UserSession.completeOAuth2(
           {
             clientId: "clientId",
-            redirectUri: "https://example-app.com/redirect-uri"
+            redirectUri: "https://example-app.com/redirect-uri",
           },
           MockWindow
         );
@@ -1069,23 +1068,23 @@ describe("UserSession", () => {
           throw new Error(
             "This window isn't where auth started, but was opened from somewhere else via window.open() perhaps from another domain which would cause a cross domain error when read."
           );
-        }
+        },
       };
 
       const MockWindow = {
         location: {
-          hash: "#error=Invalid_Signin&error_description=Invalid_Signin"
+          hash: "#error=Invalid_Signin&error_description=Invalid_Signin",
         },
         get opener() {
           return MockParent;
-        }
+        },
       };
 
       expect(function() {
         UserSession.completeOAuth2(
           {
             clientId: "clientId",
-            redirectUri: "https://example-app.com/redirect-uri"
+            redirectUri: "https://example-app.com/redirect-uri",
           },
           MockWindow
         );
@@ -1093,13 +1092,13 @@ describe("UserSession", () => {
     });
   });
 
-  describe('postmessage auth :: ', () => { 
+  describe("postmessage auth :: ", () => {
     const MockWindow = {
       addEventListener: () => {},
       removeEventListener: () => {},
       parent: {
-        postMessage: () => {}
-      }
+        postMessage: () => {},
+      },
     };
 
     const cred = {
@@ -1107,190 +1106,270 @@ describe("UserSession", () => {
       server: "https://www.arcgis.com",
       ssl: false,
       token: "token",
-      userId: "jsmith"
+      userId: "jsmith",
     };
 
-    it('.disablePostMessageAuth removes event listener', () => { 
-      const removeSpy = spyOn(MockWindow, 'removeEventListener');
-      const session = UserSession.fromCredential(cred)
-      session.disablePostMessageAuth(MockWindow);
-      expect(removeSpy.calls.count()).toBe(1, 'should call removeEventListener');
-    });
-    it('.enablePostMessageAuth adds event listener', () => { 
-      const addSpy = spyOn(MockWindow, 'addEventListener');
+    it(".disablePostMessageAuth removes event listener", () => {
+      const removeSpy = spyOn(MockWindow, "removeEventListener");
       const session = UserSession.fromCredential(cred);
-      session.enablePostMessageAuth(['https://storymaps.arcgis.com'], MockWindow);
-      expect(addSpy.calls.count()).toBe(1, 'should call addEventListener');
+      session.disablePostMessageAuth(MockWindow);
+      expect(removeSpy.calls.count()).toBe(
+        1,
+        "should call removeEventListener"
+      );
+    });
+    it(".enablePostMessageAuth adds event listener", () => {
+      const addSpy = spyOn(MockWindow, "addEventListener");
+      const session = UserSession.fromCredential(cred);
+      session.enablePostMessageAuth(
+        ["https://storymaps.arcgis.com"],
+        MockWindow
+      );
+      expect(addSpy.calls.count()).toBe(1, "should call addEventListener");
     });
 
-    it('.enablePostMessage handler returns credential to origin in list', () => {
-      // ok, this gets kinda gnarly... 
+    it(".enablePostMessage handler returns credential to origin in list", () => {
+      // ok, this gets kinda gnarly...
 
       // create a mock window object
       // that will hold the passed in event handler so we can fire it manually
       const Win = {
-        _fn: (evt:any) => {},
-        addEventListener (evt:any, fn:any) {
+        _fn: (evt: any) => {},
+        addEventListener(evt: any, fn: any) {
           // enablePostMessageAuth passes in the handler, which is what we're actually testing
           Win._fn = fn;
         },
-        removeEventListener () {},
-      }
+        removeEventListener() {},
+      };
       // Create the session
       const session = UserSession.fromCredential(cred);
       // enable postMessageAuth allowing storymaps.arcgis.com to recieve creds
-      session.enablePostMessageAuth(['https://storymaps.arcgis.com'], Win);
+      session.enablePostMessageAuth(["https://storymaps.arcgis.com"], Win);
       // create an event object, with a matching origin
       // an a source.postMessage fn that we can spy on
       const event = {
-        origin: 'https://storymaps.arcgis.com',
+        origin: "https://storymaps.arcgis.com",
         source: {
-          postMessage (msg: any, origin: string) {}
-        }
-      }
+          postMessage(msg: any, origin: string) {},
+        },
+      };
       // create the spy
-      const sourceSpy = spyOn(event.source, 'postMessage');
+      const sourceSpy = spyOn(event.source, "postMessage");
       // Now, fire the handler, simulating what happens when a postMessage event comes
       // from an embedded iframe
       Win._fn(event);
       // Expectations...
-      expect(sourceSpy.calls.count()).toBe(1, 'souce.postMessage should be called in handler');
+      expect(sourceSpy.calls.count()).toBe(
+        1,
+        "souce.postMessage should be called in handler"
+      );
       const args = sourceSpy.calls.argsFor(0);
-      expect(args[0].type).toBe('arcgis:auth:credential', 'should send credential type');
-      expect(args[0].credential.userId).toBe('jsmith', 'should send credential');
+      expect(args[0].type).toBe(
+        "arcgis:auth:credential",
+        "should send credential type"
+      );
+      expect(args[0].credential.userId).toBe(
+        "jsmith",
+        "should send credential"
+      );
       // now the case where it's not a valid origin
-      event.origin = 'https://evil.com';
+      event.origin = "https://evil.com";
       Win._fn(event);
-      expect(sourceSpy.calls.count()).toBe(2, 'souce.postMessage should be called in handler');
+      expect(sourceSpy.calls.count()).toBe(
+        2,
+        "souce.postMessage should be called in handler"
+      );
       const args2 = sourceSpy.calls.argsFor(1);
-      expect(args2[0].type).toBe('arcgis:auth:rejected', 'should send reject');
+      expect(args2[0].type).toBe("arcgis:auth:rejected", "should send reject");
     });
 
-    it('.fromParent happy path', () => { 
+    it(".fromParent happy path", () => {
       // create a mock window that will fire the handler
       const Win = {
-        _fn: (evt:any) => {},
-        addEventListener (evt:any, fn:any) {
+        _fn: (evt: any) => {},
+        addEventListener(evt: any, fn: any) {
           Win._fn = fn;
         },
-        removeEventListener () {},
+        removeEventListener() {},
         parent: {
-          postMessage (msg: any, origin:string) {
-            Win._fn({origin: 'https://origin.com', data: {type: 'arcgis:auth:credential', credential: cred }});
-          }
+          postMessage(msg: any, origin: string) {
+            Win._fn({
+              origin: "https://origin.com",
+              data: { type: "arcgis:auth:credential", credential: cred },
+            });
+          },
+        },
+      };
+
+      return UserSession.fromParent("https://origin.com", Win).then(
+        (session) => {
+          expect(session.username).toBe(
+            "jsmith",
+            "should use the cred wired throu the mock window"
+          );
         }
-      }
-
-      return UserSession.fromParent('https://origin.com', Win)
-      .then((session) => {
-        expect(session.username).toBe('jsmith', 'should use the cred wired throu the mock window');
-      });
+      );
     });
 
-    it('.fromParent ignores other messages, then intercepts the correct one', async () => { 
+    it(".fromParent ignores other messages, then intercepts the correct one", async () => {
       // create a mock window that will fire the handler
       const Win = {
-        _fn: (evt:any) => {},
-        addEventListener (evt:any, fn:any) {
+        _fn: (evt: any) => {},
+        addEventListener(evt: any, fn: any) {
           Win._fn = fn;
         },
-        removeEventListener () {},
+        removeEventListener() {},
         parent: {
-          postMessage (msg: any, origin:string) {
+          postMessage(msg: any, origin: string) {
             // fire one we intend to ignore
-            Win._fn({origin: 'https://notorigin.com', data: {type: 'other:random', foo: {bar:"baz"} }});
+            Win._fn({
+              origin: "https://notorigin.com",
+              data: { type: "other:random", foo: { bar: "baz" } },
+            });
             // fire a second we want to intercept
-            Win._fn({origin: 'https://origin.com', data: {type: 'arcgis:auth:credential', credential: cred }});
-          }
-        }
-      }
+            Win._fn({
+              origin: "https://origin.com",
+              data: { type: "arcgis:auth:credential", credential: cred },
+            });
+          },
+        },
+      };
 
-      return UserSession.fromParent('https://origin.com', Win)
-      .then((resp) => {
-        expect(resp.username).toBe('jsmith', 'should use the cred wired throu the mock window');
+      return UserSession.fromParent("https://origin.com", Win).then((resp) => {
+        expect(resp.username).toBe(
+          "jsmith",
+          "should use the cred wired throu the mock window"
+        );
       });
     });
 
-    it('.fromParent rejects if invlid cred', () => { 
+    it(".fromParent rejects if invlid cred", () => {
       // create a mock window that will fire the handler
       const Win = {
-        _fn: (evt:any) => {},
-        addEventListener (evt:any, fn:any) {
+        _fn: (evt: any) => {},
+        addEventListener(evt: any, fn: any) {
           Win._fn = fn;
         },
-        removeEventListener () {},
+        removeEventListener() {},
         parent: {
-          postMessage (msg: any, origin:string) {
-            Win._fn({origin: 'https://origin.com', data: {type: 'arcgis:auth:credential', credential: {foo:"bar"} }});
-          }
-        }
-      }
+          postMessage(msg: any, origin: string) {
+            Win._fn({
+              origin: "https://origin.com",
+              data: {
+                type: "arcgis:auth:credential",
+                credential: { foo: "bar" },
+              },
+            });
+          },
+        },
+      };
 
-      return UserSession.fromParent('https://origin.com', Win)
-      .catch((err) => {
-        expect(err).toBeDefined('Should reject');
-      })
+      return UserSession.fromParent("https://origin.com", Win).catch((err) => {
+        expect(err).toBeDefined("Should reject");
+      });
     });
 
-    it('.fromParent rejects if auth rejected', () => { 
+    it(".fromParent rejects if auth rejected", () => {
       // create a mock window that will fire the handler
       const Win = {
-        _fn: (evt:any) => {},
-        addEventListener (evt:any, fn:any) {
+        _fn: (evt: any) => {},
+        addEventListener(evt: any, fn: any) {
           Win._fn = fn;
         },
-        removeEventListener () {},
+        removeEventListener() {},
         parent: {
-          postMessage (msg: any, origin:string) {
-            Win._fn({origin: 'https://origin.com', data: {type: 'arcgis:auth:rejected', message: 'Rejected authentication request.'}});
-          }
-        }
-      }
+          postMessage(msg: any, origin: string) {
+            Win._fn({
+              origin: "https://origin.com",
+              data: {
+                type: "arcgis:auth:rejected",
+                message: "Rejected authentication request.",
+              },
+            });
+          },
+        },
+      };
 
-      return UserSession.fromParent('https://origin.com', Win)
-      .catch((err) => {
-        expect(err).toBeDefined('Should reject');
-      })
+      return UserSession.fromParent("https://origin.com", Win).catch((err) => {
+        expect(err).toBeDefined("Should reject");
+      });
     });
 
-    it('.fromParent rejects if auth unknown message', () => { 
+    it(".fromParent rejects if auth unknown message", () => {
       // create a mock window that will fire the handler
       const Win = {
-        _fn: (evt:any) => {},
-        addEventListener (evt:any, fn:any) {
+        _fn: (evt: any) => {},
+        addEventListener(evt: any, fn: any) {
           Win._fn = fn;
         },
-        removeEventListener () {},
+        removeEventListener() {},
         parent: {
-          postMessage (msg: any, origin:string) {
-            Win._fn({origin: 'https://origin.com', data: {type: 'arcgis:auth:other'}});
-          }
-        }
-      }
+          postMessage(msg: any, origin: string) {
+            Win._fn({
+              origin: "https://origin.com",
+              data: { type: "arcgis:auth:other" },
+            });
+          },
+        },
+      };
 
-      return UserSession.fromParent('https://origin.com', Win)
-      .catch((err) => {
-        expect(err.message).toBe("Unknown message type.", 'Should reject');
-      })
+      return UserSession.fromParent("https://origin.com", Win).catch((err) => {
+        expect(err.message).toBe("Unknown message type.", "Should reject");
+      });
     });
+  });
 
+  describe("validateAppAccess: ", () => {
+    it("makes a request to /oauth2/validateAppAccess passing params", () => {
+      const VERIFYAPPACCESS_URL =
+        "https://www.arcgis.com/sharing/rest/oauth2/validateAppAccess";
+      fetchMock.postOnce(VERIFYAPPACCESS_URL, {
+        valid: true,
+        viewOnlyUserTypeApp: false,
+      });
+      const session = new UserSession({
+        clientId: "clientId",
+        redirectUri: "https://example-app.com/redirect-uri",
+        token: "FAKE-TOKEN",
+        tokenExpires: TOMORROW,
+        refreshToken: "refreshToken",
+        refreshTokenExpires: TOMORROW,
+        refreshTokenTTL: 1440,
+        username: "jsmith",
+        password: "123456",
+      });
+      return session
+        .validateAppAccess("abc123")
+        .then((response) => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+            VERIFYAPPACCESS_URL
+          );
+          expect(url).toEqual(VERIFYAPPACCESS_URL);
+          expect(options.body).toContain("f=json");
+          expect(options.body).toContain("token=FAKE-TOKEN");
+          expect(options.body).toContain("client_id=abc123");
+          expect(response.valid).toEqual(true);
+          expect(response.viewOnlyUserTypeApp).toBe(false);
+        })
+        .catch((e) => fail(e));
+    });
   });
 
   it("should throw an unknown error if the url has no error or access_token", () => {
     const MockWindow = {
       location: {
-        hash: ""
+        hash: "",
       },
       get opener() {
         return this;
-      }
+      },
     };
 
     expect(function() {
       UserSession.completeOAuth2(
         {
           clientId: "clientId",
-          redirectUri: "https://example-app.com/redirect-uri"
+          redirectUri: "https://example-app.com/redirect-uri",
         },
         MockWindow
       );
@@ -1298,7 +1377,7 @@ describe("UserSession", () => {
   });
 
   describe(".authorize()", () => {
-    it("should redirect the request to the authorization page", done => {
+    it("should redirect the request to the authorization page", (done) => {
       const spy = jasmine.createSpy("spy");
       const MockResponse: any = {
         writeHead: spy,
@@ -1308,13 +1387,13 @@ describe("UserSession", () => {
             "https://arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId&duration=20160&response_type=code&redirect_uri=https%3A%2F%2Fexample-app.com%2Fredirect-uri"
           );
           done();
-        }
+        },
       };
 
       UserSession.authorize(
         {
           clientId: "clientId",
-          redirectUri: "https://example-app.com/redirect-uri"
+          redirectUri: "https://example-app.com/redirect-uri",
         },
         MockResponse
       );
@@ -1332,23 +1411,23 @@ describe("UserSession", () => {
       paramsSpy.calls.reset();
     });
 
-    it("should exchange an authorization code for a new UserSession", done => {
+    it("should exchange an authorization code for a new UserSession", (done) => {
       fetchMock.postOnce("https://www.arcgis.com/sharing/rest/oauth2/token", {
         access_token: "token",
         expires_in: 1800,
         refresh_token: "refreshToken",
         username: "Casey",
-        ssl: true
+        ssl: true,
       });
 
       UserSession.exchangeAuthorizationCode(
         {
           clientId: "clientId",
-          redirectUri: "https://example-app.com/redirect-uri"
+          redirectUri: "https://example-app.com/redirect-uri",
         },
         "code"
       )
-        .then(session => {
+        .then((session) => {
           expect(session.token).toBe("token");
           expect(session.tokenExpires.getTime()).toBeGreaterThan(Date.now());
           expect(session.username).toBe("Casey");
@@ -1356,7 +1435,7 @@ describe("UserSession", () => {
           expect(session.ssl).toBe(true);
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
@@ -1365,14 +1444,14 @@ describe("UserSession", () => {
   describe(".getUser()", () => {
     afterEach(fetchMock.restore);
 
-    it("should cache metadata about the user", done => {
+    it("should cache metadata about the user", (done) => {
       // we intentionally only mock one response
       fetchMock.once(
         "https://www.arcgis.com/sharing/rest/community/self?f=json&token=token",
         {
           username: "jsmith",
           fullName: "John Smith",
-          role: "org_publisher"
+          role: "org_publisher",
         }
       );
 
@@ -1385,36 +1464,36 @@ describe("UserSession", () => {
         refreshTokenExpires: TOMORROW,
         refreshTokenTTL: 1440,
         username: "jsmith",
-        password: "123456"
+        password: "123456",
       });
 
       session
         .getUser()
-        .then(response => {
+        .then((response) => {
           expect(response.role).toEqual("org_publisher");
           session
             .getUser()
-            .then(cachedResponse => {
+            .then((cachedResponse) => {
               expect(cachedResponse.fullName).toEqual("John Smith");
               done();
             })
-            .catch(e => {
+            .catch((e) => {
               fail(e);
             });
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should never make more then 1 request", done => {
+    it("should never make more then 1 request", (done) => {
       // we intentionally only mock one response
       fetchMock.once(
         "https://www.arcgis.com/sharing/rest/community/self?f=json&token=token",
         {
           username: "jsmith",
           fullName: "John Smith",
-          role: "org_publisher"
+          role: "org_publisher",
         }
       );
 
@@ -1427,14 +1506,14 @@ describe("UserSession", () => {
         refreshTokenExpires: TOMORROW,
         refreshTokenTTL: 1440,
         username: "jsmith",
-        password: "123456"
+        password: "123456",
       });
 
       Promise.all([session.getUser(), session.getUser()])
         .then(() => {
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
@@ -1443,53 +1522,53 @@ describe("UserSession", () => {
   describe(".getUsername()", () => {
     afterEach(fetchMock.restore);
 
-    it("should fetch the username via getUser()", done => {
+    it("should fetch the username via getUser()", (done) => {
       // we intentionally only mock one response
       fetchMock.once(
         "https://www.arcgis.com/sharing/rest/community/self?f=json&token=token",
         {
-          username: "jsmith"
+          username: "jsmith",
         }
       );
 
       const session = new UserSession({
-        token: "token"
+        token: "token",
       });
 
       session
         .getUsername()
-        .then(response => {
+        .then((response) => {
           expect(response).toEqual("jsmith");
 
           // also test getting it from the cache.
           session
             .getUsername()
-            .then(username => {
+            .then((username) => {
               done();
 
               expect(username).toEqual("jsmith");
             })
-            .catch(e => {
+            .catch((e) => {
               fail(e);
             });
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should use a username if passed in the session", done => {
+    it("should use a username if passed in the session", (done) => {
       const session = new UserSession({
-        username: "jsmith"
+        username: "jsmith",
       });
 
       session
         .getUsername()
-        .then(response => {
+        .then((response) => {
           expect(response).toEqual("jsmith");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
@@ -1501,7 +1580,7 @@ describe("UserSession", () => {
       server: "https://www.arcgis.com",
       ssl: false,
       token: "token",
-      userId: "jsmith"
+      userId: "jsmith",
     };
 
     const MOCK_USER_SESSION = new UserSession({
@@ -1514,7 +1593,7 @@ describe("UserSession", () => {
       refreshTokenExpires: TOMORROW,
       refreshTokenTTL: 1440,
       username: "jsmith",
-      password: "123456"
+      password: "123456",
     });
 
     it("should create a credential object from a session", () => {
@@ -1551,7 +1630,7 @@ describe("UserSession", () => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
-        tokenExpires: TOMORROW
+        tokenExpires: TOMORROW,
       });
 
       const root = session.getServerRootUrl(
@@ -1564,7 +1643,7 @@ describe("UserSession", () => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
-        tokenExpires: TOMORROW
+        tokenExpires: TOMORROW,
       });
 
       const root = session.getServerRootUrl(
@@ -1579,7 +1658,7 @@ describe("UserSession", () => {
       const session = new UserSession({
         clientId: "id",
         token: "token",
-        tokenExpires: TOMORROW
+        tokenExpires: TOMORROW,
       });
 
       const root = session.getServerRootUrl(
@@ -1592,34 +1671,34 @@ describe("UserSession", () => {
   });
 
   describe("non-federated server", () => {
-    it("shouldnt fetch a fresh token if the current one isn't expired.", done => {
+    it("shouldnt fetch a fresh token if the current one isn't expired.", (done) => {
       const MOCK_USER_SESSION = new UserSession({
         username: "c@sey",
         password: "123456",
         token: "token",
         tokenExpires: TOMORROW,
-        server: "https://fakeserver.com/arcgis"
+        server: "https://fakeserver.com/arcgis",
       });
 
       MOCK_USER_SESSION.getToken(
         "https://fakeserver.com/arcgis/rest/services/Fake/MapServer/"
       )
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("token");
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           fail(err);
         });
     });
 
-    it("should fetch a fresh token if the current one is expired.", done => {
+    it("should fetch a fresh token if the current one is expired.", (done) => {
       const MOCK_USER_SESSION = new UserSession({
         username: "jsmith",
         password: "123456",
         token: "token",
         tokenExpires: YESTERDAY,
-        server: "https://fakeserver.com/arcgis"
+        server: "https://fakeserver.com/arcgis",
       });
 
       fetchMock.postOnce("https://fakeserver.com/arcgis/rest/info", {
@@ -1627,20 +1706,20 @@ describe("UserSession", () => {
         fullVersion: "10.6.1",
         authInfo: {
           isTokenBasedSecurity: true,
-          tokenServicesUrl: "https://fakeserver.com/arcgis/tokens/"
-        }
+          tokenServicesUrl: "https://fakeserver.com/arcgis/tokens/",
+        },
       });
 
       fetchMock.postOnce("https://fakeserver.com/arcgis/tokens/", {
         token: "fresh-token",
         expires: TOMORROW.getTime(),
-        username: " jsmith"
+        username: " jsmith",
       });
 
       MOCK_USER_SESSION.getToken(
         "https://fakeserver.com/arcgis/rest/services/Fake/MapServer/"
       )
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("fresh-token");
           const [url, options]: [string, RequestInit] = fetchMock.lastCall(
             "https://fakeserver.com/arcgis/tokens/"
@@ -1652,18 +1731,18 @@ describe("UserSession", () => {
           expect(options.body).toContain("client=referer");
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           fail(err);
         });
     });
 
-    it("should trim down the server url if necessary.", done => {
+    it("should trim down the server url if necessary.", (done) => {
       const MOCK_USER_SESSION = new UserSession({
         username: "jsmith",
         password: "123456",
         token: "token",
         tokenExpires: YESTERDAY,
-        server: "https://fakeserver.com/arcgis/rest/services/blah/"
+        server: "https://fakeserver.com/arcgis/rest/services/blah/",
       });
 
       fetchMock.postOnce("https://fakeserver.com/arcgis/rest/info", {
@@ -1671,52 +1750,52 @@ describe("UserSession", () => {
         fullVersion: "10.6.1",
         authInfo: {
           isTokenBasedSecurity: true,
-          tokenServicesUrl: "https://fakeserver.com/arcgis/tokens/"
-        }
+          tokenServicesUrl: "https://fakeserver.com/arcgis/tokens/",
+        },
       });
 
       fetchMock.postOnce("https://fakeserver.com/arcgis/tokens/", {
         token: "fresh-token",
         expires: TOMORROW.getTime(),
-        username: " jsmith"
+        username: " jsmith",
       });
 
       MOCK_USER_SESSION.getToken(
         "https://fakeserver.com/arcgis/rest/services/Fake/MapServer/"
       )
-        .then(token => {
+        .then((token) => {
           expect(token).toBe("fresh-token");
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           fail(err);
         });
     });
 
-    it("should throw an error if the server isnt trusted.", done => {
+    it("should throw an error if the server isnt trusted.", (done) => {
       fetchMock.postOnce("https://fakeserver2.com/arcgis/rest/info", {
         currentVersion: 10.61,
         fullVersion: "10.6.1",
         authInfo: {
           isTokenBasedSecurity: true,
-          tokenServicesUrl: "https://fakeserver2.com/arcgis/tokens/"
-        }
+          tokenServicesUrl: "https://fakeserver2.com/arcgis/tokens/",
+        },
       });
       const MOCK_USER_SESSION = new UserSession({
         username: "c@sey",
         password: "123456",
         token: "token",
         tokenExpires: TOMORROW,
-        server: "https://fakeserver.com/arcgis"
+        server: "https://fakeserver.com/arcgis",
       });
 
       MOCK_USER_SESSION.getToken(
         "https://fakeserver2.com/arcgis/rest/services/Fake/MapServer/"
       )
-        .then(token => {
+        .then((token) => {
           fail(token);
         })
-        .catch(err => {
+        .catch((err) => {
           expect(err.code).toBe("NOT_FEDERATED");
           expect(err.originalMessage).toEqual(
             "https://fakeserver2.com/arcgis/rest/services/Fake/MapServer/ is not federated with any portal and is not explicitly trusted."

--- a/packages/arcgis-rest-auth/test/app-tokens.test.ts
+++ b/packages/arcgis-rest-auth/test/app-tokens.test.ts
@@ -1,0 +1,91 @@
+/* Copyright (c) 2018-2020 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+
+import * as fetchMock from "fetch-mock";
+
+import { exchangeToken, platformSelf } from "../src/app-tokens";
+
+describe("app-token functions: ", () => {
+  describe("exchangeToken:", () => {
+    it("makes a request to /oauth2/exchangeToken passing params", () => {
+      const EXCHANGE_TOKEN_URL =
+        "https://www.arcgis.com/sharing/rest/oauth2/exchangeToken";
+      fetchMock.postOnce(EXCHANGE_TOKEN_URL, {
+        token: "APP-TOKEN",
+      });
+      return exchangeToken("FAKE-TOKEN", "CLIENT-ID-ABC123")
+        .then((response) => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+            EXCHANGE_TOKEN_URL
+          );
+          expect(url).toEqual(EXCHANGE_TOKEN_URL);
+          expect(options.body).toContain("f=json");
+          expect(options.body).toContain("token=FAKE-TOKEN");
+          expect(options.body).toContain("client_id=CLIENT-ID-ABC123");
+          expect(response).toEqual("APP-TOKEN");
+        })
+        .catch((e) => fail(e));
+    });
+    it("takes a portalUrl", () => {
+      const PORTAL_BASE_URL = "https://my-portal.com/instance/sharing/rest";
+      const PORTAL_EXCHANGE_URL = `${PORTAL_BASE_URL}/oauth2/exchangeToken`;
+      fetchMock.postOnce(PORTAL_EXCHANGE_URL, {
+        valid: true,
+        viewOnlyUserTypeApp: false,
+      });
+      return exchangeToken("FAKE-TOKEN", "CLIENT-ID-ABC123", PORTAL_BASE_URL)
+        .then((response) => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+            PORTAL_EXCHANGE_URL
+          );
+          expect(url).toEqual(PORTAL_EXCHANGE_URL);
+        })
+        .catch((e) => fail(e));
+    });
+  });
+
+  describe("platformSelf:", () => {
+    it("makes a request to /oauth2/platformSelf passing params", () => {
+      const PLATFORM_SELF_URL =
+        "https://www.arcgis.com/sharing/rest/oauth2/platformSelf";
+      fetchMock.postOnce(PLATFORM_SELF_URL, {
+        username: "jsmith",
+        token: "APP-TOKEN",
+      });
+      return platformSelf(
+        "CLIENT-ID-ABC123",
+        "https://hub.arcgis.com/torii-provider-arcgis/redirect.html"
+      )
+        .then((response) => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+            PLATFORM_SELF_URL
+          );
+          expect(url).toEqual(PLATFORM_SELF_URL);
+          const headers = options.headers || ({} as any);
+          expect(headers["X-Esri-Auth-Redirect-Uri"]).toBe(
+            "https://hub.arcgis.com/torii-provider-arcgis/redirect.html"
+          );
+          expect(headers["X-Esri-Auth-Client-Id"]).toBe("CLIENT-ID-ABC123");
+          expect(response.token).toEqual("APP-TOKEN");
+          expect(response.username).toEqual("jsmith");
+        })
+        .catch((e) => fail(e));
+    });
+    it("takes a portalUrl", () => {
+      const PORTAL_BASE_URL = "https://my-portal.com/instance/sharing/rest";
+      const PORTAL_PLATFORM_SELF_URL = `${PORTAL_BASE_URL}/oauth2/platformSelf`;
+      fetchMock.postOnce(PORTAL_PLATFORM_SELF_URL, {
+        username: "jsmith",
+        token: "APP-TOKEN",
+      });
+      return platformSelf("FAKE-TOKEN", "CLIENT-ID-ABC123", PORTAL_BASE_URL)
+        .then((response) => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+            PORTAL_PLATFORM_SELF_URL
+          );
+          expect(url).toEqual(PORTAL_PLATFORM_SELF_URL);
+        })
+        .catch((e) => fail(e));
+    });
+  });
+});

--- a/packages/arcgis-rest-auth/test/validate-app-access.test.ts
+++ b/packages/arcgis-rest-auth/test/validate-app-access.test.ts
@@ -1,0 +1,46 @@
+/* Copyright (c) 2018-2020 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
+import * as fetchMock from "fetch-mock";
+
+import { validateAppAccess } from "../src/validate-app-access";
+
+const VERIFYAPPACCESS_URL =
+  "https://www.arcgis.com/sharing/rest/oauth2/validateAppAccess";
+
+describe("validateAppAccess: ", () => {
+  it("makes a request to /oauth2/validateAppAccess passing params", () => {
+    fetchMock.postOnce(VERIFYAPPACCESS_URL, {
+      valid: true,
+      viewOnlyUserTypeApp: false,
+    });
+    return validateAppAccess("FAKE-TOKEN", "abc123")
+      .then((response) => {
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          VERIFYAPPACCESS_URL
+        );
+        expect(url).toEqual(VERIFYAPPACCESS_URL);
+        expect(options.body).toContain("f=json");
+        expect(options.body).toContain("token=FAKE-TOKEN");
+        expect(options.body).toContain("client_id=abc123");
+        expect(response.valid).toEqual(true);
+        expect(response.viewOnlyUserTypeApp).toBe(false);
+      })
+      .catch((e) => fail(e));
+  });
+  it("takes a portalUrl", () => {
+    const PORTAL_BASE_URL = "https://my-portal.com/instance/sharing/rest";
+    const PORTAL_VERIFY_URL = `${PORTAL_BASE_URL}/oauth2/validateAppAccess`;
+    fetchMock.postOnce(PORTAL_VERIFY_URL, {
+      valid: true,
+      viewOnlyUserTypeApp: false,
+    });
+    return validateAppAccess("FAKE-TOKEN", "abc123", PORTAL_BASE_URL)
+      .then((response) => {
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          PORTAL_VERIFY_URL
+        );
+        expect(url).toEqual(PORTAL_VERIFY_URL);
+      })
+      .catch((e) => fail(e));
+  });
+});


### PR DESCRIPTION
In an upcoming release, the `esri_auth` clear-text cookie will be removed in favor of an encrypted `esri_aopc` cookie that client's can not read.

To get a token from the `esri_aopc` cookie, the app needs to call `/oauth2/platformSelf`, passing in the client_id and redirect_uri of the app for which they want an app-specific token to be issued.

This is exposed as `platformSelf(clientId, redirectUri, portal?) -> {username: "jsmith", token: "aj8csja..."}`

 ---

If the app has a token from another app (i.e. it is passed auth information via "postMessage") then the app can exchange that token for a token that is specific to the app.
 
For example - a Dashboard that is iframed into a Hub Site may get passed an `ICredential` via `postMessage`, but that credential contains a token for the Hub application. 

To exchange that for a token that's specific to the Dashboard app, it can use the `/oauth2/exchangeToken` end-point, which is wrapped in to REST-JS as `exchangeToken(currentToken, clientId, portal) -> {token: "ashda898ds..."}`

---

Finally, to streamline checking if the current user has access to the app, and if the app should present a "Viewer" UX, there is the `/oauth2/validateAppAccess` end point, which is wrapped as `validateAppAccess(token, clientId) -> {valid: true, viewOnlyUserTypeApp: false}`
This is also exposed in the `UserSession` object as `session.validateAppAccess(clientId) -> {valid: true, viewOnlyUserTypeApp:false}`

These functions are all specifically for Esri "Platform" applications hosted on *.arcgis.com or within an Enterprise Portal. Other apps will receive errors calling these functions.