### PR TITLE
Small Fixes: Export validateAppAccess, add expires_in to IPlatformSelfResponse

### DIFF
--- a/packages/arcgis-rest-auth/src/app-tokens.ts
+++ b/packages/arcgis-rest-auth/src/app-tokens.ts
@@ -40,9 +40,23 @@ export function exchangeToken(
   return request(url, ro).then((response) => response.token);
 }
 
+/**
+ * Response from the `platformSelf(...)` function.
+ */
 export interface IPlatformSelfResponse {
+  /**
+   * Username of the user the encrypted cookie was issued for
+   */
   username: string;
+  /**
+   * Token the consuming application can use, It is tied to the
+   * clientId used in the `platformSelf` call
+   */
   token: string;
+  /**
+   * Token expiration, in seconds-from-now
+   */
+  expires_in: number;
 }
 
 /**
@@ -62,6 +76,33 @@ export interface IPlatformSelfResponse {
  *
  * Note: This is only usable by Esri applications hosted on *arcgis.com, *esri.com or within
  * an ArcGIS Enterprise installation. Custom applications can not use this.
+ *
+ * ```js
+ * // convert the encrypted platform cookie into a UserSession
+ * import { platformSelf, UserSession } from '@esri/arcgis-rest-auth';
+ *
+ * const portal = 'https://www.arcgis.com/sharing/rest';
+ * const clientId = 'YOURAPPCLIENID';
+ *
+ * // exchange esri_aopc cookie
+ * return platformSelf(clientId, 'https://your-app-redirect-uri', portal)
+ * .then((response) => {
+ *  const currentTimestamp = new Date().getTime();
+ *  const tokenExpiresTimestamp = currentTimestamp + (response.expires_in * 1000);
+ *  // Construct the session and return it
+ *  return new UserSession({
+ *    portal,
+ *    clientId,
+ *    username: response.username,
+ *    token: response.token,
+ *    tokenExpires: new Date(tokenExiresTimestamp),
+ *    ssl: true
+ *  });
+ * })
+ *
+ * ```
+ *
+ *
  * @param clientId
  * @param redirectUri
  * @param portal

--- a/packages/arcgis-rest-auth/src/index.ts
+++ b/packages/arcgis-rest-auth/src/index.ts
@@ -8,3 +8,4 @@ export * from "./generate-token";
 export * from "./authenticated-request-options";
 export { IUser } from "@esri/arcgis-rest-types";
 export * from "./app-tokens";
+export * from "./validate-app-access";

--- a/packages/arcgis-rest-auth/src/index.ts
+++ b/packages/arcgis-rest-auth/src/index.ts
@@ -8,4 +8,5 @@ export * from "./generate-token";
 export * from "./authenticated-request-options";
 export { IUser } from "@esri/arcgis-rest-types";
 export * from "./app-tokens";
+
 export * from "./validate-app-access";


### PR DESCRIPTION
As it says - export a fn that should have been exported a while back, and add the `expires_in` prop to the `IPlatformSelfResponse`

Also updates the `platformSelf` doc to include an example creating a UserSession from the `platformSelf` response

![image](https://user-images.githubusercontent.com/119129/104218933-ae87d900-53fa-11eb-95f7-4be84b4c830c.png)
