### PR TITLE
fix: platformSelf to send cookies and append f=json in url

### DIFF
--- a/packages/arcgis-rest-auth/src/app-tokens.ts
+++ b/packages/arcgis-rest-auth/src/app-tokens.ts
@@ -71,12 +71,19 @@ export function platformSelf(
   redirectUri: string,
   portal: string = "https://www.arcgis.com/sharing/rest"
 ): Promise<IPlatformSelfResponse> {
-  const url = `${portal}/oauth2/platformSelf`;
+  // TEMPORARY: the f=json should not be needed, but currently is
+  const url = `${portal}/oauth2/platformSelf?f=json`;
   const ro = {
     method: "POST",
     headers: {
       "X-Esri-Auth-Client-Id": clientId,
       "X-Esri-Auth-Redirect-Uri": redirectUri,
+    },
+    // We need to ensure the cookies are sent as that's
+    // what the API uses to convert things
+    credentials: "include",
+    params: {
+      f: "json",
     },
   } as IRequestOptions;
   // make the request and return the token

--- a/packages/arcgis-rest-auth/test/app-tokens.test.ts
+++ b/packages/arcgis-rest-auth/test/app-tokens.test.ts
@@ -47,7 +47,7 @@ describe("app-token functions: ", () => {
   describe("platformSelf:", () => {
     it("makes a request to /oauth2/platformSelf passing params", () => {
       const PLATFORM_SELF_URL =
-        "https://www.arcgis.com/sharing/rest/oauth2/platformSelf";
+        "https://www.arcgis.com/sharing/rest/oauth2/platformSelf?f=json";
       fetchMock.postOnce(PLATFORM_SELF_URL, {
         username: "jsmith",
         token: "APP-TOKEN",
@@ -73,7 +73,7 @@ describe("app-token functions: ", () => {
     });
     it("takes a portalUrl", () => {
       const PORTAL_BASE_URL = "https://my-portal.com/instance/sharing/rest";
-      const PORTAL_PLATFORM_SELF_URL = `${PORTAL_BASE_URL}/oauth2/platformSelf`;
+      const PORTAL_PLATFORM_SELF_URL = `${PORTAL_BASE_URL}/oauth2/platformSelf?f=json`;
       fetchMock.postOnce(PORTAL_PLATFORM_SELF_URL, {
         username: "jsmith",
         token: "APP-TOKEN",


### PR DESCRIPTION
Update the recently added `platformSelf` function to send cookies as well as `?f=json` in the url. 


The latter should be a short-term fix as the API should not require it, but currently it will 405 on the OPTIONS pre-flight if that's no in the url as shown

![image](https://user-images.githubusercontent.com/119129/99114177-a3a4f980-25ad-11eb-8193-910ec6ab5fc9.png)
