### PR TITLE
fix(arcgis-rest-portal): admin uses items/:id/share route for items outside their org

### DIFF
--- a/packages/arcgis-rest-auth/package-lock.json
+++ b/packages/arcgis-rest-auth/package-lock.json
@@ -1,11 +1,27 @@
 {
-	"requires": true,
+	"name": "@esri/arcgis-rest-auth",
+	"version": "3.3.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@esri/arcgis-rest-request": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.3.1.tgz",
+			"integrity": "sha512-96Tb/6c5mmN80a6pjnGBYaZ0fW6m56g1Z/8QKlYPyI75fr0Ddx8W1seAXWQfF4hGibUcyZ5SyNG2LG4ZGAeu+g==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.10.0"
+			}
+		},
+		"@esri/arcgis-rest-types": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.3.1.tgz",
+			"integrity": "sha512-cqLUTW1PfF8anbeSmFe7kDYlm3YQntNGsAdmVtFWu3rm9IfmojtniHPjNtDQF6Y0P34MBMaLmSh+xdhxRAp32g=="
+		},
 		"tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		}
 	}
 }

--- a/packages/arcgis-rest-portal/package-lock.json
+++ b/packages/arcgis-rest-portal/package-lock.json
@@ -1,11 +1,37 @@
 {
-	"requires": true,
+	"name": "@esri/arcgis-rest-portal",
+	"version": "3.3.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@esri/arcgis-rest-auth": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.3.1.tgz",
+			"integrity": "sha512-1TMiqa5+14aZJ1v3VdotInDdOmKrw+A78AfsO2JOmgupklOw7vHL5c2VbfoA9DaCg3TSDTmKKEXkqqtqCEQGvw==",
+			"dev": true,
+			"requires": {
+				"@esri/arcgis-rest-types": "^3.3.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/arcgis-rest-request": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.3.1.tgz",
+			"integrity": "sha512-96Tb/6c5mmN80a6pjnGBYaZ0fW6m56g1Z/8QKlYPyI75fr0Ddx8W1seAXWQfF4hGibUcyZ5SyNG2LG4ZGAeu+g==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.10.0"
+			}
+		},
+		"@esri/arcgis-rest-types": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.3.1.tgz",
+			"integrity": "sha512-cqLUTW1PfF8anbeSmFe7kDYlm3YQntNGsAdmVtFWu3rm9IfmojtniHPjNtDQF6Y0P34MBMaLmSh+xdhxRAp32g=="
+		},
 		"tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		}
 	}
 }

--- a/packages/arcgis-rest-portal/test/sharing/share-item-with-group.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/share-item-with-group.test.ts
@@ -1201,7 +1201,7 @@ describe("shareItemWithGroup() ::", () => {
         });
     });
   });
-  describe("ensureMembership", function() {
+  describe("ensureMembership", function () {
     it("should revert the user promotion and suppress resolved error", (done) => {
       fetchMock
         .once(
@@ -1315,6 +1315,60 @@ describe("shareItemWithGroup() ::", () => {
           // verify we shared the item
           const shareOptions: RequestInit = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
+          );
+          expect(shareOptions.body).toContain("groups=t6b");
+
+          done();
+        })
+        .catch((e) => {
+          fail();
+        });
+    });
+  });
+  describe("share item from another org to admin user's favorites group ::", () => {
+    it("should share item", (done) => {
+      fetchMock
+        .once(
+          "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
+          {
+            ...OrgAdminUserResponse,
+            favGroupId: "t6b",
+          }
+        )
+        .once(
+          "https://myorg.maps.arcgis.com/sharing/rest/search",
+          NoResultsSearchResponse
+        )
+        .get(
+          "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b?f=json&token=fake-token",
+          GroupOwnerResponse
+        )
+        .once(
+          "https://myorg.maps.arcgis.com/sharing/rest/community/users/casey?f=json&token=fake-token",
+          {
+            username: "casey",
+            orgId: "SOMEOTHERORG",
+            groups: [] as any[],
+          }
+        )
+        .post(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share",
+          { notSharedWith: [], itemId: "n3v" }
+        );
+
+      shareItemWithGroup({
+        authentication: MOCK_USER_SESSION,
+        id: "n3v",
+        groupId: "t6b",
+        owner: "casey",
+      })
+        .then((result) => {
+          expect(fetchMock.done()).toBeTruthy(
+            "All fetchMocks should have been called"
+          );
+          // verify we shared the item
+          const shareOptions: RequestInit = fetchMock.lastOptions(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
 

--- a/packages/arcgis-rest-request/package-lock.json
+++ b/packages/arcgis-rest-request/package-lock.json
@@ -1,11 +1,13 @@
 {
-	"requires": true,
+	"name": "@esri/arcgis-rest-request",
+	"version": "3.3.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		}
 	}
 }

--- a/packages/arcgis-rest-types/package-lock.json
+++ b/packages/arcgis-rest-types/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@esri/arcgis-rest-types",
+  "version": "3.3.1",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-portal

ISSUES CLOSED: #917 #882

Verified against PROD API using https://devtopia.esri.com/dc/portal-api-check/blob/master/spec/admin-share-living-atlast-to-own-group.spec.ts#L36