### PR TITLE
Fix refresh token duration

### DIFF
--- a/demos/express/package.json
+++ b/demos/express/package.json
@@ -8,7 +8,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@esri/arcgis-rest-request": "^3.3.0",
+    "@esri/arcgis-rest-request": "file:../../packages/arcgis-rest-request",
     "express": "^4.16.3"
   },
   "author": ""

--- a/demos/express/server.js
+++ b/demos/express/server.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const app = express();
-const { UserSession } = require("@esri/arcgis-rest-request");
+const { ArcGISIdentityManager } = require("@esri/arcgis-rest-request");
 const { clientId } = require("./config.json");
 
 const credentials = {
@@ -10,15 +10,15 @@ const credentials = {
 
 app.get("/authorize", function (req, res) {
   // send the user to the authorization screen
-  UserSession.authorize(credentials, res);
+  ArcGISIdentityManager.authorize(credentials, res);
 });
 
 // the after authorizing the user is redirected to /authenticate
 app.get("/authenticate", function (req, res) {
   if (credentials) {
     // the user will be redirected with an authorization code we will need to exchange for tokens.
-    // After exchanging we will have a UserSession we can use in REST JS.
-    UserSession.exchangeAuthorizationCode(credentials, req.query.code)
+    // After exchanging we will have a ArcGISIdentityManager we can use in REST JS.
+    ArcGISIdentityManager.exchangeAuthorizationCode(credentials, req.query.code)
       .then((session) => {
         // get the users info
         return session.getUser();

--- a/demos/express/server.js
+++ b/demos/express/server.js
@@ -5,7 +5,8 @@ const { clientId } = require("./config.json");
 
 const credentials = {
   clientId,
-  redirectUri: "http://localhost:3000/authenticate"
+  redirectUri: "http://localhost:3000/authenticate",
+  expiration: 10
 };
 
 app.get("/authorize", function (req, res) {
@@ -20,6 +21,7 @@ app.get("/authenticate", function (req, res) {
     // After exchanging we will have a ArcGISIdentityManager we can use in REST JS.
     ArcGISIdentityManager.exchangeAuthorizationCode(credentials, req.query.code)
       .then((session) => {
+        console.log(session);
         // get the users info
         return session.getUser();
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,7 +350,7 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "^3.3.0",
+        "@esri/arcgis-rest-request": "file:../../packages/arcgis-rest-request",
         "express": "^4.16.3"
       }
     },
@@ -359,7 +359,7 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "../../packages/arcgis-rest-request",
+        "@esri/arcgis-rest-request": "file:../../packages/arcgis-rest-request",
         "dotenv": "^16.0.0",
         "express": "^4.16.3",
         "express-session": "^1.17.2",
@@ -370,58 +370,6 @@
       "resolved": "demos/packages/arcgis-rest-request",
       "link": true
     },
-    "demos/express-oauth-advanced/node_modules/body-parser": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-      "dependencies": {
-        "bytes": "3.0.0",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
-        "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
-        "qs": "6.5.2",
-        "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "demos/express-oauth-advanced/node_modules/dotenv": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
@@ -429,156 +377,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "demos/express-oauth-advanced/node_modules/express": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
-      "dependencies": {
-        "accepts": "~1.3.5",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.18.3",
-        "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.1.1",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
-        "qs": "6.5.2",
-        "range-parser": "~1.2.0",
-        "safe-buffer": "5.1.2",
-        "send": "0.16.2",
-        "serve-static": "1.13.2",
-        "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/finalhandler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/http-errors": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "demos/express-oauth-advanced/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "demos/express-oauth-advanced/node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "demos/express-oauth-advanced/node_modules/qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-      "dependencies": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "demos/express-oauth-advanced/node_modules/setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-    },
-    "demos/express-oauth-advanced/node_modules/statuses": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "demos/express/node_modules/@esri/arcgis-rest-request": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.4.3.tgz",
-      "integrity": "sha512-pUYB2YTJwClVBQ1ygnkBS3L/Hrob190Wx5dIgCgH9ipPsl+aBMtu+oG45bOttk6SldYltWQAHEiXltaHVUcQRA==",
-      "dependencies": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "demos/express/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "demos/feature-service-browser": {
       "version": "3.3.0",
@@ -840,6 +638,33 @@
       "devDependencies": {
         "ts-node": "^10.7.0",
         "typescript": "^4.6.2"
+      }
+    },
+    "demos/node-typescript-es-modules/node_modules/@esri/arcgis-rest-portal": {
+      "version": "4.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.2.tgz",
+      "integrity": "sha512-0QrLjW1IgaGBVB5OJfJOryflEL5yVEa05q2p3MKzU7Zhb8BDUjOwaEybUADjYUBN8KgGOItIos2cTdlYOZRAWg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+      }
+    },
+    "demos/node-typescript-es-modules/node_modules/@esri/arcgis-rest-request": {
+      "version": "4.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.2.tgz",
+      "integrity": "sha512-khDUZ8YMaGFG29Bg9pTkx8ApwxyYEC2SzJJWr57QJISaaGufXvhgjy1kxOkjdyKxnU0dcRErTou9e8qGrkK2xw==",
+      "dependencies": {
+        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "demos/node-typescript-es-modules/node_modules/typescript": {
@@ -41260,6 +41085,7 @@
     },
     "node_modules/send": {
       "version": "0.16.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -41282,6 +41108,7 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -41289,6 +41116,7 @@
     },
     "node_modules/send/node_modules/http-errors": {
       "version": "1.6.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~1.1.2",
@@ -41302,10 +41130,12 @@
     },
     "node_modules/send/node_modules/inherits": {
       "version": "2.0.3",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -41313,14 +41143,17 @@
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/send/node_modules/setprototypeof": {
       "version": "1.1.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/send/node_modules/statuses": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -41406,6 +41239,7 @@
     },
     "node_modules/serve-static": {
       "version": "1.13.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~1.0.2",
@@ -48603,11 +48437,24 @@
     },
     "packages/arcgis-rest-auth": {
       "name": "@esri/arcgis-rest-auth",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2",
+        "@esri/arcgis-rest-request": "4.0.0-beta.3",
         "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "packages/arcgis-rest-auth/node_modules/@esri/arcgis-rest-request": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
+      "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
+      "dependencies": {
+        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=12.20.0"
@@ -48615,38 +48462,81 @@
     },
     "packages/arcgis-rest-demographics": {
       "name": "@esri/arcgis-rest-demographics",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+        "@esri/arcgis-rest-request": "4.0.0-beta.3"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+        "@esri/arcgis-rest-request": "4.0.0-beta.3"
+      }
+    },
+    "packages/arcgis-rest-demographics/node_modules/@esri/arcgis-rest-request": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
+      "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
+      "dev": true,
+      "dependencies": {
+        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "packages/arcgis-rest-feature-service": {
       "name": "@esri/arcgis-rest-feature-service",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-portal": "4.0.0-beta.2",
-        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+        "@esri/arcgis-rest-portal": "4.0.0-beta.3",
+        "@esri/arcgis-rest-request": "4.0.0-beta.3"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@esri/arcgis-rest-portal": "4.0.0-beta.2",
-        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+        "@esri/arcgis-rest-portal": "4.0.0-beta.3",
+        "@esri/arcgis-rest-request": "4.0.0-beta.3"
+      }
+    },
+    "packages/arcgis-rest-feature-service/node_modules/@esri/arcgis-rest-portal": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.3.tgz",
+      "integrity": "sha512-9uyO98EwF9KDQ7rc8OY+WZFTo0/6irwyBYp2zByx+e9YZIuRgG2LHwHRnRWkeZ2D3EPJLK2Cwo+4Qlxa5R5ikQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@esri/arcgis-rest-request": "4.0.0-beta.3"
+      }
+    },
+    "packages/arcgis-rest-feature-service/node_modules/@esri/arcgis-rest-request": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
+      "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
+      "dev": true,
+      "dependencies": {
+        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "packages/arcgis-rest-fetch": {
@@ -48665,7 +48555,7 @@
     },
     "packages/arcgis-rest-geocoding": {
       "name": "@esri/arcgis-rest-geocoding",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@terraformer/arcgis": "^2.0.7",
@@ -48673,35 +48563,49 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+        "@esri/arcgis-rest-request": "4.0.0-beta.3"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+        "@esri/arcgis-rest-request": "4.0.0-beta.3"
+      }
+    },
+    "packages/arcgis-rest-geocoding/node_modules/@esri/arcgis-rest-request": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
+      "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
+      "dev": true,
+      "dependencies": {
+        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "packages/arcgis-rest-portal": {
       "name": "@esri/arcgis-rest-portal",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+        "@esri/arcgis-rest-request": "4.0.0-beta.4"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+        "@esri/arcgis-rest-request": "4.0.0-beta.4"
       }
     },
     "packages/arcgis-rest-request": {
       "name": "@esri/arcgis-rest-request",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
@@ -48714,7 +48618,7 @@
     },
     "packages/arcgis-rest-routing": {
       "name": "@esri/arcgis-rest-routing",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@terraformer/arcgis": "^2.0.7",
@@ -48722,13 +48626,27 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+        "@esri/arcgis-rest-request": "4.0.0-beta.3"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2"
+        "@esri/arcgis-rest-request": "4.0.0-beta.3"
+      }
+    },
+    "packages/arcgis-rest-routing/node_modules/@esri/arcgis-rest-request": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
+      "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
+      "dev": true,
+      "dependencies": {
+        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     }
   },
@@ -50500,8 +50418,20 @@
     "@esri/arcgis-rest-auth": {
       "version": "file:packages/arcgis-rest-auth",
       "requires": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2",
+        "@esri/arcgis-rest-request": "4.0.0-beta.3",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-request": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
+          "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
+          "requires": {
+            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@esri/arcgis-rest-demo-browser-es-modules": {
@@ -50548,29 +50478,14 @@
     "@esri/arcgis-rest-demo-express": {
       "version": "file:demos/express",
       "requires": {
-        "@esri/arcgis-rest-request": "^3.3.0",
+        "@esri/arcgis-rest-request": "file:../../packages/arcgis-rest-request",
         "express": "^4.16.3"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-request": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.4.3.tgz",
-          "integrity": "sha512-pUYB2YTJwClVBQ1ygnkBS3L/Hrob190Wx5dIgCgH9ipPsl+aBMtu+oG45bOttk6SldYltWQAHEiXltaHVUcQRA==",
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
     "@esri/arcgis-rest-demo-express-oauth-advanced": {
       "version": "file:demos/express-oauth-advanced",
       "requires": {
-        "@esri/arcgis-rest-request": "../../packages/arcgis-rest-request",
+        "@esri/arcgis-rest-request": "file:../../packages/arcgis-rest-request",
         "dotenv": "^16.0.0",
         "express": "^4.16.3",
         "express-session": "^1.17.2",
@@ -50580,166 +50495,10 @@
         "@esri/arcgis-rest-request": {
           "version": "file:demos/packages/arcgis-rest-request"
         },
-        "body-parser": {
-          "version": "1.18.3",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-          "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-          "requires": {
-            "bytes": "3.0.0",
-            "content-type": "~1.0.4",
-            "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "http-errors": "~1.6.3",
-            "iconv-lite": "0.4.23",
-            "on-finished": "~2.3.0",
-            "qs": "6.5.2",
-            "raw-body": "2.3.3",
-            "type-is": "~1.6.16"
-          }
-        },
-        "bytes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-        },
-        "content-disposition": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
-        },
-        "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "dotenv": {
           "version": "16.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
           "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
-        },
-        "express": {
-          "version": "4.16.4",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-          "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
-          "requires": {
-            "accepts": "~1.3.5",
-            "array-flatten": "1.1.1",
-            "body-parser": "1.18.3",
-            "content-disposition": "0.5.2",
-            "content-type": "~1.0.4",
-            "cookie": "0.3.1",
-            "cookie-signature": "1.0.6",
-            "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
-            "finalhandler": "1.1.1",
-            "fresh": "0.5.2",
-            "merge-descriptors": "1.0.1",
-            "methods": "~1.1.2",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.2",
-            "path-to-regexp": "0.1.7",
-            "proxy-addr": "~2.0.4",
-            "qs": "6.5.2",
-            "range-parser": "~1.2.0",
-            "safe-buffer": "5.1.2",
-            "send": "0.16.2",
-            "serve-static": "1.13.2",
-            "setprototypeof": "1.1.0",
-            "statuses": "~1.4.0",
-            "type-is": "~1.6.16",
-            "utils-merge": "1.0.1",
-            "vary": "~1.1.2"
-          }
-        },
-        "finalhandler": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-          "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.2",
-            "statuses": "~1.4.0",
-            "unpipe": "~1.0.0"
-          }
-        },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "path-to-regexp": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-        },
-        "raw-body": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-          "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-          "requires": {
-            "bytes": "3.0.0",
-            "http-errors": "1.6.3",
-            "iconv-lite": "0.4.23",
-            "unpipe": "1.0.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
@@ -50902,16 +50661,51 @@
     "@esri/arcgis-rest-demographics": {
       "version": "file:packages/arcgis-rest-demographics",
       "requires": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2",
+        "@esri/arcgis-rest-request": "4.0.0-beta.3",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-request": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
+          "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
+          "dev": true,
+          "requires": {
+            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@esri/arcgis-rest-feature-service": {
       "version": "file:packages/arcgis-rest-feature-service",
       "requires": {
-        "@esri/arcgis-rest-portal": "4.0.0-beta.2",
-        "@esri/arcgis-rest-request": "4.0.0-beta.2",
+        "@esri/arcgis-rest-portal": "4.0.0-beta.3",
+        "@esri/arcgis-rest-request": "4.0.0-beta.3",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-portal": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.3.tgz",
+          "integrity": "sha512-9uyO98EwF9KDQ7rc8OY+WZFTo0/6irwyBYp2zByx+e9YZIuRgG2LHwHRnRWkeZ2D3EPJLK2Cwo+4Qlxa5R5ikQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
+          "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
+          "dev": true,
+          "requires": {
+            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@esri/arcgis-rest-fetch": {
@@ -50972,16 +50766,29 @@
     "@esri/arcgis-rest-geocoding": {
       "version": "file:packages/arcgis-rest-geocoding",
       "requires": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2",
+        "@esri/arcgis-rest-request": "4.0.0-beta.3",
         "@terraformer/arcgis": "^2.0.7",
         "@types/terraformer__arcgis": "^2.0.0",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-request": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
+          "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
+          "dev": true,
+          "requires": {
+            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@esri/arcgis-rest-portal": {
       "version": "file:packages/arcgis-rest-portal",
       "requires": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2",
+        "@esri/arcgis-rest-request": "4.0.0-beta.4",
         "tslib": "^2.3.0"
       }
     },
@@ -50996,10 +50803,23 @@
     "@esri/arcgis-rest-routing": {
       "version": "file:packages/arcgis-rest-routing",
       "requires": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.2",
+        "@esri/arcgis-rest-request": "4.0.0-beta.3",
         "@terraformer/arcgis": "^2.0.7",
         "@types/terraformer__arcgis": "^2.0.0",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-request": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
+          "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
+          "dev": true,
+          "requires": {
+            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@esri/arcgis-rest-tree-shaking-rollup": {
@@ -78663,6 +78483,7 @@
     },
     "send": {
       "version": "0.16.2",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -78681,12 +78502,14 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "http-errors": {
           "version": "1.6.3",
+          "dev": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -78695,19 +78518,24 @@
           }
         },
         "inherits": {
-          "version": "2.0.3"
+          "version": "2.0.3",
+          "dev": true
         },
         "mime": {
-          "version": "1.4.1"
+          "version": "1.4.1",
+          "dev": true
         },
         "ms": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "dev": true
         },
         "setprototypeof": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "dev": true
         },
         "statuses": {
-          "version": "1.4.0"
+          "version": "1.4.0",
+          "dev": true
         }
       }
     },
@@ -78772,6 +78600,7 @@
     },
     "serve-static": {
       "version": "1.13.2",
+      "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -81385,6 +81214,24 @@
         "typescript": "^4.6.2"
       },
       "dependencies": {
+        "@esri/arcgis-rest-portal": {
+          "version": "4.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.2.tgz",
+          "integrity": "sha512-0QrLjW1IgaGBVB5OJfJOryflEL5yVEa05q2p3MKzU7Zhb8BDUjOwaEybUADjYUBN8KgGOItIos2cTdlYOZRAWg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "4.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.2.tgz",
+          "integrity": "sha512-khDUZ8YMaGFG29Bg9pTkx8ApwxyYEC2SzJJWr57QJISaaGufXvhgjy1kxOkjdyKxnU0dcRErTou9e8qGrkK2xw==",
+          "requires": {
+            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
+            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
+            "tslib": "^2.3.1"
+          }
+        },
         "typescript": {
           "version": "4.6.2",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",

--- a/packages/arcgis-rest-feature-service/test/addToServiceDefinition.test.ts
+++ b/packages/arcgis-rest-feature-service/test/addToServiceDefinition.test.ts
@@ -30,7 +30,6 @@ describe("add to feature service", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-feature-service/test/createFeatureService.test.ts
+++ b/packages/arcgis-rest-feature-service/test/createFeatureService.test.ts
@@ -19,7 +19,6 @@ describe("create feature service", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-feature-service/test/getServiceAdminInfo.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getServiceAdminInfo.test.ts
@@ -16,7 +16,6 @@ describe("getServiceAdminInfo: ", () => {
     tokenExpires: TOMORROW,
     refreshToken: "refreshToken",
     refreshTokenExpires: TOMORROW,
-    refreshTokenTTL: 1440,
     username: "casey",
     password: "123456",
     portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-feature-service/test/getViewSources.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getViewSources.test.ts
@@ -14,7 +14,6 @@ describe("get-view-sources: ", () => {
     tokenExpires: TOMORROW,
     refreshToken: "refreshToken",
     refreshTokenExpires: TOMORROW,
-    refreshTokenTTL: 1440,
     username: "casey",
     password: "123456",
     portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-feature-service/test/updateServiceDefinition.test.ts
+++ b/packages/arcgis-rest-feature-service/test/updateServiceDefinition.test.ts
@@ -19,7 +19,6 @@ describe("update service definition", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/groups/add-users.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/add-users.test.ts
@@ -27,7 +27,6 @@ describe("add-users", () => {
     tokenExpires: TOMORROW,
     refreshToken: "refreshToken",
     refreshTokenExpires: TOMORROW,
-    refreshTokenTTL: 1440,
     username: "casey",
     password: "123456",
     portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/groups/crud.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/crud.test.ts
@@ -28,7 +28,6 @@ describe("groups", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/groups/invite-users.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/invite-users.test.ts
@@ -29,7 +29,6 @@ describe("invite-users", () => {
     tokenExpires: TOMORROW,
     refreshToken: "refreshToken",
     refreshTokenExpires: TOMORROW,
-    refreshTokenTTL: 1440,
     username: "casey",
     password: "123456",
     portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/groups/join.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/join.test.ts
@@ -22,7 +22,6 @@ describe("groups", () => {
         tokenExpires: TOMORROW,
         refreshToken: "refreshToken",
         refreshTokenExpires: TOMORROW,
-        refreshTokenTTL: 1440,
         username: "casey",
         password: "123456",
         portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/groups/notification.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/notification.test.ts
@@ -18,7 +18,6 @@ describe("groups", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/groups/protect.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/protect.test.ts
@@ -22,7 +22,6 @@ describe("groups", () => {
         tokenExpires: TOMORROW,
         refreshToken: "refreshToken",
         refreshTokenExpires: TOMORROW,
-        refreshTokenTTL: 1440,
         username: "casey",
         password: "123456",
         portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/groups/remove-users.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/remove-users.test.ts
@@ -28,7 +28,6 @@ describe("remove-users", () => {
     tokenExpires: TOMORROW,
     refreshToken: "refreshToken",
     refreshTokenExpires: TOMORROW,
-    refreshTokenTTL: 1440,
     username: "casey",
     password: "123456",
     portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/items/add.test.ts
+++ b/packages/arcgis-rest-portal/test/items/add.test.ts
@@ -27,7 +27,6 @@ describe("search", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/items/content.test.ts
+++ b/packages/arcgis-rest-portal/test/items/content.test.ts
@@ -19,7 +19,6 @@ describe("getContent", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "moses",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/items/create.test.ts
+++ b/packages/arcgis-rest-portal/test/items/create.test.ts
@@ -29,7 +29,6 @@ describe("search", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/items/export.test.ts
+++ b/packages/arcgis-rest-portal/test/items/export.test.ts
@@ -19,7 +19,6 @@ describe("exportItem", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "moses",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/items/get.test.ts
+++ b/packages/arcgis-rest-portal/test/items/get.test.ts
@@ -265,7 +265,6 @@ describe("get", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/items/protect.test.ts
+++ b/packages/arcgis-rest-portal/test/items/protect.test.ts
@@ -21,7 +21,6 @@ describe("search", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/items/remove.test.ts
+++ b/packages/arcgis-rest-portal/test/items/remove.test.ts
@@ -28,7 +28,6 @@ describe("search", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/items/search.test.ts
+++ b/packages/arcgis-rest-portal/test/items/search.test.ts
@@ -244,7 +244,6 @@ describe("search", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/items/update.test.ts
+++ b/packages/arcgis-rest-portal/test/items/update.test.ts
@@ -33,7 +33,6 @@ describe("search", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/items/upload.test.ts
+++ b/packages/arcgis-rest-portal/test/items/upload.test.ts
@@ -24,7 +24,6 @@ describe("search", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "casey",
       password: "123456",
       portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/mocks/sharing/sharing.ts
+++ b/packages/arcgis-rest-portal/test/mocks/sharing/sharing.ts
@@ -11,7 +11,6 @@ export const MOCK_USER_SESSION = new ArcGISIdentityManager({
   tokenExpires: TOMORROW,
   refreshToken: "refreshToken",
   refreshTokenExpires: TOMORROW,
-  refreshTokenTTL: 1440,
   username: "jsmith",
   password: "123456",
   portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/orgs/notification.test.ts
+++ b/packages/arcgis-rest-portal/test/orgs/notification.test.ts
@@ -25,7 +25,6 @@ describe("create-org-notification", () => {
     tokenExpires: TOMORROW,
     refreshToken: "refreshToken",
     refreshTokenExpires: TOMORROW,
-    refreshTokenTTL: 1440,
     username: "casey",
     password: "123456",
     portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/services/get-unique-service-name.test.ts
+++ b/packages/arcgis-rest-portal/test/services/get-unique-service-name.test.ts
@@ -17,7 +17,6 @@ describe("get-unique-service-name:", () => {
     tokenExpires: TOMORROW,
     refreshToken: "refreshToken",
     refreshTokenExpires: TOMORROW,
-    refreshTokenTTL: 1440,
     username: "casey",
     password: "123456",
     portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-portal/test/services/is-service-name-available.test.ts
+++ b/packages/arcgis-rest-portal/test/services/is-service-name-available.test.ts
@@ -14,7 +14,6 @@ describe("is-service-name-available", () => {
     tokenExpires: TOMORROW,
     refreshToken: "refreshToken",
     refreshTokenExpires: TOMORROW,
-    refreshTokenTTL: 1440,
     username: "casey",
     password: "123456",
     portal: "https://myorg.maps.arcgis.com/sharing/rest"

--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -87,9 +87,9 @@ export interface IOAuth2Options {
   /**
    * The requested validity in minutes for a refresh token/access token. Defaults to 20160 (2 weeks).
    *
-   * When using PKCE or server based OAuth this will control the duration of the refresh token. In this scenario access tokens will always have a 30 minute validity.
+   * When using PKCE or server-based OAuth this will control the duration of the refresh token. In this scenario, access tokens will always have a 30 minute validity.
    *
-   * When using implict auth (`pkce: false`) in {@linkcode ArcGISIdentityManager.beginOAuth2} this controls the duration of the access token and no refresh token will be granted.
+   * When using implicit auth (`pkce: false`) in {@linkcode ArcGISIdentityManager.beginOAuth2}, this controls the duration of the access token and no refresh token will be granted.
    */
   expiration?: number;
 

--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -1456,10 +1456,13 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
    * Refreshes the current `token` and `tokenExpires` with `refreshToken`.
    */
   private refreshWithRefreshToken(requestOptions?: ITokenRequestOptions) {
+    // If our refresh token expires sometime in the next 24 hours then refresh the refresh token
+    const ONE_DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
+
     if (
       this.refreshToken &&
       this.refreshTokenExpires &&
-      this.refreshTokenExpires.getTime() < Date.now()
+      this.refreshTokenExpires.getTime() - ONE_DAY_IN_MILLISECONDS < Date.now()
     ) {
       return this.exchangeRefreshToken(requestOptions);
     }

--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -85,16 +85,13 @@ export interface IOAuth2Options {
   provider?: AuthenticationProvider;
 
   /**
-   * The requested validity in minutes for a token. Defaults to 20160 (two weeks).
+   * The requested validity in minutes for a refresh token/access token. Defaults to 20160 (2 weeks).
+   *
+   * When using PKCE or server based OAuth this will control the duration of the refresh token. In this scenario access tokens will always have a 30 minute validity.
+   *
+   * When using implict auth (`pkce: false`) in {@linkcode ArcGISIdentityManager.beginOAuth2} this controls the duration of the access token and no refresh token will be granted.
    */
   expiration?: number;
-
-  /**
-   * Duration (in minutes) that a token will be valid. Defaults to 20160 (two weeks).
-   *
-   * @deprecated use 'expiration' instead
-   */
-  duration?: number;
 
   /**
    * If `true` will use the PKCE oAuth 2.0 extension spec in to authorize the user and obtain a token. A value of `false` will use the deprecated oAuth 2.0 implicit grant type.
@@ -116,13 +113,6 @@ export interface IOAuth2Options {
    * @browserOnly
    */
   popupWindowFeatures?: string;
-
-  /**
-   * Duration (in minutes) that a refresh token will be valid.
-   *
-   * @nodeOnly
-   */
-  refreshTokenTTL?: number;
 
   /**
    * The locale assumed to render the login page.
@@ -205,11 +195,6 @@ export interface IArcGISIdentityManagerOptions {
    * Duration of requested token validity in minutes. Used when requesting tokens with `username` and `password` or when validating the identity of unknown servers. Defaults to two weeks.
    */
   tokenDuration?: number;
-
-  /**
-   * Duration (in minutes) that a refresh token will be valid.
-   */
-  refreshTokenTTL?: number;
 
   /**
    * An unfederated ArcGIS Server instance known to recognize credentials supplied manually.
@@ -733,10 +718,9 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
     options: IOAuth2Options,
     authorizationCode: string
   ): Promise<ArcGISIdentityManager> {
-    const { portal, clientId, redirectUri, refreshTokenTTL }: IOAuth2Options = {
+    const { portal, clientId, redirectUri }: IOAuth2Options = {
       ...{
-        portal: "https://www.arcgis.com/sharing/rest",
-        refreshTokenTTL: 20160
+        portal: "https://www.arcgis.com/sharing/rest"
       },
       ...options
     };
@@ -755,10 +739,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
         ssl: response.ssl,
         redirectUri,
         refreshToken: response.refreshToken,
-        refreshTokenTTL,
-        refreshTokenExpires: new Date(
-          Date.now() + (refreshTokenTTL - 1) * 60 * 1000
-        ),
+        refreshTokenExpires: response.refreshTokenExpires,
         token: response.token,
         tokenExpires: response.expires,
         username: response.username
@@ -784,7 +765,6 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
       ssl: options.ssl,
       tokenDuration: options.tokenDuration,
       redirectUri: options.redirectUri,
-      refreshTokenTTL: options.refreshTokenTTL,
       server: options.server
     });
   }
@@ -908,11 +888,6 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
   public readonly redirectUri: string;
 
   /**
-   * Duration of new OAuth 2.0 refresh token validity (in minutes).
-   */
-  public readonly refreshTokenTTL: number;
-
-  /**
    * An unfederated ArcGIS Server instance known to recognize credentials supplied manually.
    * ```js
    * {
@@ -985,7 +960,6 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
     this.provider = options.provider || "arcgis";
     this.tokenDuration = options.tokenDuration || 20160;
     this.redirectUri = options.redirectUri;
-    this.refreshTokenTTL = options.refreshTokenTTL || 20160;
     this.server = options.server;
 
     this.federatedServers = {};
@@ -1161,7 +1135,6 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
       ssl: this.ssl,
       tokenDuration: this.tokenDuration,
       redirectUri: this.redirectUri,
-      refreshTokenTTL: this.refreshTokenTTL,
       server: this.server
     };
   }
@@ -1542,9 +1515,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
         this._token = response.token;
         this._tokenExpires = response.expires;
         this._refreshToken = response.refreshToken;
-        this._refreshTokenExpires = new Date(
-          Date.now() + (this.refreshTokenTTL - 1) * 60 * 1000
-        );
+        this._refreshTokenExpires = response.refreshTokenExpires;
         return this;
       }
     );

--- a/packages/arcgis-rest-request/src/fetch-token.ts
+++ b/packages/arcgis-rest-request/src/fetch-token.ts
@@ -45,7 +45,7 @@ export function fetchToken(
       ),
       ssl: response.ssl === true
     };
-    console.log(response);
+
     if (response.refresh_token) {
       r.refreshToken = response.refresh_token;
     }

--- a/packages/arcgis-rest-request/src/fetch-token.ts
+++ b/packages/arcgis-rest-request/src/fetch-token.ts
@@ -45,7 +45,7 @@ export function fetchToken(
       ),
       ssl: response.ssl === true
     };
-
+    console.log(response);
     if (response.refresh_token) {
       r.refreshToken = response.refresh_token;
     }

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -30,7 +30,6 @@ describe("ArcGISIdentityManager", () => {
         tokenExpires: TOMORROW,
         refreshToken: "refreshToken",
         refreshTokenExpires: TOMORROW,
-        refreshTokenTTL: 1440,
         username: "c@sey",
         password: "123456"
       });
@@ -49,7 +48,6 @@ describe("ArcGISIdentityManager", () => {
       expect(session2.username).toEqual("c@sey");
       expect(session2.password).toEqual("123456");
       expect(session2.tokenDuration).toEqual(20160);
-      expect(session2.refreshTokenTTL).toEqual(1440);
     });
 
     it("should serialize to and from JSON with a server", () => {
@@ -72,7 +70,6 @@ describe("ArcGISIdentityManager", () => {
         clientId: "clientId",
         redirectUri: "https://example-app.com/redirect-uri",
         token: "token",
-        refreshTokenTTL: 1440,
         username: "c@sey",
         password: "123456"
       });
@@ -1888,7 +1885,6 @@ describe("ArcGISIdentityManager", () => {
         tokenExpires: TOMORROW,
         refreshToken: "refreshToken",
         refreshTokenExpires: TOMORROW,
-        refreshTokenTTL: 1440,
         username: "jsmith",
         password: "123456"
       });
@@ -2072,7 +2068,6 @@ describe("ArcGISIdentityManager", () => {
         tokenExpires: TOMORROW,
         refreshToken: "refreshToken",
         refreshTokenExpires: TOMORROW,
-        refreshTokenTTL: 1440,
         username: "jsmith",
         password: "123456"
       });
@@ -2114,7 +2109,6 @@ describe("ArcGISIdentityManager", () => {
         tokenExpires: TOMORROW,
         refreshToken: "refreshToken",
         refreshTokenExpires: TOMORROW,
-        refreshTokenTTL: 1440,
         username: "jsmith",
         password: "123456"
       });
@@ -2201,7 +2195,6 @@ describe("ArcGISIdentityManager", () => {
       tokenExpires: TOMORROW,
       refreshToken: "refreshToken",
       refreshTokenExpires: TOMORROW,
-      refreshTokenTTL: 1440,
       username: "jsmith",
       password: "123456"
     });
@@ -2460,7 +2453,6 @@ describe("ArcGISIdentityManager", () => {
         tokenExpires: TOMORROW,
         refreshToken: "refreshToken",
         refreshTokenExpires: TOMORROW,
-        refreshTokenTTL: 1440,
         username: "jsmith",
         password: "123456"
       });
@@ -2504,7 +2496,6 @@ describe("ArcGISIdentityManager", () => {
         tokenExpires: TOMORROW,
         refreshToken: "refreshToken",
         refreshTokenExpires: TOMORROW,
-        refreshTokenTTL: 1440,
         username: "jsmith",
         password: "123456"
       });

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -785,13 +785,13 @@ describe("ArcGISIdentityManager", () => {
         });
     });
 
-    it("should refresh with  an expired refresh token", (done) => {
+    it("should refresh with  a refresh token that it is about to expire", (done) => {
       const session = new ArcGISIdentityManager({
         clientId: "clientId",
         token: "token",
         username: "c@sey",
         refreshToken: "refreshToken",
-        refreshTokenExpires: YESTERDAY,
+        refreshTokenExpires: new Date(Date.now() + 1000 * 60 * 60), // expires in one hour
         redirectUri: "https://example-app.com/redirect-uri"
       });
 
@@ -799,7 +799,8 @@ describe("ArcGISIdentityManager", () => {
         access_token: "newToken",
         expires_in: 60,
         username: " c@sey",
-        refresh_token: "newRefreshToken"
+        refresh_token: "newRefreshToken",
+        refresh_token_expires_in: 1209600
       });
 
       session
@@ -2014,10 +2015,11 @@ describe("ArcGISIdentityManager", () => {
         });
     });
 
-    it("should return a ArcGISIdentityManager where refreshTokenExpires is 2 weeks from now (within 10 ms)", (done) => {
+    it("should return a ArcGISIdentityManager where refreshTokenExpires is 2 weeks from now (within 5 minutes)", (done) => {
       fetchMock.postOnce("https://www.arcgis.com/sharing/rest/oauth2/token", {
         access_token: "token",
         refresh_token: "refreshToken",
+        refresh_token_expires_in: 1209600,
         username: "Casey",
         ssl: true
       });
@@ -2031,13 +2033,13 @@ describe("ArcGISIdentityManager", () => {
       )
         .then((session) => {
           const twoWeeksFromNow = new Date(
-            Date.now() + (20160 - 1) * 60 * 1000
+            Date.now() + (20160 - 1) * 60 * 1000 - 1000 * 60 * 5
           );
           expect(session.refreshTokenExpires.getTime()).toBeGreaterThan(
-            twoWeeksFromNow.getTime() - 10
+            twoWeeksFromNow.getTime() - 1000 * 60 * 10
           );
           expect(session.refreshTokenExpires.getTime()).toBeLessThan(
-            twoWeeksFromNow.getTime() + 10
+            twoWeeksFromNow.getTime() + 1000 * 60 * 10
           );
           done();
         })

--- a/scripts/test-helpers.ts
+++ b/scripts/test-helpers.ts
@@ -9,6 +9,12 @@ export const TOMORROW = (function () {
   return now;
 })();
 
+export const FIVE_DAYS_FROM_NOW = (function () {
+  const now = new Date();
+  now.setDate(now.getDate() + 5);
+  return now;
+})();
+
 export const YESTERDAY = (function () {
   const now = new Date();
   now.setDate(now.getDate() - 1);


### PR DESCRIPTION
This fixes the behavior around refresh token lifespans detailed in https://github.com/Esri/arcgis-rest-js/issues/699 and https://github.com/Esri/arcgis-rest-js/issues/842. In the next version on Online/Enterprise we will actually get a `refresh_token_expires_in` from the server so we can quit guessing at the token lifespan.

This PR totally removes `refreshTokenTTL` in favor of `expiration`. If you get a refresh token from a version of server that doesn't return `refresh_token_expires_in` we will just assume your refresh token is always valid.

If your server doesn't support `refresh_token_expires_in` the best thing to do would be to call the new `.exchangeRefreshToken()` method to update the refresh token every time the app loads. If this method errors then the refresh token is likely invalid. If it does not error the session was extended for 2 more weeks.

To get the absolute most long lived sessions possible you can just call `.exchangeRefreshToken()` every time the app loads to get another refresh token that lasts 2 more weeks. This will only invalidate the session when the user doesn't access the app for 2 weeks OR signs out (`.destroy()`).