### PR TITLE
Automatically refresh session and try again with new token on invalid token errors

### DIFF
--- a/packages/arcgis-rest-portal/test/groups/update-user-membership.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/update-user-membership.test.ts
@@ -16,7 +16,7 @@ describe("udpate-user-membership", () => {
     });
 
     // make sure session doesnt cache metadata
-    MOCK_USER_SESSION.refreshSession()
+    MOCK_USER_SESSION.refreshCredentials()
       .then(() => done())
       .catch();
   });

--- a/packages/arcgis-rest-portal/test/sharing/access.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/access.test.ts
@@ -23,7 +23,7 @@ describe("setItemAccess()", () => {
     });
 
     // make sure session doesnt cache metadata
-    MOCK_USER_SESSION.refreshSession()
+    MOCK_USER_SESSION.refreshCredentials()
       .then(() => done())
       .catch();
   });

--- a/packages/arcgis-rest-portal/test/sharing/share-item-with-group.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/share-item-with-group.test.ts
@@ -97,7 +97,7 @@ describe("shareItemWithGroup() ::", () => {
     });
 
     // make sure session doesnt cache metadata
-    MOCK_USER_SESSION.refreshSession()
+    MOCK_USER_SESSION.refreshCredentials()
       .then(() => done())
       .catch();
   });

--- a/packages/arcgis-rest-portal/test/sharing/unshare-item-with-group.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/unshare-item-with-group.test.ts
@@ -53,7 +53,7 @@ describe("unshareItemWithGroup() ::", () => {
     });
 
     // make sure session doesnt cache metadata
-    MOCK_USER_SESSION.refreshSession()
+    MOCK_USER_SESSION.refreshCredentials()
       .then(() => done())
       .catch();
   });

--- a/packages/arcgis-rest-request/src/ApplicationCredentialsManager.ts
+++ b/packages/arcgis-rest-request/src/ApplicationCredentialsManager.ts
@@ -122,7 +122,7 @@ export class ApplicationCredentialsManager implements IAuthenticationManager {
     );
   }
 
-  public refreshSession() {
+  public refreshCredentials() {
     return this.refreshToken().then(() => this);
   }
 }

--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -1499,6 +1499,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
       },
       ...requestOptions
     };
