### PR TITLE
fix: update package versions post v4 launch

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,4 +24,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages # The branch the action should deploy to.
-          folder: docs/build/arcgis-rest-js # The folder the action should deploy.
+          folder: docs/build # The folder the action should deploy.

--- a/demos/ago-node-cli/package.json
+++ b/demos/ago-node-cli/package.json
@@ -17,8 +17,8 @@
     "start": "echo \"CLI - node index.js <search>\" && exit 1"
   },
   "dependencies": {
-    "@esri/arcgis-rest-portal": "beta",
-    "@esri/arcgis-rest-request": "beta",
+    "@esri/arcgis-rest-portal": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0",
     "chalk": "^2.3.0",
     "commander": "^2.12.2",
     "cross-fetch": "^3.0.0",

--- a/demos/attachments-browser/package.json
+++ b/demos/attachments-browser/package.json
@@ -8,8 +8,8 @@
     "start": "node ../../scripts/run-demo-server.js"
   },
   "dependencies": {
-    "@esri/arcgis-rest-feature-service": "beta",
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-feature-service": "^4.0.1",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "author": ""
 }

--- a/demos/attachments-node/package.json
+++ b/demos/attachments-node/package.json
@@ -11,7 +11,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@esri/arcgis-rest-request": "beta",
+    "@esri/arcgis-rest-request": "^4.0.0",
     "fetch-blob": "^3.1.2",
     "mime": "^2.5.2",
     "mime-types": "^2.1.32"

--- a/demos/batch-geocoder-node/package.json
+++ b/demos/batch-geocoder-node/package.json
@@ -18,8 +18,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@esri/arcgis-rest-geocoding": "beta",
-    "@esri/arcgis-rest-request": "beta",
+    "@esri/arcgis-rest-geocoding": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0",
     "papaparse": "^4.6.0"
   },
   "author": "Max Payson (mpayson)",

--- a/demos/browser-es-modules/package.json
+++ b/demos/browser-es-modules/package.json
@@ -8,8 +8,8 @@
     "start": "node ../../scripts/run-demo-server.js"
   },
   "dependencies": {
-    "@esri/arcgis-rest-portal": "beta",
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-portal": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "author": ""
 }

--- a/demos/express-oauth-advanced/app.html
+++ b/demos/express-oauth-advanced/app.html
@@ -11,8 +11,8 @@
   <button id="refreshSession">Refresh Credentials</button>
 
   <script type="module">
-    import { ArcGISIdentityManager } from 'https://cdn.skypack.dev/@esri/arcgis-rest-request@beta';
-    import { getUserContent, searchItems, SearchQueryBuilder } from 'https://cdn.skypack.dev/@esri/arcgis-rest-portal@beta';
+    import { ArcGISIdentityManager } from 'https://cdn.skypack.dev/@esri/arcgis-rest-request@^4.0.0';
+    import { getUserContent, searchItems, SearchQueryBuilder } from 'https://cdn.skypack.dev/@esri/arcgis-rest-portal@^4.0.0';
     
     let session;
 

--- a/demos/express-oauth-advanced/package.json
+++ b/demos/express-oauth-advanced/package.json
@@ -9,7 +9,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@esri/arcgis-rest-request": "beta",
+    "@esri/arcgis-rest-request": "^4.0.0",
     "dotenv": "^16.0.0",
     "express": "^4.16.3",
     "express-session": "^1.17.2",

--- a/demos/express/package.json
+++ b/demos/express/package.json
@@ -8,7 +8,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@esri/arcgis-rest-request": "beta",
+    "@esri/arcgis-rest-request": "^4.0.0",
     "express": "^4.16.3"
   },
   "author": ""

--- a/demos/feature-service-browser/package.json
+++ b/demos/feature-service-browser/package.json
@@ -8,8 +8,8 @@
     "start": "node ../../scripts/run-demo-server.js"
   },
   "dependencies": {
-    "@esri/arcgis-rest-feature-layer": "beta",
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-feature-service": "^4.0.1",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "author": ""
 }

--- a/demos/jsapi-integration/package.json
+++ b/demos/jsapi-integration/package.json
@@ -8,8 +8,8 @@
     "start": "node ../../scripts/run-demo-server.js"
   },
   "dependencies": {
-    "@esri/arcgis-rest-portal": "^3.3.0",
-    "@esri/arcgis-rest-request": "^3.3.0"
+    "@esri/arcgis-rest-portal": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "author": ""
 }

--- a/demos/node-cli-item-management/package.json
+++ b/demos/node-cli-item-management/package.json
@@ -15,8 +15,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@esri/arcgis-rest-portal": "beta",
-    "@esri/arcgis-rest-request": "beta",
+    "@esri/arcgis-rest-portal": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0",
     "chalk": "^2.3.0",
     "prompts": "^2.0.3"
   },

--- a/demos/node-common-js/package.json
+++ b/demos/node-common-js/package.json
@@ -10,7 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "author": ""
 }

--- a/demos/node-es-modules/package.json
+++ b/demos/node-es-modules/package.json
@@ -11,7 +11,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "author": ""
 }

--- a/demos/node-typescript-es-modules/package.json
+++ b/demos/node-typescript-es-modules/package.json
@@ -11,8 +11,8 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@esri/arcgis-rest-portal": "beta",
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-portal": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.7.0",

--- a/demos/oauth2-browser/package.json
+++ b/demos/oauth2-browser/package.json
@@ -8,8 +8,8 @@
     "start": "node ../../scripts/run-demo-server.js"
   },
   "dependencies": {
-    "@esri/arcgis-rest-auth": "beta",
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-auth": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "author": ""
 }

--- a/demos/parcel/package.json
+++ b/demos/parcel/package.json
@@ -10,8 +10,8 @@
     "start": "NODE_PATH=../../ parcel index.html"
   },
   "dependencies": {
-    "@esri/arcgis-rest-portal": "beta",
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-portal": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.5"

--- a/demos/snowpack/package.json
+++ b/demos/snowpack/package.json
@@ -10,8 +10,8 @@
     "start": "snowpack dev"
   },
   "dependencies": {
-    "@esri/arcgis-rest-portal": "beta",
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-portal": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "snowpack": "^3.8.8"

--- a/demos/stream-response-to-file/package.json
+++ b/demos/stream-response-to-file/package.json
@@ -16,8 +16,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@esri/arcgis-rest-feature-layer": "beta",
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-feature-service": "^4.0.1",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "author": "Joshua Tanner",
   "homepage": "https://github.com/Esri/arcgis-rest-js#readme",

--- a/demos/tree-shaking-rollup/package.json
+++ b/demos/tree-shaking-rollup/package.json
@@ -10,7 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^20.0.0",

--- a/demos/tree-shaking-webpack/package.json
+++ b/demos/tree-shaking-webpack/package.json
@@ -11,8 +11,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@esri/arcgis-rest-portal": "beta",
-    "@esri/arcgis-rest-request": "beta"
+    "@esri/arcgis-rest-portal": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",

--- a/demos/vite/package.json
+++ b/demos/vite/package.json
@@ -9,8 +9,8 @@
     "start": "npm run dev"
   },
   "dependencies": {
-    "@esri/arcgis-rest-portal": "^3.3.0",
-    "@esri/arcgis-rest-request": "^3.3.0"
+    "@esri/arcgis-rest-portal": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "vite": "^2.5.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@types/node": "^12.20.4",
         "@typescript-eslint/eslint-plugin": "^4.4.0",
         "@typescript-eslint/parser": "^4.31.0",
+        "browser-sync": "^2.27.9",
         "eslint": "^7.11.0",
         "eslint-config-prettier": "^6.12.0",
         "eslint-import-resolver-typescript": "^2.4.0",
@@ -103,10 +104,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "demos/ago-node-cli/node_modules/commander": {
-      "version": "2.20.3",
-      "license": "MIT"
     },
     "demos/attachments-browser": {
       "name": "attachments",
@@ -2125,14 +2122,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/@commitlint/cli/node_modules/get-stdin": {
@@ -4192,15 +4181,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@lerna/cli/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/@lerna/cli/node_modules/is-fullwidth-code-point": {
@@ -8681,6 +8661,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/@socket.io/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+      "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
+      "dev": true
+    },
     "node_modules/@stroncium/procfs": {
       "version": "1.2.1",
       "dev": true,
@@ -8753,6 +8748,24 @@
         "@types/node": "*",
         "@types/responselike": "*"
       }
+    },
+    "node_modules/@types/component-emitter": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
+      "integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==",
+      "dev": true
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",
@@ -9905,6 +9918,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async-each-series": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+      "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/async-limiter": {
       "version": "1.0.1",
       "dev": true,
@@ -9975,6 +9997,15 @@
       "version": "1.11.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
     },
     "node_modules/babel-loader": {
       "version": "8.2.3",
@@ -10217,6 +10248,12 @@
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
+    },
+    "node_modules/batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+      "dev": true
     },
     "node_modules/batch-geocoder": {
       "resolved": "demos/batch-geocoder-node",
@@ -10651,6 +10688,268 @@
         "resolve": "^1.17.0"
       }
     },
