### PR TITLE
fix: export app-tokens

### DIFF
--- a/packages/arcgis-rest-auth/src/index.ts
+++ b/packages/arcgis-rest-auth/src/index.ts
@@ -7,3 +7,4 @@ export * from "./fetch-token";
 export * from "./generate-token";
 export * from "./authenticated-request-options";
 export { IUser } from "@esri/arcgis-rest-types";
+export * from "./app-tokens";


### PR DESCRIPTION
Missed exporting `app-token` functions from the package 🙃