+
     return fetchToken(`${this.portal}/oauth2/token`, options).then(
       (response) => {
         this._token = response.token;

--- a/packages/arcgis-rest-request/src/fetch-token.ts
+++ b/packages/arcgis-rest-request/src/fetch-token.ts
@@ -30,6 +30,7 @@ export function fetchToken(
   requestOptions: ITokenRequestOptions
 ): Promise<IFetchTokenResponse> {
   const options: IRequestOptions = requestOptions;
+
   // we generate a response, so we can't return the raw response
   options.rawResponse = false;
 

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -75,10 +75,12 @@ export class ArcGISAuthError extends ArcGISRequestError {
       code === "AUTHENTICATION_ERROR_CODE" ? message : `${code}: ${message}`;
   }
 
-  public retry(getSession: IRetryAuthError, retryLimit = 3) {
+  public retry(getSession: IRetryAuthError, retryLimit = 1) {
     let tries = 0;
 
     const retryRequest = (resolve: any, reject: any) => {
+      tries = tries + 1;
+
       getSession(this.url, this.options)
         .then((session) => {
           const newOptions = {
@@ -86,8 +88,7 @@ export class ArcGISAuthError extends ArcGISRequestError {
             ...{ authentication: session }
           };
 
-          tries = tries + 1;
-          return request(this.url, newOptions);
+          return internalRequest(this.url, newOptions);
         })
         .then((response) => {
           resolve(response);
@@ -95,7 +96,11 @@ export class ArcGISAuthError extends ArcGISRequestError {
         .catch((e) => {
           if (e.name === "ArcGISAuthError" && tries < retryLimit) {
             retryRequest(resolve, reject);
-          } else if (e.name === "ArcGISAuthError" && tries >= retryLimit) {
+          } else if (
+            e.name === this.name &&
+            e.message === this.message &&
+            tries >= retryLimit
+          ) {
             reject(this);
           } else {
             reject(e);
@@ -171,30 +176,17 @@ export function checkForErrors(
 }
 
 /**
- * ```js
- * import { request } from '@esri/arcgis-rest-request';
- * //
- * request('https://www.arcgis.com/sharing/rest')
- *   .then(response) // response.currentVersion === 5.2
- * //
- * request('https://www.arcgis.com/sharing/rest', {
- *   httpMethod: "GET"
- * })
- * //
- * request('https://www.arcgis.com/sharing/rest/search', {
- *   params: { q: 'parks' }
- * })
- *   .then(response) // response.total => 78379
- * ```
- * Generic method for making HTTP requests to ArcGIS REST API endpoints.
+ * This is the internal implementation of `request` without the automatic retry behavior to prevent
+ * infinite loops when a server continues to return invalid token errors.
  *
  * @param url - The URL of the ArcGIS REST API endpoint.
  * @param requestOptions - Options for the request, including parameters relevant to the endpoint.
  * @returns A Promise that will resolve with the data from the response.
+ * @internal
  */
-export function request(
+export function internalRequest(
   url: string,
-  requestOptions: IRequestOptions = { params: { f: "json" } }
+  requestOptions: IRequestOptions
 ): Promise<any> {
   const defaults = getDefaultRequestOptions();
   const options: IRequestOptions = {
@@ -269,6 +261,10 @@ export function request(
   } else {
     authentication = options.authentication;
   }
+
+  // for errors in GET requests we want the URL passed to the error to the the URL before
+  // query params are applied.
+  const originalUrl = url;
 
   return (
     authentication
@@ -416,7 +412,7 @@ export function request(
       if ((params.f === "json" || params.f === "geojson") && !rawResponse) {
         const response = checkForErrors(
           data,
-          url,
+          originalUrl,
           params,
           options,
           originalAuthError
@@ -443,4 +439,48 @@ export function request(
         return data;
       }
     });
+}
+
+/**
+ * ```js
+ * import { request } from '@esri/arcgis-rest-request';
+ * //
+ * request('https://www.arcgis.com/sharing/rest')
+ *   .then(response) // response.currentVersion === 5.2
+ * //
+ * request('https://www.arcgis.com/sharing/rest', {
+ *   httpMethod: "GET"
+ * })
+ * //
+ * request('https://www.arcgis.com/sharing/rest/search', {
+ *   params: { q: 'parks' }
+ * })
+ *   .then(response) // response.total => 78379
+ * ```
+ * Generic method for making HTTP requests to ArcGIS REST API endpoints.
+ *
+ * @param url - The URL of the ArcGIS REST API endpoint.
+ * @param requestOptions - Options for the request, including parameters relevant to the endpoint.
+ * @returns A Promise that will resolve with the data from the response.
+ */
+export function request(
+  url: string,
+  requestOptions: IRequestOptions = { params: { f: "json" } }
+): Promise<any> {
+  return internalRequest(url, requestOptions).catch((e) => {
+    if (
+      e instanceof ArcGISAuthError &&
+      e.code === 498 &&
+      e.message === "498: Invalid token." &&
+      requestOptions.authentication &&
+      (requestOptions.authentication as any).canRefresh &&
+      (requestOptions.authentication as any).refreshSession
+    ) {
+      return e.retry(() => {
+        return (requestOptions.authentication as any).refreshSession();
+      }, 1);
+    } else {
+      return Promise.reject(e);
+    }
+  });
 }

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -473,11 +473,12 @@ export function request(
       e.code === 498 &&
       e.message === "498: Invalid token." &&
       requestOptions.authentication &&
-      (requestOptions.authentication as any).canRefresh &&
-      (requestOptions.authentication as any).refreshSession
+      typeof requestOptions.authentication !== "string" &&
+      requestOptions.authentication.canRefresh &&
+      requestOptions.authentication.refreshCredentials
     ) {
       return e.retry(() => {
-        return (requestOptions.authentication as any).refreshSession();
+        return (requestOptions.authentication as any).refreshCredentials();
       }, 1);
     } else {
       return Promise.reject(e);

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -262,7 +262,7 @@ export function internalRequest(
     authentication = options.authentication;
   }
 
-  // for errors in GET requests we want the URL passed to the error to the the URL before
+  // for errors in GET requests we want the URL passed to the error to be the URL before
   // query params are applied.
   const originalUrl = url;
 

--- a/packages/arcgis-rest-request/src/utils/IAuthenticationManager.ts
+++ b/packages/arcgis-rest-request/src/utils/IAuthenticationManager.ts
@@ -17,6 +17,31 @@ export interface IAuthenticationManager {
    * Defaults to 'https://www.arcgis.com/sharing/rest'.
    */
   portal: string;
+
+  /**
+   * Returns the proper token for a given URL and request options.
+   * @param url The requested URL.
+   * @param requestOptions the requests options.
+   */
   getToken(url: string, requestOptions?: ITokenRequestOptions): Promise<string>;
+
+  /**
+   * Returns the proper [`credentials`] option for `fetch` for a given domain.
+   * See [trusted server](https://enterprise.arcgis.com/en/portal/latest/administer/windows/configure-security.htm#ESRI_SECTION1_70CC159B3540440AB325BE5D89DBE94A).
+   * Used internally by underlying request methods to add support for specific security considerations.
+   *
+   * @param url The url of the request
+   * @returns "include" or "same-origin"
+   */
   getDomainCredentials?(url: string): RequestCredentials;
+
+  /**
+   * Should return `true` if these credentials can be refreshed and `false` if it cannot. The
+   */
+  canRefresh?: boolean;
+
+  /**
+   * Refresh the stored credentials.
+   */
+  refreshCredentials?(requestOptions?: ITokenRequestOptions): Promise<this>;
 }

--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -51,7 +51,6 @@ export interface IRequestOptions {
   headers?: {
     [key: string]: any;
   };
-
   /**
    * Suppress any ArcGIS REST JS related warnings for this request.
    */

--- a/packages/arcgis-rest-request/test/ApplicationSession.test.ts
+++ b/packages/arcgis-rest-request/test/ApplicationSession.test.ts
@@ -136,7 +136,7 @@ describe("ApplicationCredentialsManager", () => {
     });
 
     session
-      .refreshSession()
+      .refreshCredentials()
       .then((s) => {
         expect(s).toBe(session);
         done();

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -714,7 +714,7 @@ describe("ArcGISIdentityManager", () => {
     });
   });
 
-  describe(".refreshSession()", () => {
+  describe(".refreshCredentials()", () => {
     it("should refresh with a username and password if expired", (done) => {
       const session = new ArcGISIdentityManager({
         username: "c@sey",
@@ -730,7 +730,7 @@ describe("ArcGISIdentityManager", () => {
       });
 
       session
-        .refreshSession()
+        .refreshCredentials()
         .then((s) => {
           expect(s.token).toBe("token");
           expect(s.tokenExpires).toEqual(TOMORROW);
@@ -759,7 +759,7 @@ describe("ArcGISIdentityManager", () => {
       });
 
       session
-        .refreshSession()
+        .refreshCredentials()
         .then((s) => {
           expect(s.token).toBe("newToken");
           expect(s.tokenExpires.getTime()).toBeGreaterThan(
@@ -790,7 +790,7 @@ describe("ArcGISIdentityManager", () => {
       });
 
       session
-        .refreshSession()
+        .refreshCredentials()
         .then((s) => {
           expect(s.token).toBe("newToken");
           expect(s.tokenExpires.getTime()).toBeGreaterThan(
@@ -816,7 +816,7 @@ describe("ArcGISIdentityManager", () => {
 
       expect(session.canRefresh).toBe(false);
 
-      session.refreshSession().catch((e) => {
+      session.refreshCredentials().catch((e) => {
         expect(e instanceof ArcGISAuthError).toBeTruthy();
         expect(e.name).toBe("ArcGISAuthError");
         expect(e.message).toBe("Unable to refresh token.");

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -641,7 +641,7 @@ describe("request()", () => {
       });
     });
 
-    it("should throw throw an error is it also fails with the new token", () => {
+    it("should throw an error if it also fails with the new token", () => {
       fetchMock.get(
         "https://www.arcgis.com/sharing/rest/portals/self?f=json&token=TOKEN",
         { error: { code: 498, message: "Invalid token.", details: [] } }

--- a/packages/arcgis-rest-request/test/utils/ArcGISAuthError.test.ts
+++ b/packages/arcgis-rest-request/test/utils/ArcGISAuthError.test.ts
@@ -4,12 +4,12 @@
 import {
   ArcGISAuthError,
   IRetryAuthError,
-  ErrorTypes,
+  ErrorTypes
 } from "../../src/index.js";
 import {
   ArcGISOnlineAuthError,
   ArcGISOnlineError,
-  GenerateTokenError,
+  GenerateTokenError
 } from "./../mocks/errors.js";
 import { request } from "../../src/request.js";
 import fetchMock from "fetch-mock";
@@ -56,7 +56,7 @@ describe("ArcGISRequestError", () => {
       },
       retryHandler(url, options) {
         return Promise.resolve(MockAuth);
-      },
+      }
     };
 
     it("should allow retrying a request with a new or updated session", (done) => {
@@ -71,21 +71,21 @@ describe("ArcGISRequestError", () => {
             title: "Test Map",
             tags: "foo",
             type: "Web Map",
-            f: "json",
-          },
+            f: "json"
+          }
         }
       );
 
       fetchMock.once("*", {
         success: true,
         id: "abc",
-        folder: null,
+        folder: null
       });
 
       const retryHandlerSpy = spyOn(MockAuth, "retryHandler").and.callThrough();
 
       error
-        .retry(MockAuth.retryHandler, 1)
+        .retry(MockAuth.retryHandler, 3)
         .then((response: any) => {
           const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
           expect(url).toEqual(
@@ -118,8 +118,8 @@ describe("ArcGISRequestError", () => {
             title: "Test Map",
             tags: "foo",
             type: "Web Map",
-            f: "json",
-          },
+            f: "json"
+          }
         }
       );
 
@@ -127,7 +127,7 @@ describe("ArcGISRequestError", () => {
 
       const retryHandlerSpy = spyOn(MockAuth, "retryHandler").and.callThrough();
 
-      error.retry(MockAuth.retryHandler).catch((e: any) => {
+      error.retry(MockAuth.retryHandler, 3).catch((e: any) => {
         const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "http://www.arcgis.com/sharing/rest/content/users/caseyjones/addItem"
@@ -155,8 +155,8 @@ describe("ArcGISRequestError", () => {
           httpMethod: "POST",
           params: {
             type: "Web Map",
-            f: "json",
-          },
+            f: "json"
+          }
         }
       );
 
@@ -185,8 +185,8 @@ describe("ArcGISRequestError", () => {
           username: "correct",
           password: "incorrect",
           expiration: 10260,
-          referer: "localhost",
-        },
+          referer: "localhost"
+        }
       }).catch((err) => {
         expect(err.name).toBe(ErrorTypes.ArcGISAuthError);
         done();

--- a/packages/arcgis-rest-request/test/utils/check-for-errors.test.ts
+++ b/packages/arcgis-rest-request/test/utils/check-for-errors.test.ts
@@ -5,7 +5,7 @@ import {
   checkForErrors,
   warn,
   ArcGISRequestError,
-  ArcGISAuthError,
+  ArcGISAuthError
 } from "../../src/index.js";
 import { SharingRestInfo } from "./../mocks/sharing-rest-info.js";
 import {
@@ -17,7 +17,7 @@ import {
   ArcGISOnlineErrorNoCode,
   ArcGISServerTokenRequired,
   ArcGISOnlineAuthError,
-  BillingErrorWithCode200,
+  BillingErrorWithCode200
 } from "./../mocks/errors.js";
 
 describe("checkForErrors", () => {

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,6 +2,7 @@
   "out": "typedoc",
   "json": "typedoc/typedoc.json",
   "logLevel": "Verbose",
+  "excludeInternal": true,
   "packages": [
     "./packages/arcgis-rest-auth/",
     "./packages/arcgis-rest-demographics/",


### PR DESCRIPTION
This PR adds extra support for `Invalid token.` errors. When `request` encounters an invalid token it checks if:

1. The `authentication` option `canRefresh` and has `refreshSession`.
2. The error is `498: Invalid token.`

In this scenario we call `e.retry()` calling `refreshCredentials()` to exchange for a fresh token and retry the request with a new token. 

This should handle edge cases where the server thinks a token is invalid but ArcGIS REST JS thinks it is valid OR were ArcGIS REST JS doesn't have an expiration stored for the token.

In order to avoid edge cases where a server continuously responds with `Invalid token` (for example for a resource that a user doesn't have access too) we have an `internalRequest` function which this implements everything EXCEPT the automatic retry logic. `internalRequest` is what is used when we retry auth errors. The public  `request` function is just `internalRequest` with the retry logic.

---

This also renames `refreshSession` to `refreshCredentials` to align with the new naming conventions.