### PR TITLE
Update EsLint & prettier configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-undef
+/* eslint-env node */
 module.exports = {
     root: true,
     parser: '@typescript-eslint/parser',

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
 package.json
 package-lock.json
-SearchQueryBuilder.ts

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,19 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "vueIndentScriptAndStyle": false
+}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 [![npm version][npm-img]][npm-url]
-[![build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-image]][npm-url]
 [![Coverage Status][coverage-img]][coverage-url]
 [![apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/arcgis-rest-request.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/@esri/arcgis-rest-request
-[travis-img]: https://img.shields.io/travis/Esri/arcgis-rest-js/master.svg?style=flat-square
-[travis-url]: https://travis-ci.org/Esri/arcgis-rest-js
 [gzip-image]: https://img.badgesize.io/https://unpkg.com/@esri/arcgis-rest-request/dist/umd/request.umd.min.js?compression=gzip
 [coverage-img]: https://codecov.io/gh/Esri/arcgis-rest-js/branch/master/graph/badge.svg
 [coverage-url]: https://codecov.io/gh/Esri/arcgis-rest-js

--- a/demos/.eslintrc.js
+++ b/demos/.eslintrc.js
@@ -1,0 +1,13 @@
+/* eslint-env node */
+module.exports = {
+    root: true,
+    env: {
+      node: true,
+      browser: true,
+      es6: true
+    },
+    extends: [
+      'eslint:recommended',
+      'prettier',
+    ]
+  };

--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -1,0 +1,12 @@
+/* eslint-env node */
+module.exports = {
+    root: true,
+    env: {
+      node: true,
+      es6: true
+    },
+    extends: [
+      'eslint:recommended',
+      'prettier',
+    ]
+  };

--- a/docs/build-typedoc.js
+++ b/docs/build-typedoc.js
@@ -91,7 +91,7 @@ const md = new MarkdownIt();
        * quote marks and add `.ts` back to the end of the `name`,
        */
       return children.map(child => {
-        child.name = child.name.replace(/\"/g, "") + ".ts";
+        child.name = child.name.replace(/"/g, "") + ".ts";
         return child;
       });
     })
@@ -349,7 +349,7 @@ const md = new MarkdownIt();
             } else {
               return 0;
             }
-            return 0;
+            // return 0;
           });
         }
 
@@ -370,7 +370,7 @@ const md = new MarkdownIt();
                 } else {
                   return 0;
                 }
-                return 0;
+                // return 0;
               });
             }
           });
@@ -410,7 +410,7 @@ const md = new MarkdownIt();
 })();
 
 function rankChild(child) {
-  const { isPrivate, isPublic, isOptional, isStatic } = child
+  const { isPrivate, isOptional, isStatic } = child
     ? child.flags
     : {};
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "minimatch": "^3.0.4",
     "node-sass": "^4.12.0",
     "onchange": "^3.3.0",
-    "prettier": "^2.1.2",
+    "prettier": "^2.3.1",
     "resolve": "^1.5.0",
     "rimraf": "^2.6.2",
     "rollup": "^2.26.8",
@@ -207,9 +207,9 @@
     "commitizen": {
       "path": "./node_modules/cz-lerna-changelog"
     }
-  }, 
+  },
   "eslintIgnore": [
-    "packages/**/test", 
+    "packages/**/test",
     "packages/**/dist"
   ]
 }