+    "node_modules/browser-sync": {
+      "version": "2.27.9",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.9.tgz",
+      "integrity": "sha512-3zBtggcaZIeU9so4ja9yxk7/CZu9B3DOL6zkxFpzHCHsQmkGBPVXg61jItbeoa+WXgNLnr1sYES/2yQwyEZ2+w==",
+      "dev": true,
+      "dependencies": {
+        "browser-sync-client": "^2.27.9",
+        "browser-sync-ui": "^2.27.9",
+        "bs-recipes": "1.3.4",
+        "bs-snippet-injector": "^2.0.1",
+        "chokidar": "^3.5.1",
+        "connect": "3.6.6",
+        "connect-history-api-fallback": "^1",
+        "dev-ip": "^1.0.1",
+        "easy-extender": "^2.3.4",
+        "eazy-logger": "3.1.0",
+        "etag": "^1.8.1",
+        "fresh": "^0.5.2",
+        "fs-extra": "3.0.1",
+        "http-proxy": "^1.18.1",
+        "immutable": "^3",
+        "localtunnel": "^2.0.1",
+        "micromatch": "^4.0.2",
+        "opn": "5.3.0",
+        "portscanner": "2.1.1",
+        "qs": "6.2.3",
+        "raw-body": "^2.3.2",
+        "resp-modifier": "6.0.2",
+        "rx": "4.1.0",
+        "send": "0.16.2",
+        "serve-index": "1.9.1",
+        "serve-static": "1.13.2",
+        "server-destroy": "1.0.1",
+        "socket.io": "^4.4.1",
+        "ua-parser-js": "1.0.2",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "browser-sync": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/browser-sync-client": {
+      "version": "2.27.9",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.9.tgz",
+      "integrity": "sha512-FHW8kydp7FXo6jnX3gXJCpHAHtWNLK0nx839nnK+boMfMI1n4KZd0+DmTxHBsHsF3OHud4V4jwoN8U5HExMIdQ==",
+      "dev": true,
+      "dependencies": {
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "mitt": "^1.1.3",
+        "rxjs": "^5.5.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/browser-sync-ui": {
+      "version": "2.27.9",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.9.tgz",
+      "integrity": "sha512-rsduR2bRIwFvM8CX6iY/Nu5aWub0WB9zfSYg9Le/RV5N5DEyxJYey0VxdfWCnzDOoelassTDzYQo+r0iJno3qw==",
+      "dev": true,
+      "dependencies": {
+        "async-each-series": "0.1.1",
+        "connect-history-api-fallback": "^1",
+        "immutable": "^3",
+        "server-destroy": "1.0.1",
+        "socket.io-client": "^4.4.1",
+        "stream-throttle": "^0.1.3"
+      }
+    },
+    "node_modules/browser-sync-ui/node_modules/engine.io-client": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.1.1.tgz",
+      "integrity": "sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==",
+      "dev": true,
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.0",
+        "has-cors": "1.1.0",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "ws": "~8.2.3",
+        "xmlhttprequest-ssl": "~2.0.0",
+        "yeast": "0.1.2"
+      }
+    },
+    "node_modules/browser-sync-ui/node_modules/engine.io-parser": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
+      "integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
+      "dev": true,
+      "dependencies": {
+        "@socket.io/base64-arraybuffer": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/browser-sync-ui/node_modules/socket.io-client": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.4.1.tgz",
+      "integrity": "sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==",
+      "dev": true,
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "backo2": "~1.0.2",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.1.1",
+        "parseuri": "0.0.6",
+        "socket.io-parser": "~4.1.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/browser-sync-ui/node_modules/socket.io-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
+      "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
+      "dev": true,
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/browser-sync-ui/node_modules/ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/browser-sync-ui/node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/browser-sync/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/browser-sync/node_modules/engine.io": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.3.tgz",
+      "integrity": "sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/browser-sync/node_modules/engine.io-parser": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
+      "integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
+      "dev": true,
+      "dependencies": {
+        "@socket.io/base64-arraybuffer": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/browser-sync/node_modules/socket.io": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
+      "integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.2",
+        "engine.io": "~6.1.0",
+        "socket.io-adapter": "~2.3.3",
+        "socket.io-parser": "~4.0.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/browser-sync/node_modules/socket.io-adapter": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
+      "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
+      "dev": true
+    },
+    "node_modules/browser-sync/node_modules/socket.io-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+      "dev": true,
+      "dependencies": {
+        "@types/component-emitter": "^1.2.10",
+        "component-emitter": "~1.3.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/browser-sync/node_modules/ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
       "dev": true,
@@ -10757,6 +11056,18 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/bs-recipes": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+      "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
+      "dev": true
+    },
+    "node_modules/bs-snippet-injector": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
+      "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
+      "dev": true
     },
     "node_modules/btoa-lite": {
       "version": "1.0.0",
@@ -11534,6 +11845,67 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/clone": {
       "version": "1.0.4",
       "dev": true,
@@ -11740,6 +12112,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "dev": true,
@@ -11872,6 +12249,45 @@
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
       }
+    },
+    "node_modules/connect": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "parseurl": "~1.3.2",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/connect/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/connect/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -12611,6 +13027,19 @@
       "version": "1.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -13400,6 +13829,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dev-ip": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+      "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
+      "dev": true,
+      "bin": {
+        "dev-ip": "lib/dev-ip.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/dezalgo": {
       "version": "1.0.3",
       "dev": true,
@@ -13447,6 +13888,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -13571,6 +14018,30 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/easy-extender": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
+      "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.10"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/eazy-logger": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.1.0.tgz",
+      "integrity": "sha512-/snsn2JqBtUSSstEl4R0RKjkisGHAhvYj89i7r3ytNUKW12y178KDZwXLXIgwDqLW6E/VRMT9qfld7wvFae8bQ==",
+      "dev": true,
+      "dependencies": {
+        "tfunk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -15530,6 +16001,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
       "dev": true,
@@ -15971,6 +16475,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "dev": true,
@@ -16060,6 +16584,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -17643,6 +18176,15 @@
         "minimatch": "^3.0.4"
       }
     },
+    "node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -18333,6 +18875,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number-like": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.isfinite": "^3.3.2"
       }
     },
     "node_modules/is-number-object": {
@@ -19475,14 +20026,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/karma/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/karma/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "dev": true,
@@ -19792,6 +20335,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
+      "dev": true
+    },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
       "dev": true,
@@ -19837,11 +20386,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/lint-staged/node_modules/commander": {
-      "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lint-staged/node_modules/cosmiconfig": {
       "version": "1.1.0",
@@ -20090,6 +20634,101 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/localtunnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-2.0.2.tgz",
+      "integrity": "sha512-n418Cn5ynvJd7m/N1d9WVJISLJF/ellZnfsLnx8WBWGzxv/ntNcFkJ1o6se5quUhCplfLGBNL5tYHiq5WF3Nug==",
+      "dev": true,
+      "dependencies": {
+        "axios": "0.21.4",
+        "debug": "4.3.2",
+        "openurl": "1.1.1",
+        "yargs": "17.1.1"
+      },
+      "bin": {
+        "lt": "bin/lt.js"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/localtunnel/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/localtunnel/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/localtunnel/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/localtunnel/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/localtunnel/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/localtunnel/node_modules/yargs": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/localtunnel/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/locate-path": {
       "version": "2.0.0",
       "dev": true,
@@ -20147,6 +20786,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/lodash.isfinite": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
+      "dev": true
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -21088,6 +21733,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/mitt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
+      "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
+      "dev": true
+    },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
       "dev": true,
@@ -21493,16 +22144,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/multi-semantic-release/node_modules/cliui": {
-      "version": "7.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "node_modules/multi-semantic-release/node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -21610,14 +22251,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/multi-semantic-release/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/multi-semantic-release/node_modules/get-stream": {
@@ -22131,14 +22764,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/multi-semantic-release/node_modules/y18n": {
-      "version": "5.0.8",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/multi-semantic-release/node_modules/yallist": {
@@ -23103,11 +23728,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/npm-which/node_modules/commander": {
-      "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/@gar/promisify": {
       "version": "1.1.2",
@@ -26119,6 +26739,12 @@
         "opener": "bin/opener-bin.js"
       }
     },
+    "node_modules/openurl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
+      "dev": true
+    },
     "node_modules/opn": {
       "version": "5.3.0",
       "dev": true,
@@ -26667,11 +27293,6 @@
       "engines": {
         "node": ">=0.8"
       }
-    },
-    "node_modules/parcel-bundler/node_modules/commander": {
-      "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/parcel-bundler/node_modules/cross-spawn": {
       "version": "6.0.5",
@@ -27259,6 +27880,26 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/portscanner": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+      "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+      "dev": true,
+      "dependencies": {
+        "async": "1.5.2",
+        "is-number-like": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.0.0"
+      }
+    },
+    "node_modules/portscanner/node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
@@ -28404,6 +29045,15 @@
         "node": ">=0.9"
       }
     },
+    "node_modules/qs": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/query-string": {
       "version": "4.3.4",
       "dev": true,
