### PR TITLE
Export withOptions and fix REST links

### DIFF
--- a/packages/arcgis-rest-feature-service/src/queryRelated.ts
+++ b/packages/arcgis-rest-feature-service/src/queryRelated.ts
@@ -15,7 +15,7 @@ import {
 import { IGetLayerOptions } from "./helpers.js";
 
 /**
- * Related record query request options. Additional arguments can be passed via the {@linkcode IQueryRelatedOptions.params} property. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-related-feature-service-.htm) for more information and a full list of parameters.
+ * Related record query request options. Additional arguments can be passed via the {@linkcode IQueryRelatedOptions.params} property. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/enterprise/query-related-records-feature-service-.htm) for more information and a full list of parameters.
  */
 export interface IQueryRelatedOptions extends IGetLayerOptions {
   relationshipId?: number;

--- a/packages/arcgis-rest-feature-service/src/updateServiceDefinition.ts
+++ b/packages/arcgis-rest-feature-service/src/updateServiceDefinition.ts
@@ -17,7 +17,7 @@ export interface IUpdateServiceDefinitionResult {
 }
 
 /**
- * Update a definition property in a hosted feature service. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/update-definition-feature-service-.htm) for more information.
+ * Update a definition property in a hosted feature service. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/online/update-definition-feature-service-.htm) for more information.
  *
  * ```js
  * import { updateServiceDefinition } from '@esri/arcgis-rest-service-admin';

--- a/packages/arcgis-rest-request/src/index.ts
+++ b/packages/arcgis-rest-request/src/index.ts
@@ -34,6 +34,7 @@ export * from "./app-tokens.js";
 export * from "./validate-app-access.js";
 export * from "./federation-utils.js";
 export * from "./revoke-token.js";
+export * from "./utils/with-options.js";
 
 export * from "./types/feature.js";
 export * from "./types/geometry.js";


### PR DESCRIPTION
This PR fixes a few lingering issues:

1. Export `withOptions` from the `@esri/arcgis-rest-request` which was somehow missed.
2. Fix links to the REST API pages which 404