### PR TITLE
move SpatialRelationship type

### DIFF
--- a/packages/arcgis-rest-feature-layer/src/helpers.ts
+++ b/packages/arcgis-rest-feature-layer/src/helpers.ts
@@ -3,10 +3,22 @@
 import { cleanUrl, IRequestOptions } from "@esri/arcgis-rest-request";
 import {
   GeometryType,
-  SpatialRelationship,
   IGeometry,
   ISpatialReference
 } from "@esri/arcgis-rest-types";
+
+/**
+ * The spatial relationship used to compare input geometries
+ */
+export type SpatialRelationship =
+  | "esriSpatialRelIntersects"
+  | "esriSpatialRelContains"
+  | "esriSpatialRelCrosses"
+  | "esriSpatialRelEnvelopeIntersects"
+  | "esriSpatialRelIndexIntersects"
+  | "esriSpatialRelOverlaps"
+  | "esriSpatialRelTouches"
+  | "esriSpatialRelWithin";
 
 /**
  * Base options for making requests against feature layers
@@ -82,7 +94,7 @@ const serviceRegex = new RegExp(/.+(?:map|feature|image)server/i);
 /**
  * Return the service url. If not matched, returns what was passed in
  */
-export function parseServiceUrl (url: string) {
+export function parseServiceUrl(url: string) {
   const match = url.match(serviceRegex);
   if (match) {
     return match[0];
@@ -91,7 +103,7 @@ export function parseServiceUrl (url: string) {
   }
 }
 
-function stripQueryString (url: string) {
+function stripQueryString(url: string) {
   const stripped = url.split('?')[0];
   return cleanUrl(stripped);
 }

--- a/packages/arcgis-rest-feature-layer/src/index.ts
+++ b/packages/arcgis-rest-feature-layer/src/index.ts
@@ -25,7 +25,6 @@ export {
   IFeatureSet,
   Units,
   IExtent,
-  SpatialRelationship,
   IGeometry,
   ILayerDefinition,
   IFeatureServiceDefinition

--- a/packages/arcgis-rest-types/src/geometry.ts
+++ b/packages/arcgis-rest-types/src/geometry.ts
@@ -184,24 +184,7 @@ export type GeometryType =
   | "esriGeometryPolygon"
   | "esriGeometryEnvelope";
 
-/**
- * The spatial relationship used to compare input geometries
- *
- * `SpatialRelationship` can also be imported from the following packages:
- *
- * ```js
- * import { SpatialRelationship } from "@esri/arcgis-rest-feature-layer";
- * ```
- */
-export type SpatialRelationship =
-  | "esriSpatialRelIntersects"
-  | "esriSpatialRelContains"
-  | "esriSpatialRelCrosses"
-  | "esriSpatialRelEnvelopeIntersects"
-  | "esriSpatialRelIndexIntersects"
-  | "esriSpatialRelOverlaps"
-  | "esriSpatialRelTouches"
-  | "esriSpatialRelWithin";
+
 
 /**
  * Extents are used to define rectangles and bounding boxes.


### PR DESCRIPTION
SpatialRelationship type is only used in feature-layer package, so move it there.

Addresses (partially ) #789

Waiting till `4.0-build-system` branch is merged then will rebase to the `v4.0` branch for merging