### PR TITLE
Fix UserSession token duration for oauth

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -344,7 +344,7 @@ export class UserSession implements IAuthenticationManager {
 
     const session = defer<UserSession>();
 
-    win[`__ESRI_REST_AUTH_HANDLER_${clientId}`] = function(
+    win[`__ESRI_REST_AUTH_HANDLER_${clientId}`] = function (
       errorString: any,
       oauthInfoString: string
     ) {
@@ -534,7 +534,7 @@ export class UserSession implements IAuthenticationManager {
     };
 
     response.writeHead(301, {
-      Location: `${portal}/oauth2/authorize?client_id=${clientId}&duration=${duration}&response_type=code&redirect_uri=${encodeURIComponent(
+      Location: `${portal}/oauth2/authorize?client_id=${clientId}&expiration=${duration}&response_type=code&redirect_uri=${encodeURIComponent(
         redirectUri
       )}`,
     });

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -344,7 +344,7 @@ export class UserSession implements IAuthenticationManager {
 
     const session = defer<UserSession>();
 
-    win[`__ESRI_REST_AUTH_HANDLER_${clientId}`] = function (
+    win[`__ESRI_REST_AUTH_HANDLER_${clientId}`] = function(
       errorString: any,
       oauthInfoString: string
     ) {

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1474,7 +1474,7 @@ describe("UserSession", () => {
         end() {
           expect(spy.calls.mostRecent().args[0]).toBe(301);
           expect(spy.calls.mostRecent().args[1].Location).toBe(
-            "https://arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId&duration=20160&response_type=code&redirect_uri=https%3A%2F%2Fexample-app.com%2Fredirect-uri"
+            "https://arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId&expiration=20160&response_type=code&redirect_uri=https%3A%2F%2Fexample-app.com%2Fredirect-uri"
           );
           done();
         },


### PR DESCRIPTION
Addresses an issue where token duration was not honored in oauth flow due to improper \`duration\`

AFFECTS PACKAGES:
@esri/arcgis-rest-auth

ISSUES CLOSED: #840