### PR TITLE
feat: peer and dev deps keep ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39891,7 +39891,7 @@
     },
     "packages/arcgis-rest-request": {
       "name": "@esri/arcgis-rest-request",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@esri/arcgis-rest-fetch": "4.0.0",
@@ -39919,6 +39919,20 @@
       },
       "peerDependencies": {
         "@esri/arcgis-rest-request": "4.0.1"
+      }
+    },
+    "packages/arcgis-rest-routing/node_modules/@esri/arcgis-rest-request": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.1.tgz",
+      "integrity": "sha512-ZpA4EPQAuKZfpAQPvTTZ1hS/revjEvwhJuWXyKocyEC1qxW5N+1QWVz+nodc1B/wq0Ola94y39R7H3ySI9ukWg==",
+      "dev": true,
+      "dependencies": {
+        "@esri/arcgis-rest-fetch": "4.0.0",
+        "@esri/arcgis-rest-form-data": "4.0.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     }
   },
@@ -41622,6 +41636,19 @@
         "@terraformer/arcgis": "^2.0.7",
         "@types/terraformer__arcgis": "^2.0.0",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-request": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.1.tgz",
+          "integrity": "sha512-ZpA4EPQAuKZfpAQPvTTZ1hS/revjEvwhJuWXyKocyEC1qxW5N+1QWVz+nodc1B/wq0Ola94y39R7H3ySI9ukWg==",
+          "dev": true,
+          "requires": {
+            "@esri/arcgis-rest-fetch": "4.0.0",
+            "@esri/arcgis-rest-form-data": "4.0.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@esri/arcgis-rest-tree-shaking-rollup": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "prettify": "prettier --write --parser typescript --tab-width 2 --use-tabs false \"packages/**/+(src|test)/**/*.ts\"",
     "typedoc": "typedoc --options ./typedoc.json",
     "prettify:packages-jsons": "prettier-package-json --write ./**/*/package.json",
-    "release:dry": "multi-semantic-release --dry-run --debug --deps.release=inherit --ignore-private-packages",
-    "release": "multi-semantic-release  --deps.release=inherid --ignore-private-packages"
+    "release:dry": "multi-semantic-release --dry-run --deps-bump=inherit --deps.release=inherit --ignore-private-packages --debug ",
+    "release": "multi-semantic-release --deps-bump=inherit --deps.release=inherit --ignore-private-packages"
   },
   "engines": {
     "npm": ">=7.0.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "prettify": "prettier --write --parser typescript --tab-width 2 --use-tabs false \"packages/**/+(src|test)/**/*.ts\"",
     "typedoc": "typedoc --options ./typedoc.json",
     "prettify:packages-jsons": "prettier-package-json --write ./**/*/package.json",
-    "release:dry": "multi-semantic-release --dry-run --deps-bump=inherit --deps.release=inherit --ignore-private-packages --debug ",
-    "release": "multi-semantic-release --deps-bump=inherit --deps.release=inherit --ignore-private-packages"
+    "release:dry": "multi-semantic-release --dry-run --deps.bump=inherit --deps.release=inherit --ignore-private-packages --debug ",
+    "release": "multi-semantic-release --deps.bump=inherit --deps.release=inherit --ignore-private-packages"
   },
   "engines": {
     "npm": ">=7.0.0",

--- a/packages/arcgis-rest-auth/package.json
+++ b/packages/arcgis-rest-auth/package.json
@@ -44,7 +44,7 @@
     "node": ">=12.20.0"
   },
   "dependencies": {
-    "@esri/arcgis-rest-request": "4.0.1",
+    "@esri/arcgis-rest-request": "^4.0.1",
     "tslib": "^2.3.0"
   },
   "contributors": [

--- a/packages/arcgis-rest-demographics/package.json
+++ b/packages/arcgis-rest-demographics/package.json
@@ -47,7 +47,7 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "^4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-request": "^4.0.1"

--- a/packages/arcgis-rest-demographics/package.json
+++ b/packages/arcgis-rest-demographics/package.json
@@ -47,10 +47,10 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-request": "4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.1"
   },
   "contributors": [
     "Gavin Rehkemper <grehkemper@esri.com> (http://gavinr.com/)",

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -46,8 +46,8 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-portal": "^4.0.2",
-    "@esri/arcgis-rest-request": "^4.0.1"
+    "@esri/arcgis-rest-portal": "^4.0.0",
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-portal": "^4.0.2",

--- a/packages/arcgis-rest-feature-service/package.json
+++ b/packages/arcgis-rest-feature-service/package.json
@@ -46,12 +46,12 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-portal": "4.0.2",
-    "@esri/arcgis-rest-request": "4.0.1"
+    "@esri/arcgis-rest-portal": "^4.0.2",
+    "@esri/arcgis-rest-request": "^4.0.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-portal": "4.0.2",
-    "@esri/arcgis-rest-request": "4.0.1"
+    "@esri/arcgis-rest-portal": "^4.0.2",
+    "@esri/arcgis-rest-request": "^4.0.1"
   },
   "contributors": [
     "Mike Tschudi <mtschudi@esri.com>",

--- a/packages/arcgis-rest-geocoding/package.json
+++ b/packages/arcgis-rest-geocoding/package.json
@@ -48,7 +48,7 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "^4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-request": "^4.0.1"

--- a/packages/arcgis-rest-geocoding/package.json
+++ b/packages/arcgis-rest-geocoding/package.json
@@ -48,10 +48,10 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-request": "4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.1"
   },
   "contributors": [
     "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com/)"

--- a/packages/arcgis-rest-portal/package.json
+++ b/packages/arcgis-rest-portal/package.json
@@ -47,7 +47,7 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "^4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-request": "^4.0.1"

--- a/packages/arcgis-rest-portal/package.json
+++ b/packages/arcgis-rest-portal/package.json
@@ -47,10 +47,10 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-request": "4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.1"
   },
   "contributors": [
     "Dave Bouwman <dbouwman@esri.com> (http://blog.davebouwman.com/)"

--- a/packages/arcgis-rest-request/package.json
+++ b/packages/arcgis-rest-request/package.json
@@ -44,8 +44,8 @@
     "node": ">=12.20.0"
   },
   "dependencies": {
-    "@esri/arcgis-rest-fetch": "4.0.0",
-    "@esri/arcgis-rest-form-data": "4.0.0",
+    "@esri/arcgis-rest-fetch": "^4.0.0",
+    "@esri/arcgis-rest-form-data": "^4.0.0",
     "tslib": "^2.3.1"
   },
   "contributors": [

--- a/packages/arcgis-rest-routing/package.json
+++ b/packages/arcgis-rest-routing/package.json
@@ -48,7 +48,7 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "^4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
     "@esri/arcgis-rest-request": "^4.0.1"

--- a/packages/arcgis-rest-routing/package.json
+++ b/packages/arcgis-rest-routing/package.json
@@ -48,10 +48,10 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@esri/arcgis-rest-request": "4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.1"
   },
   "devDependencies": {
-    "@esri/arcgis-rest-request": "4.0.1"
+    "@esri/arcgis-rest-request": "^4.0.1"
   },
   "contributors": [
     "Gavin Rehkemper <gavin@gavinr.com>"


### PR DESCRIPTION
- Update `devDependencies` and `peerDependencies` to use `^` ranges for in-repo packages
- change release to use `--deps.bump=inherit` and `--deps.release=inherit` which will leave the `^` ranges in the deps intact.

**NOTE**: There is a bug in the backing release package where a `major` release will _not_ maintain the `^`. There is a PR being discussed to address this, and given we don't do breaking changes often, this seems to be a reasonable solution in the near-term.

