### PR TITLE
Allow custom encoders in `request`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ notifications:
   slack:
     secure: KghYpsaoCZB1sPOqk1d+JhfBOkg76Cq8eMK665ozdf484RdPvObqLrxyrt9i+sDMDv/oZT+VuvGXsbHj6R+TUh87r2Yhfizcwvdotc4VTHei4y/oNX6cRhV8ryQox/0j6GClqI43A4kIsuOcUm8pI4FTGOhDQOK7+UDcuvcSa5VR7N7GJ97zfzC9gQtRsbfD5WKY4BEr+KlcWt0KCCbp1+Jh7craEO30ztUl38BuUuW7F1/AykrTX6kgS5E5ssUQ0pJPBlzpjb3G5UEeodzOD9wUBVLIBAbgQsofAPLi0pHeyCCeEOuTxXEo7SD8fG+kBstPlncR+V8goCEBnAJysIvBznUxLjrnxcU7V40g+iTENKwhVTIiZzZN3Z9buJd001MRaWjOTCWX80Ig6oraH8WJk7W1qtKzsDK9Lsp2N9pxNTPASbAQoFDlMCGcWYGixq6IhIAwsk1Pkb689F67vHaES8qMXkIHifB0j7yRMwrHinYFqUYASQOECPNEMJv3iqByXntmMP8X/r3VBujMehGodZ1dnbWvAOdWdEmG3KCVpn42ocKCj6k4WZL62nSxs3W00E1UVPnXujT3ENk/3L/VJE3tRWFCSbR9HnfBSDVA6WaFu4EFDg8WV6fn2T0FHKTBgCtTugQo8bsoyReYZvEU/27O/B+d5/9nqMHqyy4=
 node_js:
-  - "node"
+  # Currently `npm ci` fails when installing a GH repo dep that has a prepare script that uses a command from a devDependency
+  # https://github.com/npm/cli/issues/2084 is the issue, it's closed but node has not cut a release yet 11/9/2020
+  # Will return this once it's resolved
+  # - "node"
   - "lts/*"
   - 10
 cache: npm

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -241,6 +241,14 @@ export function request(
     );
   }
 
