### PR TITLE
fix(removeItemResource): support correct parameters

### DIFF
--- a/packages/arcgis-rest-portal/src/items/helpers.ts
+++ b/packages/arcgis-rest-portal/src/items/helpers.ts
@@ -124,6 +124,18 @@ export interface IItemResourceOptions extends IUserItemOptions {
   resource?: any;
 }
 
+export interface IRemoveItemResourceOptions extends IUserItemOptions {
+  /**
+   * Resource item to be removed. Resource prefix needs to be specified if the file resource has one.
+   */
+  resource?: string;
+
+  /**
+   * If true, all file resources are removed.
+   */
+  deleteAll?: boolean;
+}
+
 export interface ICreateUpdateItemOptions extends IUserRequestOptions {
   /**
    * The owner of the item. If this property is not present, `item.owner` will be passed, or lastly `authentication.username`.

--- a/packages/arcgis-rest-portal/src/items/remove.ts
+++ b/packages/arcgis-rest-portal/src/items/remove.ts
@@ -6,7 +6,7 @@ import { request, appendCustomParams } from "@esri/arcgis-rest-request";
 import { getPortalUrl } from "../util/get-portal-url";
 import {
   IUserItemOptions,
-  IItemResourceOptions,
+  IRemoveItemResourceOptions,
   IFolderIdOptions,
   determineOwner,
   IManageItemRelationshipOptions
@@ -79,7 +79,7 @@ export function removeItemRelationship(
  * @returns A Promise that deletes an item resource.
  */
 export function removeItemResource(
-  requestOptions: IItemResourceOptions
+  requestOptions: IRemoveItemResourceOptions
 ): Promise<{ success: boolean }> {
   return determineOwner(requestOptions).then(owner => {
     const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
@@ -91,6 +91,12 @@ export function removeItemResource(
       ...requestOptions.params,
       resource: requestOptions.resource
     };
+
+    // only override the deleteAll param specified previously if it is passed explicitly
+    if (typeof requestOptions.deleteAll !== "undefined") {
+      requestOptions.params.deleteAll = requestOptions.deleteAll;
+    }
+
     return request(url, requestOptions);
   });
 }

--- a/packages/arcgis-rest-portal/test/items/remove.test.ts
+++ b/packages/arcgis-rest-portal/test/items/remove.test.ts
@@ -163,6 +163,29 @@ describe("search", () => {
         });
     });
 
+    it("should remove a resource with deleteAll", done => {
+      fetchMock.once("*", RemoveItemResourceResponse);
+      removeItemResource({
+        id: "3ef",
+        owner: "dbouwman",
+        resource: "image/banner.png",
+        deleteAll: true,
+        ...MOCK_USER_REQOPTS
+      })
+        .then(response => {
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/removeResources"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain(encodeParam("deleteAll", "true"));
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+
     it("should remove a resource with extra params", done => {
       fetchMock.once("*", RemoveItemResourceResponse);
       removeItemResource({


### PR DESCRIPTION
- Removes unused request options (e.g. 'prefix')
- Adds support for optional 'deleteAll'

AFFECTS PACKAGES:
@esri/arcgis-rest-portal