### PR TITLE
Make "layers" parameter of IExportParameters optional

### DIFF
--- a/packages/arcgis-rest-portal/src/items/export.ts
+++ b/packages/arcgis-rest-portal/src/items/export.ts
@@ -14,14 +14,14 @@ export interface IExportLayerInfo {
 }
 
 export interface IExportParameters {
-  layers: IExportLayerInfo[];
+  layers?: IExportLayerInfo[];
   targetSR?: ISpatialReference | string;
 }
 
 export interface IExportItemRequestOptions extends IUserItemOptions {
   title?: string;
   exportFormat: ExportFormat;
-  exportParameters: IExportParameters;
+  exportParameters?: IExportParameters;
 }
 
 export interface IExportItemResponse {


### PR DESCRIPTION
We want the option of not setting `layers` in IExportParameters. That will force the /export service to include all the layers in the delivered export.