+  // Check for custom encoders
+  if (!options.encodeQueryString) {
+    options.encodeQueryString = encodeQueryString;
+  }
+  if (!options.encodeFormData) {
+    options.encodeFormData = encodeFormData;
+  }
+
   const { httpMethod, authentication, rawResponse } = options;
 
   const params: IParams = {
@@ -285,21 +293,21 @@ export function request(
       const requestHeaders: {
         [key: string]: any;
       } = {};
-      
+
       if (fetchOptions.method === "GET") {
         // Prevents token from being passed in query params when hideToken option is used.
         /* istanbul ignore if - window is always defined in a browser. Test case is covered by Jasmine in node test */
-        if (params.token && options.hideToken && 
+        if (params.token && options.hideToken &&
           // Sharing API does not support preflight check required by modern browsers https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
           typeof window === 'undefined') {
           requestHeaders["X-Esri-Authorization"] = `Bearer ${params.token}`
           delete params.token;
         }
         // encode the parameters into the query string
-        const queryParams = encodeQueryString(params);
+        const queryParams = options.encodeQueryString(params);
         // dont append a '?' unless parameters are actually present
         const urlWithQueryString =
-          queryParams === "" ? url : url + "?" + encodeQueryString(params);
+          queryParams === "" ? url : url + "?" + queryParams;
 
         if (
           // This would exceed the maximum length for URLs specified by the consumer and requires POST
@@ -330,7 +338,7 @@ export function request(
       const forceFormData = new RegExp("/items/.+/updateResources").test(url);
 
       if (fetchOptions.method === "POST") {
-        fetchOptions.body = encodeFormData(params, forceFormData);
+        fetchOptions.body = options.encodeFormData(params, forceFormData);
       }
 
       // Mixin headers from request options

--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -37,6 +37,14 @@ export interface IRequestOptions {
    */
   fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
   /**
+   * The implementation for converting parametrs into a query string. Defaults to `encodeQueryString` in this package.
+   */
+  encodeQueryString?: (params: any) => string;
+  /**
+   * The implementation for converting parametrs into a FormData. Defaults to `encodeFormData` in this package.
+   */
+  encodeFormData?: (params: any, forceFormData?: boolean) => FormData | string;
+  /**
    * If the length of a GET request's URL exceeds `maxUrlLength` the request will use POST instead.
    */
   maxUrlLength?: number;

--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -39,11 +39,11 @@ export interface IRequestOptions {
   /**
    * The implementation for converting parametrs into a query string. Defaults to `encodeQueryString` in this package.
    */
-  encodeQueryString?: (params: any) => string;
+  encodeQueryString?: (params: IParams) => string;
   /**
    * The implementation for converting parametrs into a FormData. Defaults to `encodeFormData` in this package.
    */
-  encodeFormData?: (params: any, forceFormData?: boolean) => FormData | string;
+  encodeFormData?: (params: IParams, forceFormData?: boolean) => FormData | string;
   /**
    * If the length of a GET request's URL exceeds `maxUrlLength` the request will use POST instead.
    */

--- a/packages/arcgis-rest-request/src/utils/append-custom-params.ts
+++ b/packages/arcgis-rest-request/src/utils/append-custom-params.ts
@@ -19,7 +19,9 @@ export function appendCustomParams<T extends IRequestOptions>(
     "portal",
     "fetch",
     "maxUrlLength",
-    "headers"
+    "headers",
+    "encodeFormData",
+    "encodeQueryString"
   ];
 
   const options: T = {

--- a/packages/arcgis-rest-request/src/utils/encode-form-data.ts
+++ b/packages/arcgis-rest-request/src/utils/encode-form-data.ts
@@ -3,6 +3,8 @@
 
 import { processParams, requiresFormData } from "./process-params";
 import { encodeQueryString } from "./encode-query-string";
+import { IParams } from "./IParams";
+
 /**
  * Encodes parameters in a [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object in browsers or in a [FormData](https://github.com/form-data/form-data) in Node.js
  *
@@ -10,7 +12,7 @@ import { encodeQueryString } from "./encode-query-string";
  * @returns The complete [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object.
  */
 export function encodeFormData(
-  params: any,
+  params: IParams,
   forceFormData?: boolean
 ): FormData | string {
   // see https://github.com/Esri/arcgis-rest-js/issues/499 for more info.

--- a/packages/arcgis-rest-request/src/utils/encode-query-string.ts
+++ b/packages/arcgis-rest-request/src/utils/encode-query-string.ts
@@ -2,6 +2,7 @@
  * Apache-2.0 */
 
 import { processParams } from "./process-params";
+import { IParams } from "./IParams";
 
 export function encodeParam(key: string, value: any) {
   return encodeURIComponent(key) + "=" + encodeURIComponent(value);
@@ -13,7 +14,7 @@ export function encodeParam(key: string, value: any) {
  * @param params An object to be encoded.
  * @returns An encoded query string.
  */
-export function encodeQueryString(params: any): string {
+export function encodeQueryString(params: IParams): string {
   const newParams = processParams(params);
   return Object.keys(newParams)
     .map((key: any) => {

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, ErrorTypes, setDefaultRequestOptions } from "../src/index";
+import { request, ErrorTypes, encodeFormData, encodeQueryString, setDefaultRequestOptions } from "../src/index";
 import * as fetchMock from "fetch-mock";
 import {
   SharingRestInfo,
@@ -41,6 +41,57 @@ describe("request()", () => {
       .then(response => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/info?f=json");
+        expect(options.method).toBe("GET");
+        expect(response).toEqual(SharingRestInfo);
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
+  it("should make a basic POST request with a custom FormData encoder", done => {
+    fetchMock.once("*", SharingRestInfo);
+
+    request("https://www.arcgis.com/sharing/rest/info", {
+      httpMethod: "POST",
+      encodeFormData: (params: any, forceFormData?: boolean) => {
+        const customParams = {
+          ...params,
+          custom: true
+        };
+        return encodeFormData(customParams);
+      }
+    })
+      .then(response => {
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual("https://www.arcgis.com/sharing/rest/info");
+        expect(options.method).toBe("POST");
+        expect(response).toEqual(SharingRestInfo);
+        expect(options.body).toContain("f=json");
+        done();
+      })
+      .catch(e => {
+        fail(e);
+      });
+  });
+
+  it("should make a basic GET request with a custom query string encoder", done => {
+    fetchMock.once("*", SharingRestInfo);
+
+    request("https://www.arcgis.com/sharing/rest/info", {
+      httpMethod: "GET",
+      encodeQueryString: (params: any) => {
+        const customParams = {
+          ...params,
+          custom: true
+        };
+        return encodeQueryString(customParams);
+      }
+    })
+      .then(response => {
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual("https://www.arcgis.com/sharing/rest/info?f=json&custom=true");
         expect(options.method).toBe("GET");
         expect(response).toEqual(SharingRestInfo);
         done();
@@ -300,7 +351,7 @@ describe("request()", () => {
       }
     };
 
-    const MockFetch = function() {
+    const MockFetch = function () {
       return Promise.resolve(MockFetchResponse);
     };
 
@@ -479,7 +530,7 @@ describe("request()", () => {
         }
       };
 
-      const MockFetch = function() {
+      const MockFetch = function () {
         return Promise.resolve(MockFetchResponse);
       };
 


### PR DESCRIPTION
Proposed as an alternate approach to PR #686 to minimize impact.  Modeled after the way that `request` supports a custom `fetch` implementation.