### PR TITLE
docs(typos in postMessage guide): fix typos 

### DIFF
--- a/docs/src/guides/embedded-apps.md
+++ b/docs/src/guides/embedded-apps.md
@@ -54,9 +54,9 @@ UserSession.beginOAuth2({
 
 #### 2 Host App adds params to embed url
 
-Let's suppose the host app is embedding `https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd`. To tell the embedded app that it should request authentication from the parent we need to add two url parameters:
+Let's suppose the host app is embedding `https://storymaps.arcgis.com/stories/15a9b9991fff47ad84f4618a28b01afd`. To tell the embedded app that it should request authentication from the parent we need to add a url parameter:
 
-- `arcgis-auth-origin=https://myapp.com` - This tells the app it's embedded in an iframe and should request auth from the parent, and what 'origin' to expect messages from, what origin to post messages to, and also to ignore other origins. **note** this should be uri encoded
+- `arcgis-auth-origin=https://myapp.com` - This tells the app it's embedded in an iframe and should request auth from the parent, and what 'origin' to expect messages from, what origin to post messages to, and also to ignore other origins. **note** the uri must encoded via `encodeURIComponent()` as shown below
 
 ```js
 const originalUrl =


### PR DESCRIPTION
In which I moved too fast on the last PR

AFFECTS PACKAGES:
@esri/arcgis-rest-auth