### PR TITLE
fix(UserSession): switch "duration" to "expiration" in IOAuth2Options

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -103,9 +103,16 @@ export interface IOAuth2Options {
   provider?: AuthenticationProvider;
 
   /**
-   * Duration (in minutes) that a token will be valid. Defaults to 20160 (two weeks).
+   * The requested validity in minutes for a token. Defaults to 20160 (two weeks).
    */
-  duration?: number;
+   expiration?: number;
+
+  /**
+   * Duration (in minutes) that a token will be valid. Defaults to 20160 (two weeks).
+   * 
+   * @deprecated
+   */
+   duration?: number;
 
   /**
    * Determines whether to open the authorization window in a new tab/window or in the current window.
@@ -297,11 +304,17 @@ export class UserSession implements IAuthenticationManager {
    */
   /* istanbul ignore next */
   public static beginOAuth2(options: IOAuth2Options, win: any = window) {
+
+    if(options.duration) {
+      console.log("DEPRECATED: 'duration' is deprecated - use 'expiration' instead");
+      options.expiration = options.duration;
+    }
+
     const {
       portal,
       provider,
       clientId,
-      duration,
+      expiration,
       redirectUri,
       popup,
       popupWindowFeatures,
@@ -312,7 +325,7 @@ export class UserSession implements IAuthenticationManager {
       ...{
         portal: "https://www.arcgis.com/sharing/rest",
         provider: "arcgis",
-        duration: 20160,
+        expiration: 20160,
         popup: true,
         popupWindowFeatures:
           "height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes",
@@ -323,11 +336,11 @@ export class UserSession implements IAuthenticationManager {
     };
     let url: string;
     if (provider === "arcgis") {
-      url = `${portal}/oauth2/authorize?client_id=${clientId}&response_type=token&expiration=${duration}&redirect_uri=${encodeURIComponent(
+      url = `${portal}/oauth2/authorize?client_id=${clientId}&response_type=token&expiration=${expiration}&redirect_uri=${encodeURIComponent(
         redirectUri
       )}&state=${state}&locale=${locale}`;
     } else {
-      url = `${portal}/oauth2/social/authorize?client_id=${clientId}&socialLoginProviderName=${provider}&autoAccountCreateForSocial=true&response_type=token&expiration=${duration}&redirect_uri=${encodeURIComponent(
+      url = `${portal}/oauth2/social/authorize?client_id=${clientId}&socialLoginProviderName=${provider}&autoAccountCreateForSocial=true&response_type=token&expiration=${expiration}&redirect_uri=${encodeURIComponent(
         redirectUri
       )}&state=${state}&locale=${locale}`;
     }
@@ -528,13 +541,17 @@ export class UserSession implements IAuthenticationManager {
     options: IOAuth2Options,
     response: http.ServerResponse
   ) {
-    const { portal, clientId, duration, redirectUri }: IOAuth2Options = {
-      ...{ portal: "https://arcgis.com/sharing/rest", duration: 20160 },
+    if(options.duration) {
+      console.log("DEPRECATED: 'duration' is deprecated - use 'expiration' instead");
+      options.expiration = options.duration;
+    }
+    const { portal, clientId, expiration, redirectUri }: IOAuth2Options = {
+      ...{ portal: "https://arcgis.com/sharing/rest", expiration: 20160 },
       ...options,
     };
 
     response.writeHead(301, {
-      Location: `${portal}/oauth2/authorize?client_id=${clientId}&expiration=${duration}&response_type=code&redirect_uri=${encodeURIComponent(
+      Location: `${portal}/oauth2/authorize?client_id=${clientId}&expiration=${expiration}&response_type=code&redirect_uri=${encodeURIComponent(
         redirectUri
       )}`,
     });

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -110,7 +110,7 @@ export interface IOAuth2Options {
   /**
    * Duration (in minutes) that a token will be valid. Defaults to 20160 (two weeks).
    * 
-   * @deprecated
+   * @deprecated use 'expiration' instead
    */
    duration?: number;
 

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -339,7 +339,7 @@ export class UserSession implements IAuthenticationManager {
         redirectUri
       )}&state=${state}&locale=${locale}`;
     } else {
-      url = `${portal}/oauth2/social/authorize?client_id=${clientId}&socialLoginProviderName=${provider}&autoAccountCreateForSocial=true&response_type=token&expiration=${expiration}&redirect_uri=${encodeURIComponent(
+      url = `${portal}/oauth2/social/authorize?client_id=${clientId}&socialLoginProviderName=${provider}&autoAccountCreateForSocial=true&response_type=token&expiration=${options.duration || expiration}&redirect_uri=${encodeURIComponent(
         redirectUri
       )}&state=${state}&locale=${locale}`;
     }

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -307,7 +307,6 @@ export class UserSession implements IAuthenticationManager {
 
     if(options.duration) {
       console.log("DEPRECATED: 'duration' is deprecated - use 'expiration' instead");
-      options.expiration = options.duration;
     }
 
     const {
@@ -336,7 +335,7 @@ export class UserSession implements IAuthenticationManager {
     };
     let url: string;
     if (provider === "arcgis") {
-      url = `${portal}/oauth2/authorize?client_id=${clientId}&response_type=token&expiration=${expiration}&redirect_uri=${encodeURIComponent(
+      url = `${portal}/oauth2/authorize?client_id=${clientId}&response_type=token&expiration=${options.duration || expiration}&redirect_uri=${encodeURIComponent(
         redirectUri
       )}&state=${state}&locale=${locale}`;
     } else {
@@ -543,7 +542,6 @@ export class UserSession implements IAuthenticationManager {
   ) {
     if(options.duration) {
       console.log("DEPRECATED: 'duration' is deprecated - use 'expiration' instead");
-      options.expiration = options.duration;
     }
     const { portal, clientId, expiration, redirectUri }: IOAuth2Options = {
       ...{ portal: "https://arcgis.com/sharing/rest", expiration: 20160 },
@@ -551,7 +549,7 @@ export class UserSession implements IAuthenticationManager {
     };
 
     response.writeHead(301, {
-      Location: `${portal}/oauth2/authorize?client_id=${clientId}&expiration=${expiration}&response_type=code&redirect_uri=${encodeURIComponent(
+      Location: `${portal}/oauth2/authorize?client_id=${clientId}&expiration=${options.duration || expiration}&response_type=code&redirect_uri=${encodeURIComponent(
         redirectUri
       )}`,
     });

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -967,6 +967,52 @@ describe("UserSession", () => {
         "https://www.arcgis.com/sharing/rest/oauth2/social/authorize?client_id=clientId123&socialLoginProviderName=google&autoAccountCreateForSocial=true&response_type=token&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=clientId123&locale="
       );
     });
+
+    it("should pass custom expiration", () => {
+      const MockWindow: any = {
+        location: {
+          href: "",
+        },
+      };
+
+      // https://github.com/palantir/tslint/issues/3056
+      void UserSession.beginOAuth2(
+        {
+          clientId: "clientId123",
+          redirectUri: "http://example-app.com/redirect",
+          popup: false,
+          expiration: 9000
+        },
+        MockWindow
+      );
+
+      expect(MockWindow.location.href).toBe(
+        "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId123&response_type=token&expiration=9000&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=clientId123&locale="
+      );
+    });
+
+    it("should pass custom duration (DEPRECATED)", () => {
+      const MockWindow: any = {
+        location: {
+          href: "",
+        },
+      };
+
+      // https://github.com/palantir/tslint/issues/3056
+      void UserSession.beginOAuth2(
+        {
+          clientId: "clientId123",
+          redirectUri: "http://example-app.com/redirect",
+          popup: false,
+          duration: 9001
+        },
+        MockWindow
+      );
+
+      expect(MockWindow.location.href).toBe(
+        "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId123&response_type=token&expiration=9001&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=clientId123&locale="
+      );
+    });
   });
 
   describe(".completeOAuth2()", () => {
@@ -1484,6 +1530,52 @@ describe("UserSession", () => {
         {
           clientId: "clientId",
           redirectUri: "https://example-app.com/redirect-uri",
+        },
+        MockResponse
+      );
+    });
+
+    it("should redirect the request to the authorization page with custom expiration", (done) => {
+      const spy = jasmine.createSpy("spy");
+      const MockResponse: any = {
+        writeHead: spy,
+        end() {
+          expect(spy.calls.mostRecent().args[0]).toBe(301);
+          expect(spy.calls.mostRecent().args[1].Location).toBe(
+            "https://arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId&expiration=10000&response_type=code&redirect_uri=https%3A%2F%2Fexample-app.com%2Fredirect-uri"
+          );
+          done();
+        },
+      };
+
+      UserSession.authorize(
+        {
+          clientId: "clientId",
+          redirectUri: "https://example-app.com/redirect-uri",
+          expiration: 10000
+        },
+        MockResponse
+      );
+    });
+
+    it("should redirect the request to the authorization page with custom duration (DEPRECATED)", (done) => {
+      const spy = jasmine.createSpy("spy");
+      const MockResponse: any = {
+        writeHead: spy,
+        end() {
+          expect(spy.calls.mostRecent().args[0]).toBe(301);
+          expect(spy.calls.mostRecent().args[1].Location).toBe(
+            "https://arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId&expiration=10001&response_type=code&redirect_uri=https%3A%2F%2Fexample-app.com%2Fredirect-uri"
+          );
+          done();
+        },
+      };
+
+      UserSession.authorize(
+        {
+          clientId: "clientId",
+          redirectUri: "https://example-app.com/redirect-uri",
+          duration: 10001
         },
         MockResponse
       );

--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,9 @@
     "object-literal-sort-keys": false,
     "interface-name": [true, "always-prefix"],
     "no-string-literal": false,
-    "no-console": false
+    "no-console": false,
+    "deprecation": {
+      "severity": "warning"
+    }
   }
 }


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-auth

ISSUES CLOSED: #843

Replaces #845 

Note that there's a linting error when i try to use `options.duration`:
![image](https://user-images.githubusercontent.com/209355/118728439-b1b92880-b823-11eb-851a-1f696d800967.png)

What's the way to do this properly?