### PR TITLE
feat(arcgis-rest-request): add support for AbortSignal

### DIFF
--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -245,6 +245,7 @@ export function internalRequest(
 
   const fetchOptions: RequestInit = {
     method: httpMethod,
+    signal: options.signal,
     /* ensures behavior mimics XMLHttpRequest.
     needed to support sending IWA cookies */
     credentials: options.credentials || "same-origin"

--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -52,6 +52,11 @@ export interface IRequestOptions {
     [key: string]: any;
   };
   /**
+   * An [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) object instance; allows you to abort a request and via an [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+   */
+  signal?: AbortSignal;
+
+  /**
    * Suppress any ArcGIS REST JS related warnings for this request.
    */
   suppressWarnings?: boolean;


### PR DESCRIPTION
IRequestOptions.signal is passed to fetch()

resolves #810 #114