### PR TITLE
od matrix - fixed type on `messages` parameter

### DIFF
--- a/packages/arcgis-rest-routing/src/originDestinationMatrix.ts
+++ b/packages/arcgis-rest-routing/src/originDestinationMatrix.ts
@@ -37,9 +37,9 @@ export interface IOriginDestinationMatrixOptions extends IEndpointOptions {
    *  Specify the type of output returned by the service. Defaults to "esriNAODOutputSparseMatrix".
    */
   outputType?:
-    | "esriNAODOutputSparseMatrix"
-    | "esriNAODOutputStraightLines"
-    | "esriNAODOutputNoLines";
+  | "esriNAODOutputSparseMatrix"
+  | "esriNAODOutputStraightLines"
+  | "esriNAODOutputNoLines";
   barriers?: Array<IPoint | ILocation | [number, number]> | IFeatureSet;
   polylineBarriers?: IFeatureSet;
   polygonBarriers?: IFeatureSet;
@@ -55,7 +55,7 @@ interface IFeatureSetWithGeoJson extends IFeatureSet {
 }
 
 export interface IOriginDestinationMatrixResponse {
-  messages: [ { type: number, description: string } ];
+  messages: { type: number, description: string }[];
   /**
    *  Only present if outputType is "esriNAODOutputSparseMatrix". Full description is available at https://developers.arcgis.com/rest/network/api-reference/origin-destination-cost-matrix-synchronous-service.htm#ESRI_SECTION2_114F8364507C4B56B780DFAD505270FB.
    */
@@ -168,7 +168,7 @@ export function originDestinationMatrix(
   }
 
   return request(`${cleanUrl(endpoint)}/solveODCostMatrix`, options).then(
-    function(res) {
+    function (res) {
       return cleanResponse(res, options);
     }
   );

--- a/packages/arcgis-rest-routing/test/mocks/responses.ts
+++ b/packages/arcgis-rest-routing/test/mocks/responses.ts
@@ -11094,7 +11094,13 @@ export const ServiceAreaWebMercator: any = {
 
 // with default `outputType` of "esriNAODOutputSparseMatrix"
 export const OriginDestinationMatrix: any = {
-  messages: [],
+  messages: [{
+    type: 50,
+    description: "The following restriction attributes are not valid and were ignored: test1"
+  }, {
+    type: 50,
+    description: "The following restriction attributes are not valid and were ignored: test2"
+  }],
   odCostMatrix: {
     "1": {
       "1": [23.997715775219728, 10.432671969745961, 16.78975803847885],

--- a/packages/arcgis-rest-routing/test/originDestinationMatrix.test.ts
+++ b/packages/arcgis-rest-routing/test/originDestinationMatrix.test.ts
@@ -211,6 +211,8 @@ describe("originDestinationMatrix", () => {
         expect(response.destinations.features.length).toEqual(
           destinations.length
         );
+        expect(response.messages.length).toEqual(2);
+        expect(response.messages[1].type).toEqual(50);
 
         done();
       })


### PR DESCRIPTION
This is a follow-up fix to #826.  Makes the change to the types and also adds some unit tests that verify that the types are working properly.

Resolves #834