### PR TITLE
refreshTokenTTL fix

### DIFF
--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -705,7 +705,7 @@ export class UserSession implements IAuthenticationManager {
   public readonly redirectUri: string;
 
   /**
-   * Duration of new OAuth 2.0 refresh token validity.
+   * Duration of new OAuth 2.0 refresh token validity (in minutes).
    */
   public readonly refreshTokenTTL: number;
 

--- a/packages/arcgis-rest-auth/src/UserSession.ts
+++ b/packages/arcgis-rest-auth/src/UserSession.ts
@@ -570,7 +570,7 @@ export class UserSession implements IAuthenticationManager {
     const { portal, clientId, redirectUri, refreshTokenTTL }: IOAuth2Options = {
       ...{
         portal: "https://www.arcgis.com/sharing/rest",
-        refreshTokenTTL: 1440,
+        refreshTokenTTL: 20160,
       },
       ...options,
     };
@@ -591,7 +591,7 @@ export class UserSession implements IAuthenticationManager {
         refreshToken: response.refreshToken,
         refreshTokenTTL,
         refreshTokenExpires: new Date(
-          Date.now() + (refreshTokenTTL - 1) * 1000
+          Date.now() + (refreshTokenTTL - 1) * 60 * 1000
         ),
         token: response.token,
         tokenExpires: response.expires,
@@ -780,7 +780,7 @@ export class UserSession implements IAuthenticationManager {
     this.provider = options.provider || "arcgis";
     this.tokenDuration = options.tokenDuration || 20160;
     this.redirectUri = options.redirectUri;
-    this.refreshTokenTTL = options.refreshTokenTTL || 1440;
+    this.refreshTokenTTL = options.refreshTokenTTL || 20160;
     this.server = options.server;
 
     this.federatedServers = {};

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1625,7 +1625,6 @@ describe("UserSession", () => {
     it("should return a UserSession where refreshTokenExpires is 2 weeks from now (within 10 ms)", (done) => {
       fetchMock.postOnce("https://www.arcgis.com/sharing/rest/oauth2/token", {
         access_token: "token",
-        expires_in: 1800,
         refresh_token: "refreshToken",
         username: "Casey",
         ssl: true,

--- a/packages/arcgis-rest-auth/test/UserSession.test.ts
+++ b/packages/arcgis-rest-auth/test/UserSession.test.ts
@@ -1621,6 +1621,33 @@ describe("UserSession", () => {
           fail(e);
         });
     });
+
+    it("should return a UserSession where refreshTokenExpires is 2 weeks from now (within 10 ms)", (done) => {
+      fetchMock.postOnce("https://www.arcgis.com/sharing/rest/oauth2/token", {
+        access_token: "token",
+        expires_in: 1800,
+        refresh_token: "refreshToken",
+        username: "Casey",
+        ssl: true,
+      });
+
+      UserSession.exchangeAuthorizationCode(
+        {
+          clientId: "clientId",
+          redirectUri: "https://example-app.com/redirect-uri",
+        },
+        "code"
+      )
+        .then((session) => {
+          const twoWeeksFromNow = new Date(Date.now() + (20160 - 1) * 60 * 1000);
+          expect(session.refreshTokenExpires.getTime()).toBeGreaterThan(twoWeeksFromNow.getTime() - 10);
+          expect(session.refreshTokenExpires.getTime()).toBeLessThan(twoWeeksFromNow.getTime() + 10);
+          done();
+        })
+        .catch((e) => {
+          fail(e);
+        });
+    });
   });
 
   describe(".getUser()", () => {


### PR DESCRIPTION
- expected: `refreshTokenTTL` is set to 14 days by default
- actual: `refreshTokenTTL` is set at 1 day by default

#842 
follow-up from #849.