@@ -28545,6 +29195,79 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/rc": {
@@ -29256,6 +29979,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/resp-modifier": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+      "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.2.0",
+        "minimatch": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/resp-modifier/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/resp-modifier/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
     "node_modules/responselike": {
       "version": "2.0.0",
       "dev": true,
@@ -29438,28 +30189,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
-      "version": "7.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "node_modules/rollup-plugin-visualizer/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -29499,14 +30232,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/y18n": {
-      "version": "5.0.8",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
@@ -29597,6 +30322,12 @@
       "dependencies": {
         "aproba": "^1.1.1"
       }
+    },
+    "node_modules/rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+      "dev": true
     },
     "node_modules/rxjs": {
       "version": "5.5.12",
@@ -29766,17 +30497,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/semantic-release/node_modules/cliui": {
-      "version": "7.0.4",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "node_modules/semantic-release/node_modules/cross-spawn": {
       "version": "7.0.3",
       "dev": true,
@@ -29860,15 +30580,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/semantic-release/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/semantic-release/node_modules/get-stream": {
@@ -32956,15 +33667,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/semantic-release/node_modules/y18n": {
-      "version": "5.0.8",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/semantic-release/node_modules/yallist": {
       "version": "4.0.0",
       "dev": true,
@@ -33136,6 +33838,75 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-index/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/serve-index/node_modules/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/serve-index/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/serve-index/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
+    },
+    "node_modules/serve-index/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.13.2",
       "dev": true,
@@ -33149,6 +33920,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
+      "dev": true
     },
     "node_modules/session-file-store": {
       "version": "1.5.0",
@@ -34744,6 +35521,15 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/stealthy-require": {
       "version": "1.1.1",
       "dev": true,
@@ -34840,6 +35626,22 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stream-throttle": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+      "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.2.0",
+        "limiter": "^1.0.5"
+      },
+      "bin": {
+        "throttleproxy": "bin/throttleproxy.js"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/stream-to-observable": {
       "version": "0.1.0",
@@ -35723,11 +36525,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/terser-webpack-plugin/node_modules/commander": {
-      "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/terser-webpack-plugin/node_modules/find-cache-dir": {
       "version": "2.1.0",
       "dev": true,
@@ -35965,11 +36762,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/terser/node_modules/source-map": {
       "version": "0.7.3",
       "dev": true,
@@ -35990,6 +36782,16 @@
       "version": "0.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tfunk": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-4.0.0.tgz",
+      "integrity": "sha512-eJQ0dGfDIzWNiFNYFVjJ+Ezl/GmwHaFTBTjrtqNPW0S7cuVDBrZrmzUz6VkMeCR4DZFqhd4YtLwsw3i2wYHswQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "dlv": "^1.1.3"
+      }
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -36602,6 +37404,25 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
+      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.4.10",
       "dev": true,
@@ -36711,16 +37532,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/ultra-runner/node_modules/cliui": {
-      "version": "7.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "node_modules/ultra-runner/node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -36754,14 +37565,6 @@
       "version": "8.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ultra-runner/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
     },
     "node_modules/ultra-runner/node_modules/has-flag": {
       "version": "4.0.0",
@@ -36890,14 +37693,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/ultra-runner/node_modules/y18n": {
-      "version": "5.0.8",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ultra-runner/node_modules/yargs": {
       "version": "16.2.0",
       "dev": true,
@@ -36964,11 +37759,6 @@
       "engines": {
         "node": ">=6.0"
       }
-    },
-    "node_modules/uncss/node_modules/commander": {
-      "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/uncss/node_modules/is-absolute-url": {
       "version": "3.0.3",
@@ -37985,14 +38775,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/webpack-cli/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/webpack-cli/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "dev": true,
@@ -38855,6 +39637,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "2.1.2",
       "dev": true,
@@ -38879,6 +39670,83 @@
       "bin": {
         "json2yaml": "bin/json2yaml",
         "yaml2json": "bin/yaml2json"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
+      "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yeast": {
@@ -40111,10 +40979,6 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "dev": true
         },
         "get-stdin": {
           "version": "8.0.0",
@@ -41764,11 +42628,6 @@
           "requires": {
             "locate-path": "^3.0.0"
           }
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "dev": true,
-          "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -44972,6 +45831,18 @@
         }
       }
     },
+    "@socket.io/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==",
+      "dev": true
+    },
+    "@socket.io/component-emitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+      "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
+      "dev": true
+    },
     "@stroncium/procfs": {
       "version": "1.2.1",
       "dev": true
@@ -45024,6 +45895,24 @@
         "@types/node": "*",
         "@types/responselike": "*"
       }
+    },
+    "@types/component-emitter": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
+      "integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==",
+      "dev": true
+    },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
+    "@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+      "dev": true
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -45835,6 +46724,12 @@
       "version": "1.0.3",
       "dev": true
     },
+    "async-each-series": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+      "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
+      "dev": true
+    },
     "async-limiter": {
       "version": "1.0.1",
       "dev": true
@@ -45878,6 +46773,15 @@
     "aws4": {
       "version": "1.11.0",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
     },
     "babel-loader": {
       "version": "8.2.3",
@@ -46044,6 +46948,12 @@
     },
     "base64id": {
       "version": "2.0.0",
+      "dev": true
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "batch-geocoder": {
@@ -46363,6 +47273,208 @@
         "resolve": "^1.17.0"
       }
     },
+    "browser-sync": {
+      "version": "2.27.9",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.9.tgz",
+      "integrity": "sha512-3zBtggcaZIeU9so4ja9yxk7/CZu9B3DOL6zkxFpzHCHsQmkGBPVXg61jItbeoa+WXgNLnr1sYES/2yQwyEZ2+w==",
+      "dev": true,
+      "requires": {
+        "browser-sync-client": "^2.27.9",
+        "browser-sync-ui": "^2.27.9",
+        "bs-recipes": "1.3.4",
+        "bs-snippet-injector": "^2.0.1",
+        "chokidar": "^3.5.1",
+        "connect": "3.6.6",
+        "connect-history-api-fallback": "^1",
+        "dev-ip": "^1.0.1",
+        "easy-extender": "^2.3.4",
+        "eazy-logger": "3.1.0",
+        "etag": "^1.8.1",
+        "fresh": "^0.5.2",
+        "fs-extra": "3.0.1",
+        "http-proxy": "^1.18.1",
+        "immutable": "^3",
+        "localtunnel": "^2.0.1",
+        "micromatch": "^4.0.2",
+        "opn": "5.3.0",
+        "portscanner": "2.1.1",
+        "qs": "6.2.3",
+        "raw-body": "^2.3.2",
+        "resp-modifier": "6.0.2",
+        "rx": "4.1.0",
+        "send": "0.16.2",
+        "serve-index": "1.9.1",
+        "serve-static": "1.13.2",
+        "server-destroy": "1.0.1",
+        "socket.io": "^4.4.1",
+        "ua-parser-js": "1.0.2",
+        "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+          "dev": true
+        },
+        "engine.io": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.3.tgz",
+          "integrity": "sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==",
+          "dev": true,
+          "requires": {
+            "@types/cookie": "^0.4.1",
+            "@types/cors": "^2.8.12",
+            "@types/node": ">=10.0.0",
+            "accepts": "~1.3.4",
+            "base64id": "2.0.0",
+            "cookie": "~0.4.1",
+            "cors": "~2.8.5",
+            "debug": "~4.3.1",
+            "engine.io-parser": "~5.0.3",
+            "ws": "~8.2.3"
+          }
+        },
+        "engine.io-parser": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
+          "integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
+          "dev": true,
+          "requires": {
+            "@socket.io/base64-arraybuffer": "~1.0.2"
+          }
+        },
+        "socket.io": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
+          "integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "base64id": "~2.0.0",
+            "debug": "~4.3.2",
+            "engine.io": "~6.1.0",
+            "socket.io-adapter": "~2.3.3",
+            "socket.io-parser": "~4.0.4"
+          }
+        },
+        "socket.io-adapter": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
+          "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
+          "dev": true
+        },
+        "socket.io-parser": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+          "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+          "dev": true,
+          "requires": {
+            "@types/component-emitter": "^1.2.10",
+            "component-emitter": "~1.3.0",
+            "debug": "~4.3.1"
+          }
+        },
+        "ws": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "browser-sync-client": {
+      "version": "2.27.9",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.9.tgz",
+      "integrity": "sha512-FHW8kydp7FXo6jnX3gXJCpHAHtWNLK0nx839nnK+boMfMI1n4KZd0+DmTxHBsHsF3OHud4V4jwoN8U5HExMIdQ==",
+      "dev": true,
+      "requires": {
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "mitt": "^1.1.3",
+        "rxjs": "^5.5.6"
+      }
+    },
+    "browser-sync-ui": {
+      "version": "2.27.9",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.9.tgz",
+      "integrity": "sha512-rsduR2bRIwFvM8CX6iY/Nu5aWub0WB9zfSYg9Le/RV5N5DEyxJYey0VxdfWCnzDOoelassTDzYQo+r0iJno3qw==",
+      "dev": true,
+      "requires": {
+        "async-each-series": "0.1.1",
+        "connect-history-api-fallback": "^1",
+        "immutable": "^3",
+        "server-destroy": "1.0.1",
+        "socket.io-client": "^4.4.1",
+        "stream-throttle": "^0.1.3"
+      },
+      "dependencies": {
+        "engine.io-client": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.1.1.tgz",
+          "integrity": "sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==",
+          "dev": true,
+          "requires": {
+            "@socket.io/component-emitter": "~3.0.0",
+            "debug": "~4.3.1",
+            "engine.io-parser": "~5.0.0",
+            "has-cors": "1.1.0",
+            "parseqs": "0.0.6",
+            "parseuri": "0.0.6",
+            "ws": "~8.2.3",
+            "xmlhttprequest-ssl": "~2.0.0",
+            "yeast": "0.1.2"
+          }
+        },
+        "engine.io-parser": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
+          "integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
+          "dev": true,
+          "requires": {
+            "@socket.io/base64-arraybuffer": "~1.0.2"
+          }
+        },
+        "socket.io-client": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.4.1.tgz",
+          "integrity": "sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==",
+          "dev": true,
+          "requires": {
+            "@socket.io/component-emitter": "~3.0.0",
+            "backo2": "~1.0.2",
+            "debug": "~4.3.2",
+            "engine.io-client": "~6.1.1",
+            "parseuri": "0.0.6",
+            "socket.io-parser": "~4.1.1"
+          }
+        },
+        "socket.io-parser": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
+          "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
+          "dev": true,
+          "requires": {
+            "@socket.io/component-emitter": "~3.0.0",
+            "debug": "~4.3.1"
+          }
+        },
+        "ws": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+          "dev": true,
+          "requires": {}
+        },
+        "xmlhttprequest-ssl": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+          "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+          "dev": true
+        }
+      }
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "dev": true,
@@ -46451,6 +47563,18 @@
           "dev": true
         }
       }