--- a/packages/arcgis-rest-portal/src/util/SearchQueryBuilder.ts
+++ b/packages/arcgis-rest-portal/src/util/SearchQueryBuilder.ts
@@ -1,12 +1,12 @@
 /* Copyright (c) 2018-2021 Environmental Systems Research Institute, Inc.
-* Apache-2.0 */
+ * Apache-2.0 */
 
 import { IParamBuilder, warn } from "@esri/arcgis-rest-request";
 
 /**
- * `SearchQueryBuilder` can be used to construct the `q` param for 
- * [`searchItems`](/arcgis-rest-js/api/portal/searchItems#searchItems-search) or 
- * [`searchGroups`](/arcgis-rest-js/api/portal/searchGroups#searchGroups-search). 
+ * `SearchQueryBuilder` can be used to construct the `q` param for
+ * [`searchItems`](/arcgis-rest-js/api/portal/searchItems#searchItems-search) or
+ * [`searchGroups`](/arcgis-rest-js/api/portal/searchGroups#searchGroups-search).
  * By chaining methods, it helps build complex search queries.
  *
  * ```js
@@ -82,7 +82,7 @@ export class SearchQueryBuilder implements IParamBuilder {
 
     if (!this.hasRange && !this.hasTerms) {
       warn(
-        // apparently-p-rettier-ignore causes some 
+        // apparently-p-rettier-ignore causes some
         `${fn} was called with no call to \`match(...)\` or \`from(...)\`/\`to(...)\`. Your query was not modified.`
       );
       return this;
@@ -286,7 +286,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   private addModifier(modifier: string) {
     if (this.currentModifer) {
       warn(
-        // apparently-p-rettier-ignore causes some 
+        // apparently-p*rettier-ignore causes prettier to strip *all* comments O_o
         `You have called \`${this.currentModifer}()\` after \`${modifier}()\`. Your current query was not modified.`
       );
       return this;
@@ -334,7 +334,7 @@ export class SearchQueryBuilder implements IParamBuilder {
 
     if (this.hasTerms) {
       this.q += this.termStack
-        .map(term => {
+        .map((term) => {
           return this.formatTerm(term);
         })
         .join(" ");
@@ -356,7 +356,7 @@ export class SearchQueryBuilder implements IParamBuilder {
     // end a group if we have started one
     if (this.openGroups > 0) {
       warn(
-        // apparently-p-rettier-ignore causes some 
+        // apparently-p*rettier-ignore causes prettier to strip *all* comments O_o
         `Automatically closing ${this.openGroups} group(s). You can use \`endGroup(...)\` to remove this warning.`
       );
 

--- a/packages/arcgis-rest-portal/src/util/SearchQueryBuilder.ts
+++ b/packages/arcgis-rest-portal/src/util/SearchQueryBuilder.ts
@@ -82,7 +82,7 @@ export class SearchQueryBuilder implements IParamBuilder {
 
     if (!this.hasRange && !this.hasTerms) {
       warn(
-        // prettier-ignore
+        // apparently-p-rettier-ignore causes some 
         `${fn} was called with no call to \`match(...)\` or \`from(...)\`/\`to(...)\`. Your query was not modified.`
       );
       return this;
@@ -215,7 +215,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   public from(this: SearchQueryBuilder, term: number | string | Date) {
     if (this.hasTerms) {
       warn(
-        // prettier-ignore
+        // apparently-p*rettier-ignore causes prettier to strip *all* comments O_o
         `\`from(...)\` is not allowed after \`match(...)\` try using \`.from(...).to(...).in(...)\`. Your query was not modified.`
       );
       return this;
@@ -237,7 +237,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   public to(this: SearchQueryBuilder, term: any) {
     if (this.hasTerms) {
       warn(
-        // prettier-ignore
+        // apparently-p*rettier-ignore causes prettier to strip *all* comments O_o
         `\`to(...)\` is not allowed after \`match(...)\` try using \`.from(...).to(...).in(...)\`. Your query was not modified.`
       );
       return this;
@@ -286,7 +286,7 @@ export class SearchQueryBuilder implements IParamBuilder {
   private addModifier(modifier: string) {
     if (this.currentModifer) {
       warn(
-        // prettier-ignore
+        // apparently-p-rettier-ignore causes some 
         `You have called \`${this.currentModifer}()\` after \`${modifier}()\`. Your current query was not modified.`
       );
       return this;
@@ -356,7 +356,7 @@ export class SearchQueryBuilder implements IParamBuilder {
     // end a group if we have started one
     if (this.openGroups > 0) {
       warn(
-        // prettier-ignore
+        // apparently-p-rettier-ignore causes some 
         `Automatically closing ${this.openGroups} group(s). You can use \`endGroup(...)\` to remove this warning.`
       );
 


### PR DESCRIPTION
Housekeeping:
- add different / more relaxed eslint rules for `/demos` and `/docs`
- add prettier rules into repo vs relying on VSCode defaults
   - I have no strong opinions on these rules - they are the VSCode defaults, this just moves them into the repo so people not using VSCode will have the same rules
- remove the `// prettier-ignore` comments in `SearchQueryBuilder.ts` that were causing prettier to remove *all* comments from the file
- remove `SearchQueryBuilder.ts` from the `.prettierignore` file as we've resolved the issue 
- fix minor lint issues in `build-typedoc.js`
- bump prettier to latest version