### PR TITLE
Add editingInfo to ILayerDefinition.

### DIFF
--- a/packages/arcgis-rest-feature-layer/test/mocks/service.ts
+++ b/packages/arcgis-rest-feature-layer/test/mocks/service.ts
@@ -187,6 +187,9 @@ export const getFeatureServiceResponse: ILayerDefinition = {
     supportsDistinct: true,
     supportsSqlExpression: true
   },
+  editingInfo: {
+    lastEditDate: (new Date()).getTime()
+  },
   extent: {
     xmin: -1.4842597721444273e7,
     ymin: -7250478.783951572,

--- a/packages/arcgis-rest-types/src/webmap.ts
+++ b/packages/arcgis-rest-types/src/webmap.ts
@@ -892,6 +892,11 @@ export interface IDrawingInfo {
   transparency?: number;
 }
 
+export interface IEditingInfo {
+  /** date of last edit to the layer  */
+  lastEditDate?: number
+}
+
 /**
  * `ILayerDefinition` can also be imported from the following packages:
  *
@@ -923,6 +928,8 @@ export interface ILayerDefinition extends IHasZM {
   drawingInfo?: any;
   /** An object defining the rectangular area. */
   extent?: IExtent | null;
+  /** An object defining the editing info (last edit date). */
+  editingInfo?: IEditingInfo;
   /** Feature reductions declutter the screen by hiding features that would otherwise intersect with other features on screen. */
   featureReduction?: any;
   /** An array of field objects containing information about the attribute fields for the feature collection or layer. */


### PR DESCRIPTION
Layers often have a property named `editingInfo`:

```
  "editingInfo" : {
    "lastEditDate" : 1604943620640
  }
```

This PR adds `editingInfo` to `ILayerDefinition`.