+    },
+    "bs-recipes": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+      "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
+      "dev": true
+    },
+    "bs-snippet-injector": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
+      "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
+      "dev": true
     },
     "btoa-lite": {
       "version": "1.0.0",
@@ -46961,6 +48085,57 @@
       "dev": true,
       "peer": true
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
     "clone": {
       "version": "1.0.4",
       "dev": true
@@ -47111,6 +48286,11 @@
       "version": "1.2.9",
       "dev": true
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "common-ancestor-path": {
       "version": "1.0.1",
       "dev": true
@@ -47219,6 +48399,41 @@
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
       }
+    },
+    "connect": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "parseurl": "~1.3.2",
+        "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true
     },
     "console-browserify": {
       "version": "1.2.0",
@@ -47771,6 +48986,16 @@
       "version": "1.0.3",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cosmiconfig": {
       "version": "7.0.1",
       "dev": true,
@@ -48310,6 +49535,12 @@
         }
       }
     },
+    "dev-ip": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+      "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
+      "dev": true
+    },
     "dezalgo": {
       "version": "1.0.3",
       "dev": true,
@@ -48347,6 +49578,12 @@
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -48429,6 +49666,24 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "easy-extender": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
+      "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
+    "eazy-logger": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.1.0.tgz",
+      "integrity": "sha512-/snsn2JqBtUSSstEl4R0RKjkisGHAhvYj89i7r3ytNUKW12y178KDZwXLXIgwDqLW6E/VRMT9qfld7wvFae8bQ==",
+      "dev": true,
+      "requires": {
+        "tfunk": "^4.0.0"
       }
     },
     "ecc-jsbn": {
@@ -49757,6 +51012,38 @@
       "dev": true,
       "peer": true
     },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "find-cache-dir": {
       "version": "3.3.2",
       "dev": true,
@@ -50037,6 +51324,28 @@
       "version": "1.3.2",
       "dev": true
     },
+    "fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
+      }
+    },
     "fs-minipass": {
       "version": "2.1.0",
       "dev": true,
@@ -50103,6 +51412,12 @@
     },
     "gensync": {
       "version": "1.0.0-beta.2",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-intrinsic": {
@@ -51181,6 +52496,12 @@
         "minimatch": "^3.0.4"
       }
     },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
+      "dev": true
+    },
     "import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -51621,6 +52942,15 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      }
+    },
+    "is-number-like": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+      "dev": true,
+      "requires": {
+        "lodash.isfinite": "^3.3.2"
       }
     },
     "is-number-object": {
@@ -52247,10 +53577,6 @@
             "path-exists": "^4.0.0"
           }
         },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "dev": true
@@ -52613,6 +53939,12 @@
         "type-check": "~0.4.0"
       }
     },
+    "limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
+      "dev": true
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "dev": true
@@ -52646,10 +53978,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "commander": {
-          "version": "2.20.3",
-          "dev": true
         },
         "cosmiconfig": {
           "version": "1.1.0",
@@ -52833,6 +54161,79 @@
         }
       }
     },
+    "localtunnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-2.0.2.tgz",
+      "integrity": "sha512-n418Cn5ynvJd7m/N1d9WVJISLJF/ellZnfsLnx8WBWGzxv/ntNcFkJ1o6se5quUhCplfLGBNL5tYHiq5WF3Nug==",
+      "dev": true,
+      "requires": {
+        "axios": "0.21.4",
+        "debug": "4.3.2",
+        "openurl": "1.1.1",
+        "yargs": "17.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "yargs": {
+          "version": "17.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+          "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+          "dev": true
+        }
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "dev": true,
@@ -52877,6 +54278,12 @@
       "version": "4.4.2",
       "dev": true,
       "peer": true
+    },
+    "lodash.isfinite": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
+      "dev": true
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -53511,6 +54918,12 @@
         }
       }
     },
+    "mitt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
+      "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
+      "dev": true
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "dev": true,
@@ -53784,15 +55197,6 @@
             "supports-color": "^7.1.0"
           }
         },
-        "cliui": {
-          "version": "7.0.4",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
         "color-convert": {
           "version": "2.0.1",
           "dev": true,
@@ -53864,10 +55268,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "dev": true
         },
         "get-stream": {
           "version": "6.0.1",
@@ -54176,10 +55576,6 @@
             "isexe": "^2.0.0"
           }
         },
-        "y18n": {
-          "version": "5.0.8",
-          "dev": true
-        },
         "yallist": {
           "version": "4.0.0",
           "dev": true
@@ -54359,9 +55755,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "commander": {
-          "version": "2.20.3"
         }
       }
     },
@@ -56871,12 +58264,6 @@
         "commander": "^2.9.0",
         "npm-path": "^2.0.2",
         "which": "^1.2.10"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "dev": true
-        }
       }
     },
     "npmlog": {
@@ -57040,6 +58427,12 @@
     },
     "opener": {
       "version": "1.5.2",
+      "dev": true
+    },
+    "openurl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
       "dev": true
     },
     "opn": {
@@ -57425,10 +58818,6 @@
         },
         "clone": {
           "version": "2.1.2",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.20.3",
           "dev": true
         },
         "cross-spawn": {
@@ -57829,6 +59218,24 @@
     "pn": {
       "version": "1.1.0",
       "dev": true
+    },
+    "portscanner": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+      "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "is-number-like": "^1.0.3"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -58680,6 +60087,12 @@
       "version": "1.2.0",
       "dev": true
     },
+    "qs": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+      "dev": true
+    },
     "query-string": {
       "version": "4.3.4",
       "dev": true,
@@ -58775,6 +60188,63 @@
     },
     "range-parser": {
       "version": "1.2.1"
+    },
+    "raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+          "dev": true
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+          "dev": true,
+          "requires": {
+            "depd": "2.0.0",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "dev": true
+        },
+        "toidentifier": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+          "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+          "dev": true
+        }
+      }
     },
     "rc": {
       "version": "1.2.8",
@@ -59285,6 +60755,33 @@
       "version": "0.2.1",
       "dev": true
     },
+    "resp-modifier": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+      "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "minimatch": "^3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "responselike": {
       "version": "2.0.0",
       "dev": true,
@@ -59411,21 +60908,8 @@
           "version": "5.0.1",
           "dev": true
         },
-        "cliui": {
-          "version": "7.0.4",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
         "emoji-regex": {
           "version": "8.0.0",
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -59451,10 +60935,6 @@
           "requires": {
             "ansi-regex": "^5.0.1"
           }
-        },
-        "y18n": {
-          "version": "5.0.8",
-          "dev": true
         },
         "yargs": {
           "version": "16.2.0",
@@ -59506,6 +60986,12 @@
       "requires": {
         "aproba": "^1.1.1"
       }
+    },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+      "dev": true
     },
     "rxjs": {
       "version": "5.5.12",
@@ -59616,16 +61102,6 @@
           "dev": true,
           "peer": true
         },
-        "cliui": {
-          "version": "7.0.4",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
         "cross-spawn": {
           "version": "7.0.3",
           "dev": true,
@@ -59683,11 +61159,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "dev": true,
-          "peer": true
         },
         "get-stream": {
           "version": "6.0.1",
@@ -61878,11 +63349,6 @@
             "isexe": "^2.0.0"
           }
         },
