### PR TITLE
chore: make node-esm demo package private so semrel will ignore it

### DIFF
--- a/demos/node-typescript-es-modules/package.json
+++ b/demos/node-typescript-es-modules/package.json
@@ -1,4 +1,5 @@
 {
+  "private": "true",
   "name": "ts-node-rest",
   "version": "1.0.0",
   "description": "",


### PR DESCRIPTION
In checking semantic release for `main` noticed this package was not private, and thus was being processed.