### PR TITLE
types(feature-layer): make objectIds optional

### DIFF
--- a/packages/arcgis-rest-feature-layer/src/delete.ts
+++ b/packages/arcgis-rest-feature-layer/src/delete.ts
@@ -22,7 +22,7 @@ export interface IDeleteFeaturesOptions
   /**
    * Array of objectIds to delete.
    */
-  objectIds: number[];
+  objectIds?: number[];
 }
 
 /**


### PR DESCRIPTION
objectIds is currently required by the `IDeleteFeaturesOptions` - this should not be the case since you can also use where clauses to delete features. 