### PR TITLE
docs: fix references to @esri/arcgis-rest-auth in examples

### DIFF
--- a/packages/arcgis-rest-request/src/ApiKeyManager.ts
+++ b/packages/arcgis-rest-request/src/ApiKeyManager.ts
@@ -14,7 +14,7 @@ export interface IApiKeyOptions {
  * Used to authenticate methods in ArcGIS REST JS with an API keys. The instance of `ApiKeyManager` can be passed to  {@linkcode IRequestOptions.authentication} to authenticate requests.
  * 
  * ```js
- * import { ApiKeyManager } from '@esri/arcgis-rest-auth';
+ * import { ApiKeyManager } from '@esri/arcgis-rest-request';
  
  * const apiKey = new ApiKeyManager.fromKey("...");
  * ```

--- a/packages/arcgis-rest-request/src/app-tokens.ts
+++ b/packages/arcgis-rest-request/src/app-tokens.ts
@@ -80,7 +80,7 @@ export interface IPlatformSelfResponse {
  *
  * ```js
  * // convert the encrypted platform cookie into a ArcGISIdentityManager
- * import { platformSelf, ArcGISIdentityManager } from '@esri/arcgis-rest-auth';
+ * import { platformSelf, ArcGISIdentityManager } from '@esri/arcgis-rest-request';
  *
  * const portal = 'https://www.arcgis.com/sharing/rest';
  * const clientId = 'YOURAPPCLIENTID';

--- a/packages/arcgis-rest-request/src/types/user.ts
+++ b/packages/arcgis-rest-request/src/types/user.ts
@@ -9,7 +9,7 @@ import { IGroup } from "./group.js";
  * `IUser` can also be imported from the following packages:
  *
  * ```js
- * import { IUser } from "@esri/arcgis-rest-auth";
+ * import { IUser } from "@esri/arcgis-rest-request";
  * import { IUser } from "@esri/arcgis-rest-portal";
  * ```
  */

--- a/packages/arcgis-rest-request/src/validate-app-access.ts
+++ b/packages/arcgis-rest-request/src/validate-app-access.ts
@@ -25,7 +25,7 @@ export interface IAppAccess {
  * should not need or use this.
  *
  * ```js
- * import { validateAppAccess } from '@esri/arcgis-rest-auth';
+ * import { validateAppAccess } from '@esri/arcgis-rest-request';
  *
  * return validateAppAccess('your-token', 'theClientId')
  * .then((result) => {


### PR DESCRIPTION
This fixes a few more `@esri/arcgis-rest-auth` references in the docs.