### PR TITLE
feat(UserSession): added optional 'popupWindowFeatures' to 'IOAuth2Opions'

### DIFF
--- a/demos/oauth2-browser/index.html
+++ b/demos/oauth2-browser/index.html
@@ -162,7 +162,8 @@
           arcgisRest.UserSession.beginOAuth2({
             clientId: clientId,
             redirectUri: redirect_uri + 'authenticate.html',
-            popup: true
+            popup: true,
+            popupWindowFeatures: getPopupWindowFeatures(500, 500)
           }).then(function (newSession) {
             // Upon a successful login, update the session with the new session.
             session = newSession;
@@ -173,6 +174,14 @@
           });
         }
       });
+
+      function getPopupWindowFeatures(w, h) {
+        w = w || 500, h = h || 500;
+        // centers popup
+        const y = window.top.outerHeight / 2 + window.top.screenY - h / 2;
+        const x = window.top.outerWidth / 2 + window.top.screenX - w / 2;
+        return 'toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=no,copyhistory=no,width=' + w + ',height=' + h + ',top=' + y + ',left=' + x;
+      }
 
       // Attach a listener to the sign in buttons.
       document.getElementById('inlineRedirectButton').addEventListener('click', function (event) {

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -130,6 +130,13 @@ export interface IOAuth2Options {
   popup?: boolean;
 
   /**
+   * The window features passed to window.open() when `popup` is true. Defaults to `height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes`
+   *
+   * @browserOnly
+   */
+  popupWindowFeatures?: string;
+
+  /**
    * Duration (in minutes) that a refresh token will be valid.
    *
    * @nodeOnly
@@ -301,6 +308,7 @@ export class UserSession implements IAuthenticationManager {
       duration,
       redirectUri,
       popup,
+      popupWindowFeatures,
       state,
       locale,
       params,
@@ -310,6 +318,7 @@ export class UserSession implements IAuthenticationManager {
         provider: "arcgis",
         duration: 20160,
         popup: true,
+        popupWindowFeatures: "height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes",
         state: options.clientId,
         locale: "",
       },
@@ -366,7 +375,7 @@ export class UserSession implements IAuthenticationManager {
     win.open(
       url,
       "oauth-window",
-      "height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes"
+      popupWindowFeatures
     );
 
     return session.promise;

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -130,7 +130,7 @@ export interface IOAuth2Options {
   popup?: boolean;
 
   /**
-   * The window features passed to window.open() when `popup` is true. Defaults to `height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes`
+   * The window features passed to [window.open()](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) when `popup` is true. Defaults to `height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes`
    *
    * @browserOnly
    */


### PR DESCRIPTION
Added optional 'popupWindowFeatures' to 'IOAuth2Options'

Adding an optional 'popupWindowFeatures' property to ‘IOAuth2Options’ allows developers to pass
window features to the popup window. This allows a developer to center the popup if desired using
his own calculated offsets. Currently the popup window features are hard coded. This change simply
exposes them to the developer and provides a default (the prior hard coded values) if not supplied.
The ArcGIS JavaScript API already has the feature:
https://developers.arcgis.com/javascript/latest/api-reference/esri-identity-OAuthInfo.html#popupWindowFeatures

AFFECTS PACKAGES:
@esri/arcgis-rest-auth