### PR TITLE
Change type of ITable.id to number

### DIFF
--- a/packages/arcgis-rest-service-admin/test/addTo.test.ts
+++ b/packages/arcgis-rest-service-admin/test/addTo.test.ts
@@ -64,22 +64,22 @@ describe("add to feature service", () => {
 
     const tableDescriptionFayard: ITable = {
       name: "Fayard",
-      id: "1914"
+      id: 1914
     };
 
     const tableDescriptionHarold: ITable = {
       name: "Harold",
-      id: "1921"
+      id: 1921
     };
 
     const tableDescriptionGene: ITable = {
       name: "Gene",
-      id: "1912"
+      id: 1912
     };
 
     const tableDescriptionFail: ITable = {
       name: "",
-      id: ""
+      id: 0
     };
 
     it("should add a pair of layers", done => {

--- a/packages/arcgis-rest-types/src/webmap.ts
+++ b/packages/arcgis-rest-types/src/webmap.ts
@@ -416,8 +416,8 @@ export interface ITable {
   capabilities?: string;
   /** Object indicating the definitionEditor used as a layer's interactive filter. */
   definitionEditor?: IDefinitionEditor;
-  /** Unique string identifier for the table. */
-  id?: string;
+  /** Unique identifier for the table. */
+  id?: number;
   /** Unique string value indicating an item registered in ArcGIS Online or your organization's portal. */
   itemId?: string;
   /** A layerDefinition object defining a definition expression for the table. */


### PR DESCRIPTION
It seems that the type of `ITable.id` should be `number` instead of `string`.

See issue: #808 

AFFECTS PACKAGES:
@esri/arcgis-rest-types

ISSUES CLOSED: #808