-        "y18n": {
-          "version": "5.0.8",
-          "dev": true,
-          "peer": true
-        },
         "yallist": {
           "version": "4.0.0",
           "dev": true,
@@ -62006,6 +63472,68 @@
       "version": "3.1.1",
       "dev": true
     },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "dev": true
+        }
+      }
+    },
     "serve-static": {
       "version": "1.13.2",
       "dev": true,
@@ -62015,6 +63543,12 @@
         "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
+    },
+    "server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
+      "dev": true
     },
     "session-file-store": {
       "version": "1.5.0",
@@ -63096,6 +64630,12 @@
         }
       }
     },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true
+    },
     "stealthy-require": {
       "version": "1.1.1",
       "dev": true
@@ -63179,6 +64719,16 @@
     "stream-shift": {
       "version": "1.0.1",
       "dev": true
+    },
+    "stream-throttle": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+      "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.2.0",
+        "limiter": "^1.0.5"
+      }
     },
     "stream-to-observable": {
       "version": "0.1.0",
@@ -63725,10 +65275,6 @@
         "source-map-support": "~0.5.19"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "dev": true
-        },
         "source-map": {
           "version": "0.7.3",
           "dev": true
@@ -63773,10 +65319,6 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.20.3",
           "dev": true
         },
         "find-cache-dir": {
@@ -63953,6 +65495,16 @@
     "text-table": {
       "version": "0.2.0",
       "dev": true
+    },
+    "tfunk": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-4.0.0.tgz",
+      "integrity": "sha512-eJQ0dGfDIzWNiFNYFVjJ+Ezl/GmwHaFTBTjrtqNPW0S7cuVDBrZrmzUz6VkMeCR4DZFqhd4YtLwsw3i2wYHswQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "dlv": "^1.1.3"
+      }
     },
     "thenify": {
       "version": "3.3.1",
@@ -64355,6 +65907,12 @@
       "version": "4.4.2",
       "dev": true
     },
+    "ua-parser-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
+      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.4.10",
       "dev": true,
@@ -64425,15 +65983,6 @@
             "supports-color": "^7.1.0"
           }
         },
-        "cliui": {
-          "version": "7.0.4",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
         "color-convert": {
           "version": "2.0.1",
           "dev": true,
@@ -64456,10 +66005,6 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
           "dev": true
         },
         "has-flag": {
@@ -64534,10 +66079,6 @@
             "isexe": "^2.0.0"
           }
         },
-        "y18n": {
-          "version": "5.0.8",
-          "dev": true
-        },
         "yargs": {
           "version": "16.2.0",
           "dev": true,
@@ -64587,10 +66128,6 @@
         "request": "^2.88.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "dev": true
-        },
         "is-absolute-url": {
           "version": "3.0.3",
           "dev": true
@@ -65386,10 +66923,6 @@
             "locate-path": "^3.0.0"
           }
         },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "dev": true
@@ -65890,6 +67423,12 @@
       "version": "4.0.2",
       "dev": true
     },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
     "yallist": {
       "version": "2.1.2",
       "dev": true
@@ -65905,6 +67444,67 @@
         "argparse": "^1.0.7",
         "glob": "^7.0.5"
       }
+    },
+    "yargs": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
+      "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "dev": true
     },
     "yeast": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,8 +80,8 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "chalk": "^2.3.0",
         "commander": "^2.12.2",
         "cross-fetch": "^3.0.0",
@@ -90,33 +90,6 @@
       },
       "bin": {
         "ago": "ago.js"
-      }
-    },
-    "demos/ago-node-cli/node_modules/@esri/arcgis-rest-portal": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-      "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.4"
-      }
-    },
-    "demos/ago-node-cli/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-      "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "demos/ago-node-cli/node_modules/chalk": {
@@ -140,50 +113,8 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-feature-service": "beta",
-        "@esri/arcgis-rest-request": "beta"
-      }
-    },
-    "demos/attachments-browser/node_modules/@esri/arcgis-rest-feature-service": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-4.0.0-beta.3.tgz",
-      "integrity": "sha512-mtR0MXqftNZa2Y0Aa9dN5ve/fZVNzOJjsxNSYhvtp6+dT/vIfdg4yxn9zDl8Na6wLx1WREnFR0fzuZviYRL3Yg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-portal": "4.0.0-beta.3",
-        "@esri/arcgis-rest-request": "4.0.0-beta.3"
-      }
-    },
-    "demos/attachments-browser/node_modules/@esri/arcgis-rest-portal": {
-      "version": "4.0.0-beta.3",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.3"
-      }
-    },
-    "demos/attachments-browser/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
-      "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
+        "@esri/arcgis-rest-feature-service": "^4.0.1",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "demos/attachments-node": {
@@ -191,23 +122,10 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "fetch-blob": "^3.1.2",
         "mime": "^2.5.2",
         "mime-types": "^2.1.32"
-      }
-    },
-    "demos/attachments-node/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-      "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "demos/attachments-node/node_modules/mime": {
@@ -225,38 +143,9 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-geocoding": "beta",
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-geocoding": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "papaparse": "^4.6.0"
-      }
-    },
-    "demos/batch-geocoder-node/node_modules/@esri/arcgis-rest-geocoding": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-geocoding/-/arcgis-rest-geocoding-4.0.0-beta.3.tgz",
-      "integrity": "sha512-MWYclWSTkOdXDPstbeCIpFujnAx04+5BaPMcpdcipZWAB6Eqgt4VgnO298rffKhlFK/J+U3dlba2LmTfaDrMEQ==",
-      "dependencies": {
-        "@terraformer/arcgis": "^2.0.7",
-        "@types/terraformer__arcgis": "^2.0.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.3"
-      }
-    },
-    "demos/batch-geocoder-node/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
-      "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "demos/browser-es-modules": {
@@ -264,35 +153,8 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta"
-      }
-    },
-    "demos/browser-es-modules/node_modules/@esri/arcgis-rest-portal": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-      "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.4"
-      }
-    },
-    "demos/browser-es-modules/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-      "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "demos/express": {
@@ -300,7 +162,7 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "express": "^4.16.3"
       }
     },
@@ -309,24 +171,11 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "dotenv": "^16.0.0",
         "express": "^4.16.3",
         "express-session": "^1.17.2",
         "session-file-store": "^1.5.0"
-      }
-    },
-    "demos/express-oauth-advanced/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-      "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "demos/express-oauth-advanced/node_modules/dotenv": {
@@ -336,71 +185,13 @@
         "node": ">=12"
       }
     },
-    "demos/express/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-      "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "demos/feature-service-browser": {
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-feature-layer": "beta",
-        "@esri/arcgis-rest-request": "beta"
+        "@esri/arcgis-rest-feature-service": "^4.0.1",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
-    },
-    "demos/feature-service-browser/node_modules/@esri/arcgis-rest-auth": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.25.0.tgz",
-      "integrity": "sha512-fJHbusenCtna0vZUcqX2L0a3KAKOrXIQJE++qRFK8IaVfIjx2KWgkOfgiAgW4kUkRsF1lq15pXEXVRo5LyD43Q==",
-      "peer": true,
-      "dependencies": {
-        "@esri/arcgis-rest-types": "^2.25.0",
-        "tslib": "^1.13.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "^2.23.0"
-      }
-    },
-    "demos/feature-service-browser/node_modules/@esri/arcgis-rest-auth/node_modules/@esri/arcgis-rest-types": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.25.0.tgz",
-      "integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg==",
-      "peer": true
-    },
-    "demos/feature-service-browser/node_modules/@esri/arcgis-rest-feature-layer": {
-      "version": "3.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.0-beta.0.tgz",
-      "integrity": "sha512-PxUPZmZfm0xQmnVsgA6v2YCvenf4RVuTNd8netxIuYDeT8tcoyaBmgncHG5NPnRoaqV8LBRfrPspAPylFrduoA==",
-      "dependencies": {
-        "@esri/arcgis-rest-types": "^3.0.0-beta.0",
-        "tslib": "^1.13.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-auth": "^2.0.0",
-        "@esri/arcgis-rest-request": "^2.0.0"
-      }
-    },
-    "demos/feature-service-browser/node_modules/@esri/arcgis-rest-request": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.25.0.tgz",
-      "integrity": "sha512-4KYl+Ene7kwZg/M2ABneZizcWVoQkxDvyB9f6zrcKQ2uYjCj1kEl2OTBFmDhT7HFtBm/8cdLi79p/3kDGtSsqQ==",
-      "dependencies": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "demos/feature-service-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "demos/geocoder-browser": {
       "name": "@esri/arcgis-rest-geocoder-vanilla",
