### PR TITLE
Admin's share items via user item route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1440,7 +1440,7 @@
     "@types/mz": {
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.32.tgz",
-      "integrity": "sha1-6CSLTkFCTAUu3Bcl3TNlDDE6Nlk=",
+      "integrity": "sha512-cy3yebKhrHuOcrJGkfwNHhpTXQLgmXSv1BX+4p32j+VUQ6aP2eJ5cL7OvGcAQx75fCTFaAIIAKewvqL+iwSd4g==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1682,7 +1682,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -1759,7 +1759,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
     "are-we-there-yet": {
@@ -1796,7 +1796,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "arr-union": {
@@ -2051,7 +2051,7 @@
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
@@ -2075,7 +2075,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -2084,7 +2084,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -2093,7 +2093,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -2353,7 +2353,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -2929,7 +2929,7 @@
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
@@ -3304,7 +3304,7 @@
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
@@ -5598,7 +5598,7 @@
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
         "is-descriptor": "^1.0.2",
@@ -5608,7 +5608,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -5617,7 +5617,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -5626,7 +5626,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -6218,7 +6218,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -6564,7 +6564,7 @@
     "fetch-mock": {
       "version": "5.13.1",
       "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-5.13.1.tgz",
-      "integrity": "sha1-lVeUp389ly8WRLms5loP39YPHfc=",
+      "integrity": "sha512-eWUo2KI4sRGnRu8tKELCBfasALM5BfvrCxdI7J02j3eUM9mf+uYzJkURA0PSn/29JVapVrYFm+z+9XijXu1PdA==",
       "dev": true,
       "requires": {
         "glob-to-regexp": "^0.3.0",
@@ -7047,7 +7047,7 @@
     "gaze": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-      "integrity": "sha1-xEFzPhO5J6yMD/C0w7Az8ogSkko=",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
         "globule": "^1.0.0"
@@ -7154,7 +7154,7 @@
         },
         "commander": {
           "version": "2.15.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -8637,7 +8637,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -8759,7 +8759,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -8830,7 +8830,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -9060,7 +9060,7 @@
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
@@ -9071,7 +9071,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -9233,7 +9233,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -9345,7 +9345,7 @@
     "is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha1-BKTfRtKMTP89c9Af8Gq+sxihqlI=",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
     "is-utf8": {
@@ -9357,7 +9357,7 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "is-wsl": {
@@ -9557,19 +9557,19 @@
     "jest-docblock": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha1-UVKcOzDV/RWdpgwnzu3Blfr41BQ=",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
       "dev": true
     },
     "jest-get-type": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-      "integrity": "sha1-9jdqudtLYNgeOfMHScbEZvQNSiM=",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
       "dev": true
     },
     "jest-validate": {
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
-      "integrity": "sha1-zAy8plPNVJN7pPKhEXlndFMN08c=",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
@@ -10700,7 +10700,7 @@
         "inquirer": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^3.0.0",
@@ -10762,7 +10762,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -10921,7 +10921,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -11082,7 +11082,7 @@
     "lint-staged": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-4.3.0.tgz",
-      "integrity": "sha1-7Qd5rZpCwNxiuzJE5SKHC0ESWHk=",
+      "integrity": "sha512-C/Zxslg0VRbsxwmCu977iIs+QyrmW2cyRCPUV5NDFYOH/jtRFHH8ch7ua2fH0voI/nVC3Tpg7DykfgMZySliKw==",
       "dev": true,
       "requires": {
         "app-root-path": "^2.0.0",
@@ -11682,7 +11682,7 @@
     },
     "map-stream": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
@@ -11813,7 +11813,7 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
@@ -11850,7 +11850,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -12037,7 +12037,7 @@
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
         "any-promise": "^1.0.0",
@@ -12430,7 +12430,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -12629,7 +12629,7 @@
     "onchange": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/onchange/-/onchange-3.3.0.tgz",
-      "integrity": "sha1-2pJQsWI+AZ8PcdyK/VYnNAZHK2E=",
+      "integrity": "sha512-0ZQIdGkhG8Y+r8BIcjjDV93X59KkZ4Cc+ZxA9N+wA/3vm1cvd8/f2NXlCPCZpowSd78eCERk29dtuS8+X97MLg==",
       "dev": true,
       "requires": {
         "arrify": "~1.0.1",
@@ -13143,7 +13143,7 @@
     },
     "opn": {
       "version": "5.3.0",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
@@ -13219,7 +13219,7 @@
     "osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
@@ -13253,7 +13253,7 @@
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
     "p-try": {
@@ -13732,7 +13732,7 @@
     "pretty-format": {
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-      "integrity": "sha1-rlQH888hBmzQEaobpfzntqLt2zY=",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
       "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0",
@@ -13793,7 +13793,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
         "asap": "~2.0.3"
@@ -14141,7 +14141,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
@@ -14150,7 +14150,7 @@
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.2",
@@ -14389,7 +14389,7 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
     "retry": {
@@ -14741,7 +14741,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "sass-graph": {
@@ -14806,7 +14806,7 @@
     "selenium-webdriver": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
-      "integrity": "sha1-K6h6FmLAILiYjJga5iyyoBKY6vw=",
+      "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
       "requires": {
         "jszip": "^3.1.3",
@@ -15126,7 +15126,7 @@
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
         "base": "^0.11.1",
@@ -15171,7 +15171,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
         "define-property": "^1.0.0",
@@ -15191,7 +15191,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -15200,7 +15200,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -15209,7 +15209,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -15222,7 +15222,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
@@ -15555,7 +15555,7 @@
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -15564,7 +15564,7 @@
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
         "through2": "^2.0.2"
@@ -15681,7 +15681,7 @@
     },
     "stream-combiner": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
@@ -15971,7 +15971,7 @@
     "symlink-dir": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/symlink-dir/-/symlink-dir-1.1.3.tgz",
-      "integrity": "sha1-sJr5WZr1MQwvt3rcDBYT3uOCzk4=",
+      "integrity": "sha512-klQgTYk7en8A69nAzZjJdaMXbGCmfh0DU+YLaZG/stHNp00VZSS3Pos238Ua7oCKVw57UszViod4D7RVRH6XHg==",
       "dev": true,
       "requires": {
         "@types/mz": "0.0.32",
@@ -16254,7 +16254,7 @@
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
         "define-property": "^2.0.2",
@@ -16799,7 +16799,7 @@
     "update-notifier": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-      "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
         "boxen": "^1.2.1",
@@ -16817,7 +16817,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"

--- a/packages/arcgis-rest-portal/src/sharing/share-item-with-group.ts
+++ b/packages/arcgis-rest-portal/src/sharing/share-item-with-group.ts
@@ -4,17 +4,20 @@ import { getPortalUrl } from "../util/get-portal-url";
 import {
   IGroupSharingOptions,
   ISharingResponse,
-  getUserMembership
+  getUserMembership,
 } from "./helpers";
 import { getUser } from "../users/get-user";
 import { addGroupUsers, IAddGroupUsersResult } from "../groups/add-users";
 import { removeGroupUsers } from "../groups/remove-users";
-import { updateUserMemberships, IUpdateGroupUsersResult } from "../groups/update-user-membership";
+import {
+  updateUserMemberships,
+  IUpdateGroupUsersResult,
+} from "../groups/update-user-membership";
 import { isItemSharedWithGroup } from "../sharing/is-item-shared-with-group";
 
 interface IEnsureMembershipResult {
-  promise: Promise<IAddGroupUsersResult>,
-  revert: (sharingResults: ISharingResponse) => Promise<ISharingResponse>
+  promise: Promise<IAddGroupUsersResult>;
+  revert: (sharingResults: ISharingResponse) => Promise<ISharingResponse>;
 }
 
 /**
@@ -36,7 +39,7 @@ interface IEnsureMembershipResult {
  * @param requestOptions - Options for the request.
  * @returns A Promise that will resolve with the data from the response.
  */
-export function shareItemWithGroup (
+export function shareItemWithGroup(
   requestOptions: IGroupSharingOptions
 ): Promise<ISharingResponse> {
   return isItemSharedWithGroup(requestOptions)
@@ -46,35 +49,37 @@ export function shareItemWithGroup (
         return {
           itemId: requestOptions.id,
           shortcut: true,
-          notSharedWith: []
+          notSharedWith: [],
         } as ISharingResponse;
       }
 
       const {
         authentication: { username },
         owner,
-        confirmItemControl
+        confirmItemControl,
       } = requestOptions;
       const itemOwner = owner || username;
 
       // non-item owner
       if (itemOwner !== username) {
+        // need to track if the user is an admin
+        let isAdmin = false;
         // next perform any necessary membership adjustments for
         // current user and/or item owner
         return Promise.all([
           getUser({
             username,
-            authentication: requestOptions.authentication
+            authentication: requestOptions.authentication,
           }),
           getUser({
             username: itemOwner,
-            authentication: requestOptions.authentication
+            authentication: requestOptions.authentication,
           }),
-          getUserMembership(requestOptions)
+          getUserMembership(requestOptions),
         ])
           .then(([currentUser, ownerUser, membership]) => {
             const isSharedEditingGroup = !!confirmItemControl;
-            const isAdmin = currentUser.role === "org_admin" && !currentUser.roleId;
+            isAdmin = currentUser.role === "org_admin" && !currentUser.roleId;
             return getMembershipAdjustments(
               currentUser,
               isSharedEditingGroup,
@@ -84,22 +89,24 @@ export function shareItemWithGroup (
               requestOptions
             );
           })
-          .then(membershipAdjustments => {
+          .then((membershipAdjustments) => {
             const [
               { revert } = {
                 promise: Promise.resolve({ notAdded: [] }),
                 revert: (sharingResults: ISharingResponse) => {
                   return Promise.resolve(sharingResults);
-                }
-              } as IEnsureMembershipResult
+                },
+              } as IEnsureMembershipResult,
             ] = membershipAdjustments;
             // perform all membership adjustments
-            return Promise.all(membershipAdjustments.map(({ promise }) => promise))
+            return Promise.all(
+              membershipAdjustments.map(({ promise }) => promise)
+            )
               .then(() => {
                 // then attempt the share
-                return shareToGroup(requestOptions);
+                return shareToGroup(requestOptions, isAdmin);
               })
-              .then(sharingResults => {
+              .then((sharingResults) => {
                 // lastly, if the admin user was added to the group,
                 // remove them from the group. this is a no-op that
                 // immediately resolves the sharingResults when no
@@ -112,7 +119,7 @@ export function shareItemWithGroup (
       // item owner, let it call through
       return shareToGroup(requestOptions);
     })
-    .then(sharingResponse => {
+    .then((sharingResponse) => {
       if (sharingResponse.notSharedWith.length) {
         throw Error(
           `Item ${requestOptions.id} could not be shared to group ${requestOptions.groupId}.`
@@ -124,7 +131,7 @@ export function shareItemWithGroup (
     });
 }
 
-function getMembershipAdjustments (
+function getMembershipAdjustments(
   currentUser: IUser,
   isSharedEditingGroup: boolean,
   membership: string,
@@ -137,7 +144,9 @@ function getMembershipAdjustments (
     if (isSharedEditingGroup) {
       if (!isAdmin) {
         // abort and reject promise
-        throw Error(`This item can not be shared to shared editing group ${requestOptions.groupId} by ${currentUser.username} as they not the item owner or org admin.`);
+        throw Error(
+          `This item can not be shared to shared editing group ${requestOptions.groupId} by ${currentUser.username} as they not the item owner or org admin.`
+        );
       }
 
       membershipGuarantees.push(
@@ -173,37 +182,46 @@ function getMembershipAdjustments (
       );
     } else if (membership === "none") {
       // all other non-item owners must be a group member
-      throw new Error(`This item can not be shared by ${currentUser.username} as they are not a member of the specified group ${requestOptions.groupId}.`);
+      throw new Error(
+        `This item can not be shared by ${currentUser.username} as they are not a member of the specified group ${requestOptions.groupId}.`
+      );
     }
   }
 
   return membershipGuarantees;
 }
 
-function shareToGroup (
-  requestOptions: IGroupSharingOptions
+function shareToGroup(
+  requestOptions: IGroupSharingOptions,
+  isAdmin: boolean = false
 ): Promise<ISharingResponse> {
   const username = requestOptions.authentication.username;
   const itemOwner = requestOptions.owner || username;
   // decide what url to use
   // default to the non-owner url...
-  let url = `${getPortalUrl(requestOptions)}/content/items/${requestOptions.id}/share`;
+  let url = `${getPortalUrl(requestOptions)}/content/items/${
+    requestOptions.id
+  }/share`;
 
-  // but if they are the owner, we use a different path...
-  if (itemOwner === username) {
-    url = `${getPortalUrl(requestOptions)}/content/users/${itemOwner}/items/${requestOptions.id}/share`;
+  // but if they are the owner, or org_admin, use this route
+  // Note: When using this end-point as an admin, apparently the admin does not need to be a member of the group (the itemOwner does)
+  // Have not validated this but came up in conversations w/ Sharing API team
+  if (itemOwner === username || isAdmin) {
+    url = `${getPortalUrl(requestOptions)}/content/users/${itemOwner}/items/${
+      requestOptions.id
+    }/share`;
   }
 
   // now its finally time to do the sharing
   requestOptions.params = {
     groups: requestOptions.groupId,
-    confirmItemControl: requestOptions.confirmItemControl
+    confirmItemControl: requestOptions.confirmItemControl,
   };
 
   return request(url, requestOptions);
 }
 
-export function ensureMembership (
+export function ensureMembership(
   currentUser: IUser,
   ownerUser: IUser,
   shouldPromote: boolean,
@@ -211,7 +229,7 @@ export function ensureMembership (
   requestOptions: IGroupSharingOptions
 ): IEnsureMembershipResult {
   const ownerGroups = ownerUser.groups || [];
-  const group = ownerGroups.find(g => {
+  const group = ownerGroups.find((g) => {
     return g.id === requestOptions.groupId;
   });
 
@@ -242,36 +260,34 @@ export function ensureMembership (
         id: requestOptions.groupId,
         users: [ownerUser.username],
         newMemberType: "admin",
-        authentication: requestOptions.authentication
+        authentication: requestOptions.authentication,
       })
         .then((results: IUpdateGroupUsersResult) => {
           // convert the result into the right type
-          const notAdded = results.results.reduce(
-            (acc: any[], entry: any) => {
-              if (!entry.success) {
-                acc.push(entry.username);
-              }
-              return acc;
-            },
-            []
-          );
+          const notAdded = results.results.reduce((acc: any[], entry: any) => {
+            if (!entry.success) {
+              acc.push(entry.username);
+            }
+            return acc;
+          }, []);
           // and return it
           return Promise.resolve({ notAdded });
         })
         .catch(() => ({ notAdded: [ownerUser.username] }));
-      revert = (sharingResults) => updateUserMemberships({
-        id: requestOptions.groupId,
-        users: [ownerUser.username],
-        newMemberType: "member",
-        authentication: requestOptions.authentication
-      })
-        .then(() => sharingResults)
-        .catch(() => sharingResults);
+      revert = (sharingResults) =>
+        updateUserMemberships({
+          id: requestOptions.groupId,
+          users: [ownerUser.username],
+          newMemberType: "member",
+          authentication: requestOptions.authentication,
+        })
+          .then(() => sharingResults)
+          .catch(() => sharingResults);
     } else {
       // they are already an admin in the group
       // return the same response the API would if we added them
       promise = Promise.resolve({ notAdded: [] });
-      revert = sharingResults => Promise.resolve(sharingResults);
+      revert = (sharingResults) => Promise.resolve(sharingResults);
     }
   } else {
     // attempt to add user to group
@@ -282,9 +298,9 @@ export function ensureMembership (
     promise = addGroupUsers({
       id: requestOptions.groupId,
       [userType]: [ownerUser.username],
-      authentication: requestOptions.authentication
+      authentication: requestOptions.authentication,
     })
-      .then(results => {
+      .then((results) => {
         // results.errors includes an ArcGISAuthError when the group
         // is in a different org, but notAdded is empty, throw here
         // to normalize the results in below catch
@@ -298,22 +314,21 @@ export function ensureMembership (
       return removeGroupUsers({
         id: requestOptions.groupId,
         users: [ownerUser.username],
-        authentication: requestOptions.authentication
-      })
-        .then(() => {
-          // always resolves, suppress any resolved errors
-          return sharingResults;
-        });
+        authentication: requestOptions.authentication,
+      }).then(() => {
+        // always resolves, suppress any resolved errors
+        return sharingResults;
+      });
     };
   }
 
   return {
-    promise: promise.then(membershipResponse => {
+    promise: promise.then((membershipResponse) => {
       if (membershipResponse.notAdded.length) {
         throw new Error(errorMessage);
       }
       return membershipResponse;
     }),
-    revert
+    revert,
   };
-};
+}

--- a/packages/arcgis-rest-portal/src/sharing/share-item-with-group.ts
+++ b/packages/arcgis-rest-portal/src/sharing/share-item-with-group.ts
@@ -36,6 +36,8 @@ interface IEnsureMembershipResult {
  * [group admin](https://developers.arcgis.com/rest/users-groups-and-items/share-item-as-group-admin-.htm) or
  * organization admin.
  *
+ * Note: Sharing the item as an Admin will use the `/content/users/:ownername/items/:itemid/share` end-point
+ *
  * @param requestOptions - Options for the request.
  * @returns A Promise that will resolve with the data from the response.
  */

--- a/packages/arcgis-rest-portal/test/sharing/share-item-with-group.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/share-item-with-group.test.ts
@@ -2,7 +2,10 @@
  * Apache-2.0 */
 
 import * as fetchMock from "fetch-mock";
-import { shareItemWithGroup, ensureMembership } from "../../src/sharing/share-item-with-group";
+import {
+  shareItemWithGroup,
+  ensureMembership,
+} from "../../src/sharing/share-item-with-group";
 import { MOCK_USER_SESSION } from "../mocks/sharing/sharing";
 import { TOMORROW } from "@esri/arcgis-rest-auth/test/utils";
 import { ArcGISAuthError } from "@esri/arcgis-rest-request";
@@ -12,7 +15,7 @@ import {
   GroupMemberUserResponse,
   GroupAdminUserResponse,
   OrgAdminUserResponse,
-  AnonUserResponse
+  AnonUserResponse,
 } from "../mocks/users/user";
 
 import { SearchResponse } from "../mocks/items/search";
@@ -20,18 +23,18 @@ import { ISharingResponse } from "../../src/sharing/helpers";
 
 const SharingResponse = {
   notSharedWith: [] as any,
-  itemId: "n3v"
+  itemId: "n3v",
 };
 
 const FailedSharingResponse = {
   notSharedWith: ["t6b"],
-  itemId: "n3v"
+  itemId: "n3v",
 };
 
 const CachedSharingResponse = {
   notSharedWith: [] as any,
   itemId: "a5b",
-  shortcut: true
+  shortcut: true,
 };
 
 const NoResultsSearchResponse = {
@@ -40,39 +43,39 @@ const NoResultsSearchResponse = {
   start: 0,
   num: 0,
   nextStart: 0,
-  results: [] as any
+  results: [] as any,
 };
 
 export const GroupOwnerResponse = {
   id: "tb6",
   title: "fake group",
   userMembership: {
-    memberType: "owner"
-  }
+    memberType: "owner",
+  },
 };
 
 export const GroupMemberResponse = {
   id: "tb6",
   title: "fake group",
   userMembership: {
-    memberType: "member"
-  }
+    memberType: "member",
+  },
 };
 
 export const GroupNonMemberResponse = {
   id: "tb6",
   title: "fake group",
   userMembership: {
-    memberType: "none"
-  }
+    memberType: "none",
+  },
 };
 
 export const GroupAdminResponse = {
   id: "tb6",
   title: "fake group",
   userMembership: {
-    memberType: "admin"
-  }
+    memberType: "admin",
+  },
 };
 
 export const GroupNoAccessResponse = {
@@ -80,17 +83,17 @@ export const GroupNoAccessResponse = {
     code: 400,
     messageCode: "COM_0003",
     message: "Group does not exist or is inaccessible.",
-    details: [] as any[]
-  }
+    details: [] as any[],
+  },
 };
 
 describe("shareItemWithGroup() ::", () => {
   // make sure session doesnt cache metadata
-  beforeEach(done => {
+  beforeEach((done) => {
     fetchMock.post("https://myorg.maps.arcgis.com/sharing/rest/generateToken", {
       token: "fake-token",
       expires: TOMORROW.getTime(),
-      username: "jsmith"
+      username: "jsmith",
     });
 
     // make sure session doesnt cache metadata
@@ -101,7 +104,7 @@ describe("shareItemWithGroup() ::", () => {
 
   afterEach(fetchMock.restore);
   describe("share item as owner::", () => {
-    it("should share an item with a group by owner", done => {
+    it("should share an item with a group by owner", (done) => {
       // this is called when we try to determine if the item is already in the group
       fetchMock.once(
         "https://myorg.maps.arcgis.com/sharing/rest/search",
@@ -117,9 +120,9 @@ describe("shareItemWithGroup() ::", () => {
       shareItemWithGroup({
         authentication: MOCK_USER_SESSION,
         id: "n3v",
-        groupId: "t6b"
+        groupId: "t6b",
       })
-        .then(response => {
+        .then((response) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -135,7 +138,7 @@ describe("shareItemWithGroup() ::", () => {
           expect(options.body).toContain("groups=t6b");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -143,7 +146,7 @@ describe("shareItemWithGroup() ::", () => {
         });
     });
 
-    it("should share an item with a group by org administrator", done => {
+    it("should share an item with a group by org administrator", (done) => {
       fetchMock.once(
         "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
         OrgAdminUserResponse
@@ -154,7 +157,7 @@ describe("shareItemWithGroup() ::", () => {
         {
           username: "casey",
           orgId: "qWAReEOCnD7eTxOe",
-          groups: [] as any[]
+          groups: [] as any[],
         }
       );
 
@@ -170,24 +173,24 @@ describe("shareItemWithGroup() ::", () => {
       );
 
       fetchMock.once(
-        "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+        "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share",
         SharingResponse
       );
       shareItemWithGroup({
         authentication: MOCK_USER_SESSION,
         id: "n3v",
         groupId: "t6b",
-        owner: "casey"
+        owner: "casey",
       })
-        .then(response => {
+        .then((response) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
           const [url, options]: [string, RequestInit] = fetchMock.lastCall(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(url).toBe(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(options.method).toBe("POST");
           expect(response).toEqual(SharingResponse);
@@ -195,12 +198,12 @@ describe("shareItemWithGroup() ::", () => {
           expect(options.body).toContain("groups=t6b");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should share an item with a group by group owner/admin", done => {
+    it("should share an item with a group by group owner/admin", (done) => {
       fetchMock.once(
         "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
         GroupAdminUserResponse
@@ -211,7 +214,7 @@ describe("shareItemWithGroup() ::", () => {
         {
           username: "otherguy",
           orgId: "qWAReEOCnD7eTxOe",
-          groups: [] as any[]
+          groups: [] as any[],
         }
       );
 
@@ -235,9 +238,9 @@ describe("shareItemWithGroup() ::", () => {
         authentication: MOCK_USER_SESSION,
         id: "n3v",
         groupId: "t6b",
-        owner: "otherguy"
+        owner: "otherguy",
       })
-        .then(response => {
+        .then((response) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -253,7 +256,7 @@ describe("shareItemWithGroup() ::", () => {
           expect(options.body).toContain("groups=t6b");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -261,7 +264,7 @@ describe("shareItemWithGroup() ::", () => {
         });
     });
 
-    it("should mock the response if an item was previously shared with a group", done => {
+    it("should mock the response if an item was previously shared with a group", (done) => {
       fetchMock.once(
         "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
         GroupAdminUserResponse
@@ -275,14 +278,14 @@ describe("shareItemWithGroup() ::", () => {
       shareItemWithGroup({
         authentication: MOCK_USER_SESSION,
         id: "a5b",
-        groupId: "t6b"
+        groupId: "t6b",
       })
-        .then(response => {
+        .then((response) => {
           // no web request to share at all
           expect(response).toEqual(CachedSharingResponse);
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -290,7 +293,7 @@ describe("shareItemWithGroup() ::", () => {
         });
     });
 
-    it("should allow group owner/admin/member to share item they do not own", done => {
+    it("should allow group owner/admin/member to share item they do not own", (done) => {
       fetchMock.once(
         "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
         GroupMemberUserResponse
@@ -301,7 +304,7 @@ describe("shareItemWithGroup() ::", () => {
         {
           username: "casey",
           orgId: "qWAReEOCnD7eTxOe",
-          groups: [] as any[]
+          groups: [] as any[],
         }
       );
 
@@ -325,9 +328,9 @@ describe("shareItemWithGroup() ::", () => {
         authentication: MOCK_USER_SESSION,
         id: "n3v",
         groupId: "t6b",
-        owner: "casey"
+        owner: "casey",
       })
-        .then(response => {
+        .then((response) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -343,12 +346,12 @@ describe("shareItemWithGroup() ::", () => {
           expect(options.body).toContain("groups=t6b");
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail(e);
         });
     });
 
-    it("should throw if non-owner tries to share to shared editing group", done => {
+    it("should throw if non-owner tries to share to shared editing group", (done) => {
       fetchMock.once(
         "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
         GroupMemberUserResponse
@@ -359,7 +362,7 @@ describe("shareItemWithGroup() ::", () => {
         {
           username: "casey",
           orgId: "qWAReEOCnD7eTxOe",
-          groups: [] as any[]
+          groups: [] as any[],
         }
       );
 
@@ -379,8 +382,8 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
-      }).catch(e => {
+        confirmItemControl: true,
+      }).catch((e) => {
         expect(fetchMock.done()).toBeTruthy(
           "All fetchMocks should have been called"
         );
@@ -391,7 +394,7 @@ describe("shareItemWithGroup() ::", () => {
       });
     });
 
-    it("should throw if the response from the server is fishy", done => {
+    it("should throw if the response from the server is fishy", (done) => {
       fetchMock.once(
         "https://myorg.maps.arcgis.com/sharing/rest/search",
         SearchResponse
@@ -405,8 +408,8 @@ describe("shareItemWithGroup() ::", () => {
       shareItemWithGroup({
         authentication: MOCK_USER_SESSION,
         id: "n3v",
-        groupId: "t6b"
-      }).catch(e => {
+        groupId: "t6b",
+      }).catch((e) => {
         expect(fetchMock.done()).toBeTruthy(
           "All fetchMocks should have been called"
         );
@@ -417,7 +420,7 @@ describe("shareItemWithGroup() ::", () => {
   });
 
   describe("share item as org admin on behalf of other user ::", () => {
-    it("should add user to group then share item", done => {
+    it("should add user to group then share item", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
@@ -436,7 +439,7 @@ describe("shareItemWithGroup() ::", () => {
           {
             username: "casey",
             orgId: "qWAReEOCnD7eTxOe",
-            groups: [] as any[]
+            groups: [] as any[],
           }
         )
         .post(
@@ -444,7 +447,7 @@ describe("shareItemWithGroup() ::", () => {
           { notAdded: [] }
         )
         .post(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share",
           { notSharedWith: [], itemId: "n3v" }
         );
 
@@ -453,9 +456,9 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
-        .then(result => {
+        .then((result) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -466,18 +469,18 @@ describe("shareItemWithGroup() ::", () => {
           expect(addUsersOptions.body).toContain("admins=casey");
           // verify we shared the item
           const shareOptions: RequestInit = fetchMock.lastOptions(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
           expect(shareOptions.body).toContain("confirmItemControl=true");
 
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail();
         });
     });
-    it("should add user to group the returned user lacks groups array", done => {
+    it("should add user to group the returned user lacks groups array", (done) => {
       // tbh, not 100% sure this can even happen, but... 100% coverage
       fetchMock
         .once(
@@ -496,7 +499,7 @@ describe("shareItemWithGroup() ::", () => {
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/casey?f=json&token=fake-token",
           {
             username: "casey",
-            orgId: "qWAReEOCnD7eTxOe"
+            orgId: "qWAReEOCnD7eTxOe",
           }
         )
         .post(
@@ -504,7 +507,7 @@ describe("shareItemWithGroup() ::", () => {
           { notAdded: [] }
         )
         .post(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share",
           { notSharedWith: [], itemId: "n3v" }
         );
 
@@ -513,9 +516,9 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
-        .then(result => {
+        .then((result) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -526,18 +529,18 @@ describe("shareItemWithGroup() ::", () => {
           expect(addUsersOptions.body).toContain("admins=casey");
           // verify we shared the item
           const shareOptions: RequestInit = fetchMock.lastOptions(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
           expect(shareOptions.body).toContain("confirmItemControl=true");
 
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail();
         });
     });
-    it("should upgrade user to admin then share item", done => {
+    it("should upgrade user to admin then share item", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
@@ -560,10 +563,10 @@ describe("shareItemWithGroup() ::", () => {
               {
                 id: "t6b",
                 userMembership: {
-                  memberType: "member"
-                }
-              }
-            ] as any[]
+                  memberType: "member",
+                },
+              },
+            ] as any[],
           }
         )
         .post(
@@ -571,7 +574,7 @@ describe("shareItemWithGroup() ::", () => {
           { results: [{ username: "casey", success: true }] }
         )
         .post(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share",
           { notSharedWith: [], itemId: "n3v" }
         );
 
@@ -580,9 +583,9 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
-        .then(result => {
+        .then((result) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -593,18 +596,18 @@ describe("shareItemWithGroup() ::", () => {
           expect(addUsersOptions.body).toContain("admins=casey");
           // verify we shared the item
           const shareOptions: RequestInit = fetchMock.lastOptions(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
           expect(shareOptions.body).toContain("confirmItemControl=true");
 
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail();
         });
     });
-    it("should share item if user is already admin in group", done => {
+    it("should share item if user is already admin in group", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
@@ -627,14 +630,14 @@ describe("shareItemWithGroup() ::", () => {
               {
                 id: "t6b",
                 userMembership: {
-                  memberType: "admin"
-                }
-              }
-            ] as any[]
+                  memberType: "admin",
+                },
+              },
+            ] as any[],
           }
         )
         .post(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share",
           { notSharedWith: [], itemId: "n3v" }
         );
 
@@ -643,26 +646,26 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
-        .then(result => {
+        .then((result) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
           // verify we shared the item
           const shareOptions: RequestInit = fetchMock.lastOptions(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
           expect(shareOptions.body).toContain("confirmItemControl=true");
 
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail();
         });
     });
-    it("should throw if we can not upgrade user membership", done => {
+    it("should throw if we can not upgrade user membership", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
@@ -685,10 +688,10 @@ describe("shareItemWithGroup() ::", () => {
               {
                 id: "t6b",
                 userMembership: {
-                  memberType: "member"
-                }
-              }
-            ] as any[]
+                  memberType: "member",
+                },
+              },
+            ] as any[],
           }
         )
         .post(
@@ -701,13 +704,13 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
         .then(() => {
           expect("").toBe("Should Throw, but it returned");
           fail();
         })
-        .catch(e => {
+        .catch((e) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -721,13 +724,13 @@ describe("shareItemWithGroup() ::", () => {
           done();
         });
     });
-    it("should throw if we cannot add the user as a group admin", done => {
+    it("should throw if we cannot add the user as a group admin", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
           {
             ...OrgAdminUserResponse,
-            groups: []
+            groups: [],
           }
         )
         .once(
@@ -747,15 +750,15 @@ describe("shareItemWithGroup() ::", () => {
               {
                 id: "t6b",
                 userMembership: {
-                  memberType: "admin"
-                }
-              }
-            ] as any[]
+                  memberType: "admin",
+                },
+              },
+            ] as any[],
           }
         )
         .post(
           "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/addUsers",
-          { errors: [new ArcGISAuthError('my error', 717)] }
+          { errors: [new ArcGISAuthError("my error", 717)] }
         );
 
       return shareItemWithGroup({
@@ -763,13 +766,13 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
         .then(() => {
           expect("").toBe("Should Throw, but it returned");
           fail();
         })
-        .catch(e => {
+        .catch((e) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -779,7 +782,7 @@ describe("shareItemWithGroup() ::", () => {
           done();
         });
     });
-    it("should throw when a non org admin, non group member attempts to share a view group", done => {
+    it("should throw when a non org admin, non group member attempts to share a view group", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
@@ -802,10 +805,10 @@ describe("shareItemWithGroup() ::", () => {
               {
                 id: "t6b",
                 userMembership: {
-                  memberType: "member"
-                }
-              }
-            ] as any[]
+                  memberType: "member",
+                },
+              },
+            ] as any[],
           }
         );
 
@@ -814,13 +817,13 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: false
+        confirmItemControl: false,
       })
         .then(() => {
           expect("").toBe("Should Throw, but it returned");
           fail();
         })
-        .catch(e => {
+        .catch((e) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -830,7 +833,7 @@ describe("shareItemWithGroup() ::", () => {
           done();
         });
     });
-    it("should throw if owner is in other org", done => {
+    it("should throw if owner is in other org", (done) => {
       fetchMock
         .get(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
@@ -849,7 +852,7 @@ describe("shareItemWithGroup() ::", () => {
           {
             username: "casey",
             orgId: "some-other-org",
-            groups: [] as any[]
+            groups: [] as any[],
           }
         );
 
@@ -858,13 +861,13 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
         .then(() => {
           expect("").toBe("Should Throw, but it returned");
           fail();
         })
-        .catch(e => {
+        .catch((e) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -875,11 +878,11 @@ describe("shareItemWithGroup() ::", () => {
           done();
         });
     });
-    it("should throw if owner has > 511 groups", done => {
+    it("should throw if owner has > 511 groups", (done) => {
       const caseyUser = {
         username: "casey",
         orgId: "qWAReEOCnD7eTxOe",
-        groups: new Array(512)
+        groups: new Array(512),
       };
       caseyUser.groups.fill({ id: "not-real-group" });
       fetchMock
@@ -905,13 +908,13 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
         .then(() => {
           expect("").toBe("Should Throw, but it returned");
           fail();
         })
-        .catch(e => {
+        .catch((e) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -923,7 +926,7 @@ describe("shareItemWithGroup() ::", () => {
         });
     });
 
-    it("should throw when updateUserMemberships fails", done => {
+    it("should throw when updateUserMemberships fails", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
@@ -946,10 +949,10 @@ describe("shareItemWithGroup() ::", () => {
               {
                 id: "t6b",
                 userMembership: {
-                  memberType: "member"
-                }
-              }
-            ] as any[]
+                  memberType: "member",
+                },
+              },
+            ] as any[],
           }
         )
         .post(
@@ -962,13 +965,13 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
         .then(() => {
           expect("").toBe("Should Throw, but it returned");
           fail();
         })
-        .catch(e => {
+        .catch((e) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -983,13 +986,13 @@ describe("shareItemWithGroup() ::", () => {
         });
     });
 
-    it("should add the admin user as a member, share the item, then remove the admin from the group", done => {
+    it("should add the admin user as a member, share the item, then remove the admin from the group", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
           {
             ...OrgAdminUserResponse,
-            groups: []
+            groups: [],
           }
         )
         .once(
@@ -1009,10 +1012,10 @@ describe("shareItemWithGroup() ::", () => {
               {
                 id: "t6b",
                 userMembership: {
-                  memberType: "admin"
-                }
-              }
-            ] as any[]
+                  memberType: "admin",
+                },
+              },
+            ] as any[],
           }
         )
         .post(
@@ -1020,7 +1023,7 @@ describe("shareItemWithGroup() ::", () => {
           { notAdded: [] }
         )
         .post(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share",
           { notSharedWith: [], itemId: "nv3" }
         )
         .post(
@@ -1033,31 +1036,31 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
-        .then(result => {
+        .then((result) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
           const shareOptions: RequestInit = fetchMock.lastOptions(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
           expect(shareOptions.body).toContain("confirmItemControl=true");
 
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail();
         });
     });
-    it("should add the admin user as a member, share the item, then suppress any removeUser errors", done => {
+    it("should add the admin user as a member, share the item, then suppress any removeUser errors", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
           {
             ...OrgAdminUserResponse,
-            groups: []
+            groups: [],
           }
         )
         .once(
@@ -1077,10 +1080,10 @@ describe("shareItemWithGroup() ::", () => {
               {
                 id: "t6b",
                 userMembership: {
-                  memberType: "admin"
-                }
-              }
-            ] as any[]
+                  memberType: "admin",
+                },
+              },
+            ] as any[],
           }
         )
         .post(
@@ -1088,7 +1091,7 @@ describe("shareItemWithGroup() ::", () => {
           { notAdded: [] }
         )
         .post(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share",
           { notSharedWith: [], itemId: "nv3" }
         )
         .post(
@@ -1101,25 +1104,25 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
-        .then(result => {
+        .then((result) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
           const shareOptions: RequestInit = fetchMock.lastOptions(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
           expect(shareOptions.body).toContain("confirmItemControl=true");
 
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail();
         });
     });
-    it("should upgrade user to group admin, add admin as member, then share item, then remove admin user", done => {
+    it("should upgrade user to group admin, add admin as member, then share item, then remove admin user", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
@@ -1130,10 +1133,10 @@ describe("shareItemWithGroup() ::", () => {
                 ...OrgAdminUserResponse.groups[0],
                 userMembership: {
                   ...OrgAdminUserResponse.groups[0].userMembership,
-                  memberType: "member"
-                }
-              }
-            ]
+                  memberType: "member",
+                },
+              },
+            ],
           }
         )
         .once(
@@ -1153,10 +1156,10 @@ describe("shareItemWithGroup() ::", () => {
               {
                 id: "t6b",
                 userMembership: {
-                  memberType: "member"
-                }
-              }
-            ] as any[]
+                  memberType: "member",
+                },
+              },
+            ] as any[],
           }
         )
         .once(
@@ -1164,7 +1167,7 @@ describe("shareItemWithGroup() ::", () => {
           { results: [{ username: "casey", success: true }] }
         )
         .post(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share",
           { notSharedWith: [], itemId: "n3v" }
         );
 
@@ -1173,9 +1176,9 @@ describe("shareItemWithGroup() ::", () => {
         id: "n3v",
         groupId: "t6b",
         owner: "casey",
-        confirmItemControl: true
+        confirmItemControl: true,
       })
-        .then(result => {
+        .then((result) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
@@ -1186,20 +1189,20 @@ describe("shareItemWithGroup() ::", () => {
           expect(addUsersOptions.body).toContain("admins=casey");
           // verify we shared the item
           const shareOptions: RequestInit = fetchMock.lastOptions(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
           expect(shareOptions.body).toContain("confirmItemControl=true");
 
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail();
         });
     });
   });
-  describe("ensureMembership", function () {
-    it("should revert the user promotion and suppress resolved error", done => {
+  describe("ensureMembership", function() {
+    it("should revert the user promotion and suppress resolved error", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/updateUsers",
@@ -1213,13 +1216,13 @@ describe("shareItemWithGroup() ::", () => {
         GroupAdminUserResponse,
         GroupMemberUserResponse,
         true,
-        'some error message',
+        "some error message",
         {
           authentication: MOCK_USER_SESSION,
           id: "n3v",
           groupId: "t6b",
           owner: "casey",
-          confirmItemControl: true
+          confirmItemControl: true,
         }
       );
       revert({ notSharedWith: [] } as ISharingResponse)
@@ -1229,11 +1232,11 @@ describe("shareItemWithGroup() ::", () => {
           );
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail();
         });
     });
-    it("should revert the user promotion and suppress rejected error", done => {
+    it("should revert the user promotion and suppress rejected error", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/updateUsers",
@@ -1247,13 +1250,13 @@ describe("shareItemWithGroup() ::", () => {
         GroupAdminUserResponse,
         GroupMemberUserResponse,
         true,
-        'some error message',
+        "some error message",
         {
           authentication: MOCK_USER_SESSION,
           id: "n3v",
           groupId: "t6b",
           owner: "casey",
-          confirmItemControl: true
+          confirmItemControl: true,
         }
       );
       revert({ notSharedWith: [] } as ISharingResponse)
@@ -1263,19 +1266,19 @@ describe("shareItemWithGroup() ::", () => {
           );
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail();
         });
     });
   });
   describe("share item to admin user's favorites group ::", () => {
-    it("should share item", done => {
+    it("should share item", (done) => {
       fetchMock
         .once(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
           {
             ...OrgAdminUserResponse,
-            favGroupId: "t6b"
+            favGroupId: "t6b",
           }
         )
         .once(
@@ -1291,11 +1294,11 @@ describe("shareItemWithGroup() ::", () => {
           {
             username: "casey",
             orgId: "qWAReEOCnD7eTxOe",
-            groups: [] as any[]
+            groups: [] as any[],
           }
         )
         .post(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share",
           { notSharedWith: [], itemId: "n3v" }
         );
 
@@ -1303,21 +1306,21 @@ describe("shareItemWithGroup() ::", () => {
         authentication: MOCK_USER_SESSION,
         id: "n3v",
         groupId: "t6b",
-        owner: "casey"
+        owner: "casey",
       })
-        .then(result => {
+        .then((result) => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
           // verify we shared the item
           const shareOptions: RequestInit = fetchMock.lastOptions(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
 
           done();
         })
-        .catch(e => {
+        .catch((e) => {
           fail();
         });
     });


### PR DESCRIPTION
Prepping for Sharing API v 9.2, there is a change that impacts `shareItemsToGroup` when the user doing the sharing is not the owner, but rather an `org_admin`.

Prior to 9.2, the `/content/items/:id/share` endpoint would allow an `org_admin` to share a private item, owned by another user, to a group (item owner must already be a member in said group).

At 9.2. that no longer works; instead we need to use the `/content/users/:ownername/items/:id/share` route, which is what this PR changes

This is an internal change.

Have verified that this works in PROD, as well as test envs.