### PR TITLE
Only throw auth error on code 498/499

### DIFF
--- a/packages/arcgis-rest-portal/test/users/update.test.ts
+++ b/packages/arcgis-rest-portal/test/users/update.test.ts
@@ -139,7 +139,7 @@ describe("updateUser", () => {
         expect(options.body).toContain("f=json");
         expect(options.body).toContain("token=fake-token");
         expect(options.body).toContain(encodeParam("description", "real"));
-        expect(e.name).toBe("ArcGISAuthError");
+        expect(e.name).toBe("ArcGISRequestError");
         expect(e.code).toBe("GWM_0003");
         expect(e.originalMessage).toBe(
           "You do not have permissions to access this resource or perform this operation."

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -503,8 +503,6 @@ export function request(
   return internalRequest(url, requestOptions).catch((e) => {
     if (
       e instanceof ArcGISAuthError &&
-      e.code === 498 &&
-      e.message === "498: Invalid token." &&
       requestOptions.authentication &&
       typeof requestOptions.authentication !== "string" &&
       requestOptions.authentication.canRefresh &&

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -171,12 +171,7 @@ export function checkForErrors(
     const { message, code, messageCode } = response.error;
     const errorCode = messageCode || code || "UNKNOWN_ERROR_CODE";
 
-    if (
-      code === 498 ||
-      code === 499 ||
-      messageCode === "GWM_0003" ||
-      (code === 400 && message === "Unable to generate token.")
-    ) {
+    if (code === 498 || code === 499) {
       if (originalAuthError) {
         throw originalAuthError;
       } else {

--- a/packages/arcgis-rest-request/test/utils/ArcGISAuthError.test.ts
+++ b/packages/arcgis-rest-request/test/utils/ArcGISAuthError.test.ts
@@ -188,7 +188,7 @@ describe("ArcGISRequestError", () => {
           referer: "localhost"
         }
       }).catch((err) => {
-        expect(err.name).toBe(ErrorTypes.ArcGISAuthError);
+        expect(err.name).toBe(ErrorTypes.ArcGISRequestError);
         done();
       });
     });


### PR DESCRIPTION
Thinking through the final auth changes there might be weird case where `ArcGISAuthError` was thrown but it wouldn't really make sense to retry the request. 

This PR changes things so that `ArcGISAuthError` ONLY fires on 498/499 errors which are the only codes the JS API pays attention to.

Then the automatic retry logic only applies on `ArcGISAuthError` and ignores the code.