### PR TITLE
moved SpatialRelationship

### DIFF
--- a/packages/arcgis-rest-feature-layer/src/helpers.ts
+++ b/packages/arcgis-rest-feature-layer/src/helpers.ts
@@ -3,10 +3,29 @@
 import { cleanUrl, IRequestOptions } from "@esri/arcgis-rest-request";
 import type {
   GeometryType,
-  SpatialRelationship,
   IGeometry,
   ISpatialReference
 } from "@esri/arcgis-rest-types";
+
+
+/**
+ * The spatial relationship used to compare input geometries
+ *
+ * `SpatialRelationship` can also be imported from the following packages:
+ *
+ * ```js
+ * import { SpatialRelationship } from "@esri/arcgis-rest-feature-layer";
+ * ```
+ */
+ export type SpatialRelationship =
+ | "esriSpatialRelIntersects"
+ | "esriSpatialRelContains"
+ | "esriSpatialRelCrosses"
+ | "esriSpatialRelEnvelopeIntersects"
+ | "esriSpatialRelIndexIntersects"
+ | "esriSpatialRelOverlaps"
+ | "esriSpatialRelTouches"
+ | "esriSpatialRelWithin";
 
 /**
  * Base options for making requests against feature layers

--- a/packages/arcgis-rest-feature-layer/src/index.ts
+++ b/packages/arcgis-rest-feature-layer/src/index.ts
@@ -25,7 +25,6 @@ export type {
   IFeatureSet,
   Units,
   IExtent,
-  SpatialRelationship,
   IGeometry,
   ILayerDefinition,
   IFeatureServiceDefinition

--- a/packages/arcgis-rest-types/src/geometry.ts
+++ b/packages/arcgis-rest-types/src/geometry.ts
@@ -185,25 +185,6 @@ export type GeometryType =
   | "esriGeometryEnvelope";
 
 /**
- * The spatial relationship used to compare input geometries
- *
- * `SpatialRelationship` can also be imported from the following packages:
- *
- * ```js
- * import { SpatialRelationship } from "@esri/arcgis-rest-feature-layer";
- * ```
- */
-export type SpatialRelationship =
-  | "esriSpatialRelIntersects"
-  | "esriSpatialRelContains"
-  | "esriSpatialRelCrosses"
-  | "esriSpatialRelEnvelopeIntersects"
-  | "esriSpatialRelIndexIntersects"
-  | "esriSpatialRelOverlaps"
-  | "esriSpatialRelTouches"
-  | "esriSpatialRelWithin";
-
-/**
  * Extents are used to define rectangles and bounding boxes.
  *
  * `IExtent` can also be imported from the following packages:


### PR DESCRIPTION
... from `arcgis-rest-types`, because it is currently only used in one package, `arcgis-rest-feature-layer`

Addresses (partially) #789