@@ -445,81 +236,19 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-portal": "^3.3.0",
-        "@esri/arcgis-rest-request": "^3.3.0"
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
-    },
-    "demos/jsapi-integration/node_modules/@esri/arcgis-rest-auth": {
-      "version": "3.4.3",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@esri/arcgis-rest-types": "^3.4.3",
-        "tslib": "^1.13.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "^3.0.0"
-      }
-    },
-    "demos/jsapi-integration/node_modules/@esri/arcgis-rest-portal": {
-      "version": "3.4.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@esri/arcgis-rest-types": "^3.4.3",
-        "tslib": "^1.13.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-auth": "^3.0.0",
-        "@esri/arcgis-rest-request": "^3.0.0"
-      }
-    },
-    "demos/jsapi-integration/node_modules/@esri/arcgis-rest-request": {
-      "version": "3.4.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "demos/jsapi-integration/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
     },
     "demos/node-cli-item-management": {
       "name": "cli-item-management",
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "chalk": "^2.3.0",
         "prompts": "^2.0.3"
-      }
-    },
-    "demos/node-cli-item-management/node_modules/@esri/arcgis-rest-portal": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-      "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.4"
-      }
-    },
-    "demos/node-cli-item-management/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-      "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "demos/node-cli-item-management/node_modules/chalk": {
@@ -539,20 +268,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "beta"
-      }
-    },
-    "demos/node-common-js/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-      "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "demos/node-es-modules": {
@@ -560,20 +276,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "beta"
-      }
-    },
-    "demos/node-es-modules/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-      "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "demos/node-typescript-es-modules": {
@@ -581,39 +284,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta"
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "devDependencies": {
         "ts-node": "^10.7.0",
         "typescript": "^4.6.2"
-      }
-    },
-    "demos/node-typescript-es-modules/node_modules/@esri/arcgis-rest-portal": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-      "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.4"
-      }
-    },
-    "demos/node-typescript-es-modules/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-      "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "demos/node-typescript-es-modules/node_modules/typescript": {
@@ -633,46 +309,8 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-auth": "beta",
-        "@esri/arcgis-rest-request": "beta"
-      }
-    },
-    "demos/oauth2-browser/node_modules/@esri/arcgis-rest-auth": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-4.0.0-beta.3.tgz",
-      "integrity": "sha512-l0QLYmj28FiPdLI60+mRYLitTJ9hskjhrATOuQRRzGw+KEo0ezMMQRv7XE52ijHmYsr9vYCj4gb3oEuVIakU9g==",
-      "dependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.3",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "demos/oauth2-browser/node_modules/@esri/arcgis-rest-auth/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
-      "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "demos/oauth2-browser/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-      "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
+        "@esri/arcgis-rest-auth": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "demos/parcel": {
@@ -680,38 +318,11 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta"
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "devDependencies": {
         "parcel-bundler": "^1.12.5"
-      }
-    },
-    "demos/parcel/node_modules/@esri/arcgis-rest-portal": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-      "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.4"
-      }
-    },
-    "demos/parcel/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-      "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "demos/snowpack": {
@@ -719,99 +330,27 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta"
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "devDependencies": {
         "snowpack": "^3.8.8"
-      }
-    },
-    "demos/snowpack/node_modules/@esri/arcgis-rest-portal": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-      "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.4"
-      }
-    },
-    "demos/snowpack/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-      "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "demos/stream-response-to-file": {
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-feature-layer": "beta",
-        "@esri/arcgis-rest-request": "beta"
+        "@esri/arcgis-rest-feature-service": "^4.0.1",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
-    },
-    "demos/stream-response-to-file/node_modules/@esri/arcgis-rest-auth": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.25.0.tgz",
-      "integrity": "sha512-fJHbusenCtna0vZUcqX2L0a3KAKOrXIQJE++qRFK8IaVfIjx2KWgkOfgiAgW4kUkRsF1lq15pXEXVRo5LyD43Q==",
-      "peer": true,
-      "dependencies": {
-        "@esri/arcgis-rest-types": "^2.25.0",
-        "tslib": "^1.13.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "^2.23.0"
-      }
-    },
-    "demos/stream-response-to-file/node_modules/@esri/arcgis-rest-auth/node_modules/@esri/arcgis-rest-types": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.25.0.tgz",
-      "integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg==",
-      "peer": true
-    },
-    "demos/stream-response-to-file/node_modules/@esri/arcgis-rest-feature-layer": {
-      "version": "3.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.0-beta.0.tgz",
-      "integrity": "sha512-PxUPZmZfm0xQmnVsgA6v2YCvenf4RVuTNd8netxIuYDeT8tcoyaBmgncHG5NPnRoaqV8LBRfrPspAPylFrduoA==",
-      "dependencies": {
-        "@esri/arcgis-rest-types": "^3.0.0-beta.0",
-        "tslib": "^1.13.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-auth": "^2.0.0",
-        "@esri/arcgis-rest-request": "^2.0.0"
-      }
-    },
-    "demos/stream-response-to-file/node_modules/@esri/arcgis-rest-request": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.25.0.tgz",
-      "integrity": "sha512-4KYl+Ene7kwZg/M2ABneZizcWVoQkxDvyB9f6zrcKQ2uYjCj1kEl2OTBFmDhT7HFtBm/8cdLi79p/3kDGtSsqQ==",
-      "dependencies": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "demos/stream-response-to-file/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "demos/tree-shaking-rollup": {
       "name": "@esri/arcgis-rest-tree-shaking-rollup",
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "beta"
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^20.0.0",
@@ -820,26 +359,13 @@
         "rollup-plugin-visualizer": "^5.5.2"
       }
     },
-    "demos/tree-shaking-rollup/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-      "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "demos/tree-shaking-webpack": {
       "name": "@esri/arcgis-rest-tree-shaking-webpack",
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta"
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.3.4",
@@ -850,78 +376,16 @@
         "webpack-cli": "^3.3.0"
       }
     },
