### PR TITLE
fix(arcgis-rest-request): fixes an issue in append custom params where valid params of value 0 do not get passed

### DIFF
--- a/packages/arcgis-rest-portal/test/items/search.test.ts
+++ b/packages/arcgis-rest-portal/test/items/search.test.ts
@@ -82,6 +82,33 @@ describe("search", () => {
       });
   });
 
+  it("should properly handle options for which 0 is a valid value", (done) => {
+    fetchMock.once("*", SearchResponse);
+
+    searchItems({
+      q: "DC AND typekeywords:hubSiteApplication",
+      num: 0,
+      start: 22,
+      sortField: "title",
+      sortOrder: "desc",
+      searchUserAccess: "groupMember",
+      searchUserName: "casey",
+      foo: "bar" // this one should not end up on the url
+    })
+      .then(() => {
+        expect(fetchMock.called()).toEqual(true);
+        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        expect(url).toEqual(
+          "https://www.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication&num=0&start=22&sortField=title&sortOrder=desc&searchUserAccess=groupMember&searchUserName=casey"
+        );
+        expect(options.method).toBe("GET");
+        done();
+      })
+      .catch((e) => {
+        fail(e);
+      });
+  });
+
   it("should pass through other requestOptions at the same time", (done) => {
     fetchMock.once("*", SearchResponse);
 

--- a/packages/arcgis-rest-request/src/utils/append-custom-params.ts
+++ b/packages/arcgis-rest-request/src/utils/append-custom-params.ts
@@ -30,7 +30,11 @@ export function appendCustomParams<T extends IRequestOptions>(
 
   // merge all keys in customOptions into options.params
   options.params = keys.reduce((value, key) => {
-    if (customOptions[key] || typeof customOptions[key] === "boolean") {
+    if (
+      customOptions[key] ||
+      typeof customOptions[key] === "boolean" || 
+      (typeof customOptions[key] === "number" && customOptions[key] as unknown === 0)
+    ) {
       value[key as any] = customOptions[key];
     }
     return value;


### PR DESCRIPTION
AFFECTS PACKAGES:
@esri/arcgis-rest-request

commited via `npm run c`