### PR TITLE
Update server-based oauth 2.0 for state and token consistency

### DIFF
--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1582,6 +1582,56 @@ describe("UserSession", () => {
     });
   });
 
+  describe(".authorize()", () => {
+    it("should redirect the request to the authorization page with state", done => {
+      const spy = jasmine.createSpy("spy");
+      const MockResponse: any = {
+        writeHead: spy,
+        end() {
+          expect(spy.calls.mostRecent().args[0]).toBe(301);
+          expect(spy.calls.mostRecent().args[1].Location).toBe(
+            "https://arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId&expiration=20160&response_type=code&redirect_uri=https%3A%2F%2Fexample-app.com%2Fredirect-uri&state=helloworld"
+          );
+          done();
+        }
+      };
+
+      UserSession.authorize(
+        {
+          clientId: "clientId",
+          redirectUri: "https://example-app.com/redirect-uri",
+          state: "helloworld"
+        },
+        MockResponse
+      );
+    });
+  });
+
+  describe(".authorize()", () => {
+    it("should respect the refreshTokenTTL if specified instead of the duration", done => {
+      const spy = jasmine.createSpy("spy");
+      const MockResponse: any = {
+        writeHead: spy,
+        end() {
+          expect(spy.calls.mostRecent().args[0]).toBe(301);
+          expect(spy.calls.mostRecent().args[1].Location).toBe(
+            "https://arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId&expiration=1440&response_type=code&redirect_uri=https%3A%2F%2Fexample-app.com%2Fredirect-uri"
+          );
+          done();
+        }
+      };
+
+      UserSession.authorize(
+        {
+          clientId: "clientId",
+          redirectUri: "https://example-app.com/redirect-uri",
+          refreshTokenTTL: 1440
+        },
+        MockResponse
+      );
+    });
+  });
+
   describe(".exchangeAuthorizationCode()", () => {
     let paramsSpy: jasmine.Spy;
 


### PR DESCRIPTION
Updates from #704 merged with the latest code.

Addresses #699 & #660 as well as a couple other tweaks:
* change the 'duration' URL parameter to 'expiration' in `authorize()` to match the [REST endpoint](https://developers.arcgis.com/rest/users-groups-and-items/authorize.htm)
* update 'refreshTokenExpires' calculation to reflect that 'refreshTokenTTL' is in minutes

Also related to #842 