### PR TITLE
chore: tweak github action triggers

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,11 +1,8 @@
 name: Deploy Documentation
-
+# After a push to master, redeploy the docs
 on:
-  workflow_run:
-    workflows: [run-tests]
+  push:
     branches: [master]
-    types:
-      - completed
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -1,6 +1,7 @@
 name: Pre-Release Tests
 
-# Only run on non-draft PRs, and when PRs are synched
+# On pushes to master (i.e. merging a PR)
+# run all tests, on win, macos, linux, on node 12 & 14
 on:
   push:
     branches:

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -10,8 +10,8 @@ on:
       - "**.md"
       - "docs/**"
 jobs:
-  if: github.event.pull_request.draft == false
   build:
+    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -3,13 +3,14 @@ name: PR Tests
 # Only run on non-draft PRs, and when PRs are synched
 on:
   pull_request:
-    types: [ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review, synchronize]
     # If the PR has other files, a push w/ just .md or /docs
     # files will still cause tests to run
     paths-ignore:
       - "**.md"
       - "docs/**"
 jobs:
+  if: github.event.pull_request.draft == false
   build:
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Update the PR logic to run:
- on opened PR's that are not draft
- when PR is marked `ready_for_review` (aka not in draft)
- when reopened, or synched (new commits pushed)

Update Doc Deploy to run on all merges to master

Add comments to pre-release-tests.yml