### PR TITLE
fix: resolve cross-org sharing as admin bug

### DIFF
--- a/packages/arcgis-rest-portal/src/sharing/share-item-with-group.ts
+++ b/packages/arcgis-rest-portal/src/sharing/share-item-with-group.ts
@@ -63,6 +63,8 @@ export function shareItemWithGroup(
       if (itemOwner !== username) {
         // need to track if the user is an admin
         let isAdmin = false;
+        // track if the admin & owner are in the same org
+        let isCrossOrgSharing = false;
         // next perform any necessary membership adjustments for
         // current user and/or item owner
         return Promise.all([
@@ -79,6 +81,7 @@ export function shareItemWithGroup(
           .then(([currentUser, ownerUser, membership]) => {
             const isSharedEditingGroup = !!confirmItemControl;
             isAdmin = currentUser.role === "org_admin" && !currentUser.roleId;
+            isCrossOrgSharing = currentUser.orgId !== ownerUser.orgId;
             return getMembershipAdjustments(
               currentUser,
               isSharedEditingGroup,
@@ -103,7 +106,7 @@ export function shareItemWithGroup(
             )
               .then(() => {
                 // then attempt the share
-                return shareToGroup(requestOptions, isAdmin);
+                return shareToGroup(requestOptions, isAdmin, isCrossOrgSharing);
               })
               .then((sharingResults) => {
                 // lastly, if the admin user was added to the group,
@@ -192,7 +195,8 @@ function getMembershipAdjustments(
 
 function shareToGroup(
   requestOptions: IGroupSharingOptions,
-  isAdmin = false
+  isAdmin = false,
+  isCrossOrgSharing = false
 ): Promise<ISharingResponse> {
   const username = requestOptions.authentication.username;
   const itemOwner = requestOptions.owner || username;
@@ -204,8 +208,8 @@ function shareToGroup(
 
   // but if they are the owner, or org_admin, use this route
   // Note: When using this end-point as an admin, apparently the admin does not need to be a member of the group (the itemOwner does)
-  // Have not validated this but came up in conversations w/ Sharing API team
-  if (itemOwner === username || isAdmin) {
+  // Note: Admin's can only use this route when the item is in the same org they are admin for
+  if (itemOwner === username || (isAdmin && !isCrossOrgSharing)) {
     url = `${getPortalUrl(requestOptions)}/content/users/${itemOwner}/items/${
       requestOptions.id
     }/share`;


### PR DESCRIPTION
This issue was resolved in the 3.x code stream by #919 , but was not picked up in the 4.x branch. This applies the same changes to 4.x