### PR TITLE
Add domain types

### DIFF
--- a/packages/arcgis-rest-types/src/webmap.ts
+++ b/packages/arcgis-rest-types/src/webmap.ts
@@ -38,6 +38,44 @@ export type FieldType =
   | "esriFieldTypeXML";
 
 /**
+ * Domain types
+ */
+export type DomainType = 
+ | "range"
+ | "codedValue"
+ | "inherited";
+
+/**
+ * CodedValue type
+ */
+export type ICodedValue = {
+  /**  User-friendly name for what the code means. */
+  name: string;
+  /**  The value stored in the feature attribute. */
+  code: string | number;
+}
+
+/**
+ * Information for a field with a domain
+ */
+export type IDomain = {
+  /** A string defining the domain type. */
+  type: DomainType;
+  /** A string defining the field name. */
+  name?: string;
+  /** A 2 element array defining the range of possible values. */
+  range?: [number, number];
+  /** An array of CodedValues for domains of type codedValue. */
+  codedValues?: ICodedValue[];
+  /** Description of the domain */
+  description?: string,
+  /** Merge policy */
+  mergePolicy?: string,
+  /** Split Policy */
+  splitPolicy?: string
+}
+
+/**
  * Contains information about an attribute field.
  *
  * `IField` can also be imported from the following packages:
@@ -54,7 +92,7 @@ export interface IField {
   /** A string defining the field alias. */
   alias?: string;
   /** The domain objects if applicable. */
-  domain?: any;
+  domain?: IDomain;
   /** A Boolean defining whether this field is editable. */
   editable?: boolean;
   /** A Boolean defining whether or not the field is an exact match. */


### PR DESCRIPTION
resolves #896
regarding the following types, they are included in the built in tests but they do not appear anywhere in the [documentation](https://developers.arcgis.com/documentation/common-data-types/domain-objects.htm). have they been deprecated since the tests were written? should they even be included in the domain type anymore?
```typescript
/** Description of the domain */
description?: string,
/** Merge policy */
mergePolicy?: string,
/** Split Policy */
splitPolicy?: string
```