-    "demos/tree-shaking-webpack/node_modules/@esri/arcgis-rest-portal": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-      "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0-beta.4"
-      }
-    },
-    "demos/tree-shaking-webpack/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-      "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-        "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "demos/vite": {
       "name": "arcgis-rest-js-vite",
       "version": "0.0.0",
       "dependencies": {
-        "@esri/arcgis-rest-portal": "^3.3.0",
-        "@esri/arcgis-rest-request": "^3.3.0"
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "devDependencies": {
         "vite": "^2.5.4"
       }
-    },
-    "demos/vite/node_modules/@esri/arcgis-rest-auth": {
-      "version": "3.4.3",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@esri/arcgis-rest-types": "^3.4.3",
-        "tslib": "^1.13.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-request": "^3.0.0"
-      }
-    },
-    "demos/vite/node_modules/@esri/arcgis-rest-portal": {
-      "version": "3.4.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@esri/arcgis-rest-types": "^3.4.3",
-        "tslib": "^1.13.0"
-      },
-      "peerDependencies": {
-        "@esri/arcgis-rest-auth": "^3.0.0",
-        "@esri/arcgis-rest-request": "^3.0.0"
-      }
-    },
-    "demos/vite/node_modules/@esri/arcgis-rest-request": {
-      "version": "3.4.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "demos/vite/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
     },
     "demos/vue": {
       "name": "@esri/arcgis-rest-demo-vue-with-popup",
@@ -3516,10 +2980,6 @@
     "node_modules/@esri/arcgis-rest-tree-shaking-webpack": {
       "resolved": "demos/tree-shaking-webpack",
       "link": true
-    },
-    "node_modules/@esri/arcgis-rest-types": {
-      "version": "3.4.3",
-      "license": "Apache-2.0"
     },
     "node_modules/@esri/jsapi-integration": {
       "resolved": "demos/jsapi-integration",
@@ -39450,7 +38910,7 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -39465,32 +38925,32 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0"
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0"
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "packages/arcgis-rest-feature-service": {
       "name": "@esri/arcgis-rest-feature-service",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-portal": "4.0.0",
-        "@esri/arcgis-rest-request": "4.0.0"
+        "@esri/arcgis-rest-portal": "^4.0.1",
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@esri/arcgis-rest-portal": "4.0.0",
-        "@esri/arcgis-rest-request": "4.0.0"
+        "@esri/arcgis-rest-portal": "^4.0.1",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "packages/arcgis-rest-fetch": {
@@ -39535,30 +38995,30 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0"
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0"
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "packages/arcgis-rest-portal": {
       "name": "@esri/arcgis-rest-portal",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0"
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0"
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "packages/arcgis-rest-request": {
@@ -39566,8 +39026,8 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0",
-        "@esri/arcgis-rest-form-data": "4.0.0",
+        "@esri/arcgis-rest-fetch": "^4.0.0",
+        "@esri/arcgis-rest-form-data": "^4.0.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -39584,13 +39044,13 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0"
+        "@esri/arcgis-rest-request": "^4.0.0"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@esri/arcgis-rest-request": "4.0.0"
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     }
   },
@@ -41145,76 +40605,34 @@
     "@esri/arcgis-rest-auth": {
       "version": "file:packages/arcgis-rest-auth",
       "requires": {
-        "@esri/arcgis-rest-request": "4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "tslib": "^2.3.0"
       }
     },
     "@esri/arcgis-rest-demo-browser-es-modules": {
       "version": "file:demos/browser-es-modules",
       "requires": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-portal": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-          "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-          "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "@esri/arcgis-rest-demo-express": {
       "version": "file:demos/express",
       "requires": {
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "express": "^4.16.3"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.5",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-          "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@esri/arcgis-rest-demo-express-oauth-advanced": {
       "version": "file:demos/express-oauth-advanced",
       "requires": {
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "dotenv": "^16.0.0",
         "express": "^4.16.3",
         "express-session": "^1.17.2",
         "session-file-store": "^1.5.0"
       },
       "dependencies": {
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.5",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-          "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        },
         "dotenv": {
           "version": "16.0.0"
         }
@@ -41223,111 +40641,38 @@
     "@esri/arcgis-rest-demo-parcel": {
       "version": "file:demos/parcel",
       "requires": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "parcel-bundler": "^1.12.5"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-portal": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-          "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-          "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@esri/arcgis-rest-demo-snowpack": {
       "version": "file:demos/snowpack",
       "requires": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "snowpack": "^3.8.8"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-portal": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-          "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-          "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@esri/arcgis-rest-demo-vanilla": {
       "version": "file:demos/oauth2-browser",
       "requires": {
-        "@esri/arcgis-rest-auth": "beta",
-        "@esri/arcgis-rest-request": "beta"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-auth": {
-          "version": "4.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-4.0.0-beta.3.tgz",
-          "integrity": "sha512-l0QLYmj28FiPdLI60+mRYLitTJ9hskjhrATOuQRRzGw+KEo0ezMMQRv7XE52ijHmYsr9vYCj4gb3oEuVIakU9g==",
-          "requires": {
-            "@esri/arcgis-rest-request": "4.0.0-beta.3",
-            "tslib": "^2.3.0"
-          },
-          "dependencies": {
-            "@esri/arcgis-rest-request": {
-              "version": "4.0.0-beta.3",
-              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
-              "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
-              "requires": {
-                "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-                "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-                "tslib": "^2.3.1"
-              }
-            }
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.5",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-          "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@esri/arcgis-rest-auth": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "@esri/arcgis-rest-demographics": {
       "version": "file:packages/arcgis-rest-demographics",
       "requires": {
-        "@esri/arcgis-rest-request": "4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "tslib": "^2.3.0"
       }
     },
     "@esri/arcgis-rest-feature-service": {
       "version": "file:packages/arcgis-rest-feature-service",
       "requires": {
-        "@esri/arcgis-rest-portal": "4.0.0",
-        "@esri/arcgis-rest-request": "4.0.0",
+        "@esri/arcgis-rest-portal": "^4.0.1",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "tslib": "^2.3.0"
       }
     },
@@ -41385,7 +40730,7 @@
     "@esri/arcgis-rest-geocoding": {
       "version": "file:packages/arcgis-rest-geocoding",
       "requires": {
-        "@esri/arcgis-rest-request": "4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "@terraformer/arcgis": "^2.0.7",
         "@types/terraformer__arcgis": "^2.0.0",
         "tslib": "^2.3.0"
@@ -41394,22 +40739,22 @@
     "@esri/arcgis-rest-portal": {
       "version": "file:packages/arcgis-rest-portal",
       "requires": {
-        "@esri/arcgis-rest-request": "4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "tslib": "^2.3.0"
       }
     },
     "@esri/arcgis-rest-request": {
       "version": "file:packages/arcgis-rest-request",
       "requires": {
-        "@esri/arcgis-rest-fetch": "4.0.0",
-        "@esri/arcgis-rest-form-data": "4.0.0",
+        "@esri/arcgis-rest-fetch": "^4.0.0",
+        "@esri/arcgis-rest-form-data": "^4.0.0",
         "tslib": "^2.3.1"
       }
     },
     "@esri/arcgis-rest-routing": {
       "version": "file:packages/arcgis-rest-routing",
       "requires": {
-        "@esri/arcgis-rest-request": "4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "@terraformer/arcgis": "^2.0.7",
         "@types/terraformer__arcgis": "^2.0.0",
         "tslib": "^2.3.0"
@@ -41418,23 +40763,11 @@
     "@esri/arcgis-rest-tree-shaking-rollup": {
       "version": "file:demos/tree-shaking-rollup",
       "requires": {
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "@rollup/plugin-commonjs": "^20.0.0",
         "@rollup/plugin-node-resolve": "^13.0.4",
         "rollup": "^2.56.3",
         "rollup-plugin-visualizer": "^5.5.2"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.5",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-          "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@esri/arcgis-rest-tree-shaking-webpack": {
@@ -41442,68 +40775,19 @@
       "requires": {
         "@babel/core": "^7.3.4",
         "@babel/preset-env": "^7.3.4",
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "babel-loader": "^8.0.5",
         "webpack": "^4.29.6",
         "webpack-bundle-analyzer": "^4.4.2",
         "webpack-cli": "^3.3.0"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-portal": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-          "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-          "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
       }
-    },
-    "@esri/arcgis-rest-types": {
-      "version": "3.4.3"
     },
     "@esri/jsapi-integration": {
       "version": "file:demos/jsapi-integration",
       "requires": {
-        "@esri/arcgis-rest-portal": "^3.3.0",
-        "@esri/arcgis-rest-request": "^3.3.0"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-auth": {
-          "version": "3.4.3",
-          "peer": true,
-          "requires": {
-            "@esri/arcgis-rest-types": "^3.4.3",
-            "tslib": "^1.13.0"
-          }
-        },
-        "@esri/arcgis-rest-portal": {
-          "version": "3.4.3",
-          "requires": {
-            "@esri/arcgis-rest-types": "^3.4.3",
-            "tslib": "^1.13.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "3.4.3",
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1"
-        }
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "@evocateur/libnpmaccess": {
@@ -46367,22 +45651,12 @@
     "arcgis-rest-js-node-attachments-test": {
       "version": "file:demos/attachments-node",
       "requires": {
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "fetch-blob": "^3.1.2",
         "mime": "^2.5.2",
         "mime-types": "^2.1.32"
       },
       "dependencies": {
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.5",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-          "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        },
         "mime": {
           "version": "2.5.2"
         }
@@ -46391,71 +45665,21 @@
     "arcgis-rest-js-node-common-js-integration-test": {
       "version": "file:demos/node-common-js",
       "requires": {
-        "@esri/arcgis-rest-request": "beta"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.5",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-          "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "arcgis-rest-js-node-es-modules-integration-test": {
       "version": "file:demos/node-es-modules",
       "requires": {
-        "@esri/arcgis-rest-request": "beta"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.5",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.5.tgz",
-          "integrity": "sha512-IAo5umFzZkYw18xIbgIKY75yqk5lch5T6rrBSwPFxORHi6lJgbwdMyRzX/9Alh74MF7gvwYzsnAmtXwakrqdbw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "arcgis-rest-js-vite": {
       "version": "file:demos/vite",
       "requires": {
-        "@esri/arcgis-rest-portal": "^3.3.0",
-        "@esri/arcgis-rest-request": "^3.3.0",
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "vite": "^2.5.4"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-auth": {
-          "version": "3.4.3",
-          "peer": true,
-          "requires": {
-            "@esri/arcgis-rest-types": "^3.4.3",
-            "tslib": "^1.13.0"
-          }
-        },
-        "@esri/arcgis-rest-portal": {
-          "version": "3.4.3",
-          "requires": {
-            "@esri/arcgis-rest-types": "^3.4.3",
-            "tslib": "^1.13.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "3.4.3",
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1"
-        }
       }
     },
     "are-we-there-yet": {
@@ -46635,35 +45859,8 @@
     "attachments": {
       "version": "file:demos/attachments-browser",
       "requires": {
-        "@esri/arcgis-rest-feature-service": "beta",
-        "@esri/arcgis-rest-request": "beta"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-feature-service": {
-          "version": "4.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-4.0.0-beta.3.tgz",
-          "integrity": "sha512-mtR0MXqftNZa2Y0Aa9dN5ve/fZVNzOJjsxNSYhvtp6+dT/vIfdg4yxn9zDl8Na6wLx1WREnFR0fzuZviYRL3Yg==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@esri/arcgis-rest-portal": {
-          "version": "4.0.0-beta.3",
-          "peer": true,
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
-          "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@esri/arcgis-rest-feature-service": "^4.0.1",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "author-regex": {
@@ -46852,31 +46049,9 @@
     "batch-geocoder": {
       "version": "file:demos/batch-geocoder-node",
       "requires": {
-        "@esri/arcgis-rest-geocoding": "beta",
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-geocoding": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "papaparse": "^4.6.0"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-geocoding": {
-          "version": "4.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-geocoding/-/arcgis-rest-geocoding-4.0.0-beta.3.tgz",
-          "integrity": "sha512-MWYclWSTkOdXDPstbeCIpFujnAx04+5BaPMcpdcipZWAB6Eqgt4VgnO298rffKhlFK/J+U3dlba2LmTfaDrMEQ==",
-          "requires": {
-            "@terraformer/arcgis": "^2.0.7",
-            "@types/terraformer__arcgis": "^2.0.0",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.3.tgz",
-          "integrity": "sha512-NNqeFWlb1h1Nuc4YrS0Cf2b92IvnQJsZF7mgqhjHcQAv8BYrvqO0AuopNRq6l5fBkcrLRI4NnPzCJeseCR58xQ==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "bcrypt-pbkdf": {
@@ -47715,30 +46890,12 @@
     "cli-item-management": {
       "version": "file:demos/node-cli-item-management",
       "requires": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "chalk": "^2.3.0",
         "prompts": "^2.0.3"
       },
       "dependencies": {
-        "@esri/arcgis-rest-portal": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-          "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-          "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        },
         "chalk": {
           "version": "2.4.2",
           "requires": {
@@ -50508,50 +49665,8 @@
     "feature-service-browser": {
       "version": "file:demos/feature-service-browser",
       "requires": {
-        "@esri/arcgis-rest-feature-layer": "beta",
-        "@esri/arcgis-rest-request": "beta"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-auth": {
-          "version": "2.25.0",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.25.0.tgz",
-          "integrity": "sha512-fJHbusenCtna0vZUcqX2L0a3KAKOrXIQJE++qRFK8IaVfIjx2KWgkOfgiAgW4kUkRsF1lq15pXEXVRo5LyD43Q==",
-          "peer": true,
-          "requires": {
-            "@esri/arcgis-rest-types": "^2.25.0",
-            "tslib": "^1.13.0"
-          },
-          "dependencies": {
-            "@esri/arcgis-rest-types": {
-              "version": "2.25.0",
-              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.25.0.tgz",
-              "integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg==",
-              "peer": true
-            }
-          }
-        },
-        "@esri/arcgis-rest-feature-layer": {
-          "version": "3.0.0-beta.0",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.0-beta.0.tgz",
-          "integrity": "sha512-PxUPZmZfm0xQmnVsgA6v2YCvenf4RVuTNd8netxIuYDeT8tcoyaBmgncHG5NPnRoaqV8LBRfrPspAPylFrduoA==",
-          "requires": {
-            "@esri/arcgis-rest-types": "^3.0.0-beta.0",
-            "tslib": "^1.13.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "2.25.0",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.25.0.tgz",
-          "integrity": "sha512-4KYl+Ene7kwZg/M2ABneZizcWVoQkxDvyB9f6zrcKQ2uYjCj1kEl2OTBFmDhT7HFtBm/8cdLi79p/3kDGtSsqQ==",
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@esri/arcgis-rest-feature-service": "^4.0.1",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "fetch-blob": {
@@ -55228,8 +54343,8 @@
     "node-cli": {
       "version": "file:demos/ago-node-cli",
       "requires": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "chalk": "^2.3.0",
         "commander": "^2.12.2",
         "cross-fetch": "^3.0.0",
@@ -55237,24 +54352,6 @@
         "jsonfile": "^4.0.0"
       },
       "dependencies": {
-        "@esri/arcgis-rest-portal": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-          "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-          "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        },
         "chalk": {
           "version": "2.4.2",
           "requires": {
@@ -64075,50 +63172,8 @@
     "stream-response-to-file": {
       "version": "file:demos/stream-response-to-file",
       "requires": {
-        "@esri/arcgis-rest-feature-layer": "beta",
-        "@esri/arcgis-rest-request": "beta"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-auth": {
-          "version": "2.25.0",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.25.0.tgz",
-          "integrity": "sha512-fJHbusenCtna0vZUcqX2L0a3KAKOrXIQJE++qRFK8IaVfIjx2KWgkOfgiAgW4kUkRsF1lq15pXEXVRo5LyD43Q==",
-          "peer": true,
-          "requires": {
-            "@esri/arcgis-rest-types": "^2.25.0",
-            "tslib": "^1.13.0"
-          },
-          "dependencies": {
-            "@esri/arcgis-rest-types": {
-              "version": "2.25.0",
-              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.25.0.tgz",
-              "integrity": "sha512-2iMwX8tUVTImpoyKjNVsigc0JCUM8hTlyIu/hF2NnehyetvsefSut8njMObwHy872zfBzZ+kOMyulGGzdHvLxg==",
-              "peer": true
-            }
-          }
-        },
-        "@esri/arcgis-rest-feature-layer": {
-          "version": "3.0.0-beta.0",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.0-beta.0.tgz",
-          "integrity": "sha512-PxUPZmZfm0xQmnVsgA6v2YCvenf4RVuTNd8netxIuYDeT8tcoyaBmgncHG5NPnRoaqV8LBRfrPspAPylFrduoA==",
-          "requires": {
-            "@esri/arcgis-rest-types": "^3.0.0-beta.0",
-            "tslib": "^1.13.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "2.25.0",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.25.0.tgz",
-          "integrity": "sha512-4KYl+Ene7kwZg/M2ABneZizcWVoQkxDvyB9f6zrcKQ2uYjCj1kEl2OTBFmDhT7HFtBm/8cdLi79p/3kDGtSsqQ==",
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@esri/arcgis-rest-feature-service": "^4.0.1",
+        "@esri/arcgis-rest-request": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -65188,30 +64243,12 @@
     "ts-node-rest": {
       "version": "file:demos/node-typescript-es-modules",
       "requires": {
-        "@esri/arcgis-rest-portal": "beta",
-        "@esri/arcgis-rest-request": "beta",
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0",
         "ts-node": "^10.7.0",
         "typescript": "^4.6.2"
       },
       "dependencies": {
-        "@esri/arcgis-rest-portal": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.0.0-beta.4.tgz",
-          "integrity": "sha512-xms9wKsGafJLc5vUpwY8xG+fC1gLXkdKQImeHii5aVAXGRuW6xdnrs0Z8F4k5GviUBVpZsEGe9N+hl15RlcX3Q==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.0-beta.4.tgz",
-          "integrity": "sha512-R12HvLuNHNY6OgaO4n0QwOqmthOuX228tvLkf2zyYhQe9ITjqorsS9lXkDubGqEh7rVo8RpAl4pueFDxp9nfgw==",
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0-beta.1",
-            "@esri/arcgis-rest-form-data": "4.0.0-beta.1",
-            "tslib": "^2.3.1"
-          }
-        },
         "typescript": {
           "version": "4.6.2",
           "dev": true

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@types/node": "^12.20.4",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.31.0",
+    "browser-sync": "^2.27.9",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-import-resolver-typescript": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:bundled": "ultra -r --filter \"packages/*\" dev:bundled",
     "clean": "trash packages/*/dist/",
     "precommit": "lint-staged",
-    "docs:build": "rimraf docs/build && unzip -d docs/ docs/v3-archive.zip && mv docs/v3-archive docs/build && npm run typedoc",
+    "docs:build": "rimraf docs/build && unzip -d docs/build docs/v3-archive.zip && npm run typedoc",
     "lint": "eslint ./packages --ext .ts",
     "skypack-check": "npm exec -w ./packages package-check",
     "srihash": "node scripts/generate-sri-hashes.js",

--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -44,7 +44,7 @@
     "node": ">=12.20.0"
   },
   "dependencies": {
-    "@esri/arcgis-rest-request": "4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0",
     "tslib": "^2.3.0"
   },
   "contributors": [

--- a/packages/arcgis-rest-demographics/package.json
+++ b/packages/arcgis-rest-demographics/package.json
@@ -47,10 +47,10 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "4.0.0"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-request": "4.0.0"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "contributors": [
     "Gavin Rehkemper <grehkemper@esri.com> (http://gavinr.com/)",

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -46,12 +46,12 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-portal": "4.0.1",
-    "@esri/arcgis-rest-request": "4.0.0"
+    "@esri/arcgis-rest-portal": "^4.0.1",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-portal": "4.0.1",
-    "@esri/arcgis-rest-request": "4.0.0"
+    "@esri/arcgis-rest-portal": "^4.0.1",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "contributors": [
     "Mike Tschudi <mtschudi@esri.com>",

--- a/packages/arcgis-rest-geocoding/package.json
+++ b/packages/arcgis-rest-geocoding/package.json
@@ -48,10 +48,10 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "4.0.0"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-request": "4.0.0"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "contributors": [
     "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com/)"

--- a/packages/arcgis-rest-portal/package.json
+++ b/packages/arcgis-rest-portal/package.json
@@ -47,10 +47,10 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "4.0.0"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-request": "4.0.0"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "contributors": [
     "Dave Bouwman <dbouwman@esri.com> (http://blog.davebouwman.com/)"

--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -44,8 +44,8 @@
     "node": ">=12.20.0"
   },
   "dependencies": {
-    "@esri/arcgis-rest-fetch": "4.0.0",
-    "@esri/arcgis-rest-form-data": "4.0.0",
+    "@esri/arcgis-rest-fetch": "^4.0.0",
+    "@esri/arcgis-rest-form-data": "^4.0.0",
     "tslib": "^2.3.1"
   },
   "contributors": [

--- a/packages/arcgis-rest-routing/package.json
+++ b/packages/arcgis-rest-routing/package.json
@@ -48,10 +48,10 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "4.0.0"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-request": "4.0.0"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "contributors": [
     "Gavin Rehkemper <gavin@gavinr.com>"


### PR DESCRIPTION
This PR updates all package dependencies to point to `^4.0.0` (or `^4.0.1` for portal and feature layer) so that NPM will properly link all workspaces and all demos will function when users copy them.

This also fixes the doc build so we can deploy the doc site once the dev site goes live.