### PR TITLE
Improve adminServiceInfo on IServiceInfo type

### DIFF
--- a/packages/arcgis-rest-types/src/service.ts
+++ b/packages/arcgis-rest-types/src/service.ts
@@ -117,7 +117,16 @@ export interface IFeatureServiceDefinition {
  * /arcgis/rest/admin/services/<service-name>/FeatureServer?f=json response
  */
 export interface IServiceInfo extends Record<string, unknown> {
-  adminServiceInfo?: Record<string, unknown>;
+  adminServiceInfo: {
+    name: string;
+    type: string;
+    status: string;
+    database: {
+      datasource: {
+        name: string;
+      };
+    };
+  };
   layers: Record<string, unknown>[];
 }
 


### PR DESCRIPTION
Taken from the response example found here:
https://developers.arcgis.com/rest/services-reference/online/hosted-feature-service.htm

**Questions:**
- I made `adminServiceInfo` non-optional. Do we know if the response always returns `adminServiceInfo`?
- Can we narrow `type` and `status` further down? I'm unsure about all the possible values.

@dbouwman 