### PR TITLE
fix: #995 and #1006, issues with redirect urls

### DIFF
--- a/demos/oauth2-browser/authenticate.html
+++ b/demos/oauth2-browser/authenticate.html
@@ -1,21 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>ArcGIS Rest JS OAuth redirect</title>
-  </head>
-  <body>
-    <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
-    <script src="config.js"></script>
-    <script>
-      let opts = {
-          clientId: config.clientId,
-          popup: true,
-        }
-      if (config.portal) {
-        opts.portal = config.portal
-      }
-      arcgisRest.ArcGISIdentityManager.completeOAuth2(opts);
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <title>ArcGIS Rest JS OAuth redirect</title>
+</head>
+
+<body>
+  <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
+  <script src="config.js"></script>
+  <script>
+    let opts = {
+      clientId: config.clientId,
+      redirectUri: config.popupRedirectUri,
+      popup: true,
+    }
+    if (config.portal) {
+      opts.portal = config.portal
+    }
+    arcgisRest.ArcGISIdentityManager.completeOAuth2(opts);
+  </script>
+</body>
+
 </html>

--- a/demos/oauth2-browser/authenticate.html
+++ b/demos/oauth2-browser/authenticate.html
@@ -1,25 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="utf-8">
-  <title>ArcGIS Rest JS OAuth redirect</title>
-</head>
-
-<body>
-  <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
-  <script src="config.js"></script>
-  <script>
-    let opts = {
-      clientId: config.clientId,
-      redirectUri: config.popupRedirectUri,
-      popup: true,
-    }
-    if (config.portal) {
-      opts.portal = config.portal
-    }
-    arcgisRest.ArcGISIdentityManager.completeOAuth2(opts);
-  </script>
-</body>
-
+  <head>
+    <meta charset="utf-8">
+    <title>ArcGIS Rest JS OAuth redirect</title>
+  </head>
+  <body>
+    <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
+    <script src="config.js"></script>
+    <script>
+      let opts = {
+          clientId: config.clientId,
+          popup: true,
+        }
+      if (config.portal) {
+        opts.portal = config.portal
+      }
+      arcgisRest.ArcGISIdentityManager.completeOAuth2(opts);
+    </script>
+  </body>
 </html>

--- a/demos/oauth2-browser/authenticate.html
+++ b/demos/oauth2-browser/authenticate.html
@@ -1,21 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>ArcGIS Rest JS OAuth redirect</title>
-  </head>
-  <body>
-    <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
-    <script src="config.js"></script>
-    <script>
-      let opts = {
-          clientId: config.clientId,
-          popup: true,
-        }
-      if (config.portal) {
-        opts.portal = config.portal
-      }
-      arcgisRest.ArcGISIdentityManager.completeOAuth2(opts);
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <title>ArcGIS Rest JS OAuth redirect</title>
+</head>
+
+<body>
+  <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
+  <script src="config.js"></script>
+  <script>
+    let opts = {
+      clientId: config.clientId,
+      redirectUri: config.redirectUri,
+      popup: true,
+    }
+    if (config.portal) {
+      opts.portal = config.portal
+    }
+    arcgisRest.ArcGISIdentityManager.completeOAuth2(opts);
+  </script>
+</body>
+
 </html>

--- a/demos/oauth2-browser/index.html
+++ b/demos/oauth2-browser/index.html
@@ -1,231 +1,223 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="utf-8">
-  <title>ArcGIS REST JS Browser OAuth2</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
-    integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-  <link rel="stylesheet" href="./style.css">
-</head>
-
-<body>
-  <div id="app-wrapper">
-    <div class="jumbotron">
-      <div class="container">
-        <div id="page-header" class="row">
-          <div id="logo-container" class="col-sm-3">
-            <img id="logo" src="./logo.svg">
+  <head>
+    <meta charset="utf-8">
+    <title>ArcGIS REST JS Browser OAuth2</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link rel="stylesheet" href="./style.css">
+  </head>
+  <body>
+    <div id="app-wrapper">
+      <div class="jumbotron">
+        <div class="container">
+          <div id="page-header" class="row">
+            <div id="logo-container" class="col-sm-3">
+              <img id="logo" src="./logo.svg">
+            </div>
+            <div class="col-sm-9">
+              <h2>
+                ArcGIS REST JS Browser OAuth2
+              </h2>
+              <p>
+                An application demonstrating browser-based named user login.
+              </p>
+            </div>
           </div>
-          <div class="col-sm-9">
-            <h2>
-              ArcGIS REST JS Browser OAuth2
-            </h2>
-            <p>
-              An application demonstrating browser-based named user login.
+        </div>
+      </div>
+      <div class="container">
+        <div class="row">
+          <div class="col-xs-12">
+            <div id="clientIdGroup" class="form-group">
+              <label class="control-label">Client ID</label>
+              <!-- This is input required for the app. -->
+              <input
+                id="clientId"
+                type="text"
+                class="form-control"
+                placeholder="Client ID"
+                readonly
+              >
+            </div>
+            <div class="form-group">
+              <label class="control-label">Popup Redirect URI</label>
+              <!-- This is input required for the app. -->
+              <input id="popupRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
+            </div>
+            <div class="form-group">
+              <label class="control-label">Inline Redirect URI</label>
+              <!-- This is input required for the app. -->
+              <input id="inlineRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
+            </div>
+            <p class="help-block">
+              To use this demo copy the <code>config.js.template</code> file and rename it to <code>config.js</code>. Then fill in your values for <code>clientId</code>, <code>popupRedirectUri</code> and <code>inlineRedirectUri</code>. To get you started quickly an app registered by the ArcGIS REST JS team has been configured.
+            </p>
+            <p class="help-block">
+              Consult the documentation for <a href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/register-your-application/">registering an app</a> and <a href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/add-redirect-uri/">adding a redirect URI</a> for more information.
             </p>
           </div>
         </div>
-      </div>
-    </div>
-    <div class="container">
-      <div class="row">
-        <div class="col-xs-12">
-          <div id="clientIdGroup" class="form-group">
-            <label class="control-label">Client ID</label>
-            <!-- This is input required for the app. -->
-            <input id="clientId" type="text" class="form-control" placeholder="Client ID" readonly>
+        <div class="row">
+          <div class="col-xs-6">
+            <!-- Event listeners will be added to these buttons. -->
+            <button class="btn btn-primary btn-block" id='withPopupButton'>Sign In (w/ popup + PKCE)</button>
           </div>
-          <div class="form-group">
-            <label class="control-label">Popup Redirect URI</label>
-            <!-- This is input required for the app. -->
-            <input id="popupRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
+          <div class="col-xs-6">
+            <button class="btn btn-primary btn-block" id='inlineRedirectButton'>Sign In (inline + PKCE)</button>
           </div>
-          <div class="form-group">
-            <label class="control-label">Inline Redirect URI</label>
-            <!-- This is input required for the app. -->
-            <input id="inlineRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
-          </div>
-          <p class="help-block">
-            To use this demo copy the <code>config.js.template</code> file and rename it to <code>config.js</code>. Then
-            fill in your values for <code>clientId</code>, <code>popupRedirectUri</code> and
-            <code>inlineRedirectUri</code>. To get you started quickly an app registered by the ArcGIS REST JS team has
-            been configured.
-          </p>
-          <p class="help-block">
-            Consult the documentation for <a
-              href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/register-your-application/">registering
-              an app</a> and <a
-              href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/add-redirect-uri/">adding
-              a redirect URI</a> for more information.
-          </p>
         </div>
-      </div>
-      <div class="row">
-        <div class="col-xs-6">
-          <!-- Event listeners will be added to these buttons. -->
-          <button class="btn btn-primary btn-block" id='withPopupButton'>Sign In (w/ popup + PKCE)</button>
-        </div>
-        <div class="col-xs-6">
-          <button class="btn btn-primary btn-block" id='inlineRedirectButton'>Sign In (inline + PKCE)</button>
-        </div>
-      </div>
 
-      <div class="row">
-        <div class="col-xs-12">
-          <p id="sessionInfo" class="info-panel text-center">
-            <!-- Information will be injected here. -->
-          </p>
-          <pre class="overflow-scroll"><code id="sessionCode" style="white-space: pre;"></code></pre>
+        <div class="row">
+          <div class="col-xs-12">
+            <p id="sessionInfo" class="info-panel text-center">
+              <!-- Information will be injected here. -->
+            </p>
+            <pre class="overflow-scroll"><code id="sessionCode" style="white-space: pre;"></code></pre>
+          </div>
         </div>
-      </div>
 
-      <div class="row">
-        <div class="col-xs-3">
-        </div>
-        <div class="col-xs-6 text-center">
-          <!-- Event listeners will be added to these buttons. -->
-          <button class="btn btn-primary btn-block btn-warning" id='signOutButton'>Sign Out</button>
-        </div>
-        <div class="col-xs-3">
+        <div class="row">
+          <div class="col-xs-3">
+          </div>
+          <div class="col-xs-6 text-center">
+            <!-- Event listeners will be added to these buttons. -->
+            <button class="btn btn-primary btn-block btn-warning" id='signOutButton'>Sign Out</button>
+          </div>
+          <div class="col-xs-3">
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <script src="config.js"></script>
-  <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
-  <script>
-    // Define a global session variable.
-    let session = null;
+    <script src="config.js"></script>
+    <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
+    <script>
+      // Define a global session variable.
+      let session = null;
 
-    // Check to see if there is a serialized session in local storage.
-    const serializedSession = localStorage.getItem('__ARCGIS_REST_USER_SESSION__');
+      // Check to see if there is a serialized session in local storage.
+      const serializedSession = localStorage.getItem('__ARCGIS_REST_USER_SESSION__');
 
-    // If there is a saved session, we can deserialize it into a session object.
-    if (serializedSession !== null) {
-      session = arcgisRest.ArcGISIdentityManager.deserialize(serializedSession);
-      updateSessionInfo(session);
-    }
-
-    // Inject the config values onto the page.
-    document.getElementById('clientId').value = config.clientId;
-    document.getElementById('popupRedirectUri').value = config.popupRedirectUri;
-    document.getElementById('inlineRedirectUri').value = config.inlineRedirectUri;
-
-    // Function to update the UI with session info.
-    function updateSessionInfo(session) {
-      // Get the signed in users into and log it to the console
-      if (session) {
-        session.getUser().then((user) => {
-          console.log("User info:", user);
-        });
+      // If there is a saved session, we can deserialize it into a session object.
+      if (serializedSession !== null) {
+        session = arcgisRest.ArcGISIdentityManager.deserialize(serializedSession);
+        updateSessionInfo(session);
       }
 
-      let sessionInfo = document.getElementById('sessionInfo')
-      let sessionCode = document.getElementById("sessionCode");
+      // Inject the config values onto the page.
+      document.getElementById('clientId').value = config.clientId;
+      document.getElementById('popupRedirectUri').value = config.popupRedirectUri;
+      document.getElementById('inlineRedirectUri').value = config.inlineRedirectUri;
 
-      if (session) {
-        sessionInfo.classList.remove('bg-info');
-        sessionInfo.classList.add('bg-success');
-        sessionInfo.innerHTML = 'Logged in as ' + session.username;
-        sessionCode.innerHTML = JSON.stringify(session, null, 2);
-        localStorage.setItem('__ARCGIS_REST_USER_SESSION__', session.serialize());
-      } else {
-        sessionInfo.classList.remove('bg-success');
-        sessionInfo.classList.add('bg-info');
-        sessionInfo.innerHTML = 'Log in using one of the methods above to start a session.';
-        sessionCode.innerHTML = "No session info.";
-        localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
+      // Function to update the UI with session info.
+      function updateSessionInfo(session) {
+        // Get the signed in users into and log it to the console
+        if(session) {
+          session.getUser().then((user) => {
+            console.log("User info:", user);
+          });
+        }
+        
+        let sessionInfo = document.getElementById('sessionInfo')
+        let sessionCode = document.getElementById("sessionCode");
+        
+        if (session) {
+          sessionInfo.classList.remove('bg-info');
+          sessionInfo.classList.add('bg-success');
+          sessionInfo.innerHTML = 'Logged in as ' +  session.username;
+          sessionCode.innerHTML = JSON.stringify(session, null, 2);
+          localStorage.setItem('__ARCGIS_REST_USER_SESSION__', session.serialize());
+        } else {
+          sessionInfo.classList.remove('bg-success');
+          sessionInfo.classList.add('bg-info');
+          sessionInfo.innerHTML = 'Log in using one of the methods above to start a session.';
+          sessionCode.innerHTML = "No session info.";
+          localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
+        }
       }
-    }
 
-    // Generic function to handle errors from the authentication handlers.
-    function handleAuthError(e) {
-      switch (e.code) {
-        case "no-auth-state":
-          console.log("No auth state found to complete sign in. This error can be ignored.");
-          break;
-        case "access-denied-error":
-          console.log("The user hit cancel on the authorization screen.");
-          break;
-        default:
-          console.error(e);
-          break;
+      // Generic function to handle errors from the authentication handlers.
+      function handleAuthError (e) {
+        switch (e.code) {
+          case "no-auth-state":
+            console.log("No auth state found to complete sign in. This error can be ignored.");
+            break;
+          case "access-denied-error":
+            console.log("The user hit cancel on the authorization screen.");
+            break;
+          default:
+            console.error(e);
+            break;
+        }
       }
-    }
 
-    // Inline redirects will redirect to this page so we need to call `completeOAuth2()` here 
-    // If there is no auth process to complete a `no-auth-state` error will be thrown which you can
-    // ignore because you didn't start the oauth process.
-    let opts = {
-      clientId: config.clientId,
-      popup: true,
-      redirectUri: config.inlineRedirectUri
-    }
-
-    if (config.portal) {
-      opts.portal = config.portal
-    }
-
-    arcgisRest.ArcGISIdentityManager.completeOAuth2(opts).then(newSession => {
-      session = newSession;
-      updateSessionInfo(session);
-    }).catch(e => {
-      handleAuthError(e);
-    });
-
-    // Call the function on page load to set current state.
-    updateSessionInfo(session);
-
-    // Attach a listener to the sign in buttons.
-    document.getElementById('withPopupButton').addEventListener('click', function (event) {
-      // Begin an OAuth2 login using a popup.
-      const opts = {
-        clientId: config.clientId,
-        redirectUri: config.popupRedirectUri,
-        popup: true,
-      };
-      if (config.portal) {
-        opts.portal = config.portal;
-      }
-      arcgisRest.ArcGISIdentityManager.beginOAuth2(opts).then(function (newSession) {
-        // Upon a successful login, update the session with the new session.
+      // Inline redirects will redirect to this page so we need to call `completeOAuth2()` here 
+      // If there is no auth process to complete a `no-auth-state` error will be returned.
+      let opts = {
+          clientId: config.clientId,
+          popup: true,
+          redirectUri: config.inlineRedirectUri
+        }
+        if (config.portal) {
+          opts.portal = config.portal
+        }
+      arcgisRest.ArcGISIdentityManager.completeOAuth2(opts).then(newSession => {
         session = newSession;
         updateSessionInfo(session);
       }).catch(e => {
         handleAuthError(e);
       });
-    });
 
-    // Attach a listener to the sign in buttons.
-    document.getElementById('inlineRedirectButton').addEventListener('click', function (event) {
-      // Begin an OAuth2 login in the current window.
-      const opts = {
-        clientId: config.clientId,
-        redirectUri: config.inlineRedirectUri,
-        popup: false,
-      };
-      if (config.portal) {
-        opts.portal = config.portal;
-      }
-      arcgisRest.ArcGISIdentityManager.beginOAuth2(opts);
-    });
+      // Call the function on page load to set current state.
+      updateSessionInfo(session);
 
-    // Attach a listener to the sign out button.
-    document.getElementById('signOutButton').addEventListener('click', function (event) {
-      // destroy the session and remove the item in local storage
-      arcgisRest.ArcGISIdentityManager.destroy(session).then(({ success }) => {
-        if (success) {
-          // Clear the previous session.
-          session = null;
-          localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
+      // Attach a listener to the sign in buttons.
+      document.getElementById('withPopupButton').addEventListener('click', function (event) {
+        // Begin an OAuth2 login using a popup.
+        const opts = {
+          clientId: config.clientId,
+          redirectUri: config.popupRedirectUri,
+          popup: true,
+        };
+        if (config.portal) {
+          opts.portal = config.portal;
         }
-      }).finally(() => {
-        updateSessionInfo();
+        arcgisRest.ArcGISIdentityManager.beginOAuth2(opts).then(function (newSession) {
+          // Upon a successful login, update the session with the new session.
+          session = newSession;
+          updateSessionInfo(session);
+        }).catch(e => {
+          handleAuthError(e);
+        });
       });
-    });
-  </script>
-</body>
 
+      // Attach a listener to the sign in buttons.
+      document.getElementById('inlineRedirectButton').addEventListener('click', function (event) {
+        // Begin an OAuth2 login in the current window.
+        const opts = {
+          clientId: config.clientId,
+          redirectUri: config.inlineRedirectUri,
+          popup: false,
+        };
+        if (config.portal) {
+          opts.portal = config.portal;
+        }
+        arcgisRest.ArcGISIdentityManager.beginOAuth2(opts);
+      });
+
+      // Attach a listener to the sign out button.
+      document.getElementById('signOutButton').addEventListener('click', function (event) {
+        // destroy the session and remove the item in local storage
+        arcgisRest.ArcGISIdentityManager.destroy(session).then(({success})=>{
+          if(success) {
+            // Clear the previous session.
+            session = null;
+            localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
+          }
+        }).finally(()=>{
+          updateSessionInfo();
+        });
+      });
+    </script>
+  </body>
 </html>

--- a/demos/oauth2-browser/index.html
+++ b/demos/oauth2-browser/index.html
@@ -1,223 +1,228 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>ArcGIS REST JS Browser OAuth2</title>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <link rel="stylesheet" href="./style.css">
-  </head>
-  <body>
-    <div id="app-wrapper">
-      <div class="jumbotron">
-        <div class="container">
-          <div id="page-header" class="row">
-            <div id="logo-container" class="col-sm-3">
-              <img id="logo" src="./logo.svg">
-            </div>
-            <div class="col-sm-9">
-              <h2>
-                ArcGIS REST JS Browser OAuth2
-              </h2>
-              <p>
-                An application demonstrating browser-based named user login.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
+
+<head>
+  <meta charset="utf-8">
+  <title>ArcGIS REST JS Browser OAuth2</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+    integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="./style.css">
+</head>
+
+<body>
+  <div id="app-wrapper">
+    <div class="jumbotron">
       <div class="container">
-        <div class="row">
-          <div class="col-xs-12">
-            <div id="clientIdGroup" class="form-group">
-              <label class="control-label">Client ID</label>
-              <!-- This is input required for the app. -->
-              <input
-                id="clientId"
-                type="text"
-                class="form-control"
-                placeholder="Client ID"
-                readonly
-              >
-            </div>
-            <div class="form-group">
-              <label class="control-label">Popup Redirect URI</label>
-              <!-- This is input required for the app. -->
-              <input id="popupRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
-            </div>
-            <div class="form-group">
-              <label class="control-label">Inline Redirect URI</label>
-              <!-- This is input required for the app. -->
-              <input id="inlineRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
-            </div>
-            <p class="help-block">
-              To use this demo copy the <code>config.js.template</code> file and rename it to <code>config.js</code>. Then fill in your values for <code>clientId</code>, <code>popupRedirectUri</code> and <code>inlineRedirectUri</code>. To get you started quickly an app registered by the ArcGIS REST JS team has been configured.
+        <div id="page-header" class="row">
+          <div id="logo-container" class="col-sm-3">
+            <img id="logo" src="./logo.svg">
+          </div>
+          <div class="col-sm-9">
+            <h2>
+              ArcGIS REST JS Browser OAuth2
+            </h2>
+            <p>
+              An application demonstrating browser-based named user login.
             </p>
-            <p class="help-block">
-              Consult the documentation for <a href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/register-your-application/">registering an app</a> and <a href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/add-redirect-uri/">adding a redirect URI</a> for more information.
-            </p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-xs-6">
-            <!-- Event listeners will be added to these buttons. -->
-            <button class="btn btn-primary btn-block" id='withPopupButton'>Sign In (w/ popup + PKCE)</button>
-          </div>
-          <div class="col-xs-6">
-            <button class="btn btn-primary btn-block" id='inlineRedirectButton'>Sign In (inline + PKCE)</button>
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-xs-12">
-            <p id="sessionInfo" class="info-panel text-center">
-              <!-- Information will be injected here. -->
-            </p>
-            <pre class="overflow-scroll"><code id="sessionCode" style="white-space: pre;"></code></pre>
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-xs-3">
-          </div>
-          <div class="col-xs-6 text-center">
-            <!-- Event listeners will be added to these buttons. -->
-            <button class="btn btn-primary btn-block btn-warning" id='signOutButton'>Sign Out</button>
-          </div>
-          <div class="col-xs-3">
           </div>
         </div>
       </div>
     </div>
+    <div class="container">
+      <div class="row">
+        <div class="col-xs-12">
+          <div id="clientIdGroup" class="form-group">
+            <label class="control-label">Client ID</label>
+            <!-- This is input required for the app. -->
+            <input id="clientId" type="text" class="form-control" placeholder="Client ID" readonly>
+          </div>
+          <div class="form-group">
+            <label class="control-label">Popup Redirect URI</label>
+            <!-- This is input required for the app. -->
+            <input id="popupRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
+          </div>
+          <div class="form-group">
+            <label class="control-label">Inline Redirect URI</label>
+            <!-- This is input required for the app. -->
+            <input id="inlineRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
+          </div>
+          <p class="help-block">
+            To use this demo copy the <code>config.js.template</code> file and rename it to <code>config.js</code>. Then
+            fill in your values for <code>clientId</code>, <code>popupRedirectUri</code> and
+            <code>inlineRedirectUri</code>. To get you started quickly an app registered by the ArcGIS REST JS team has
+            been configured.
+          </p>
+          <p class="help-block">
+            Consult the documentation for <a
+              href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/register-your-application/">registering
+              an app</a> and <a
+              href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/add-redirect-uri/">adding
+              a redirect URI</a> for more information.
+          </p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-6">
+          <!-- Event listeners will be added to these buttons. -->
+          <button class="btn btn-primary btn-block" id='withPopupButton'>Sign In (w/ popup + PKCE)</button>
+        </div>
+        <div class="col-xs-6">
+          <button class="btn btn-primary btn-block" id='inlineRedirectButton'>Sign In (inline + PKCE)</button>
+        </div>
+      </div>
 
-    <script src="config.js"></script>
-    <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
-    <script>
-      // Define a global session variable.
-      let session = null;
+      <div class="row">
+        <div class="col-xs-12">
+          <p id="sessionInfo" class="info-panel text-center">
+            <!-- Information will be injected here. -->
+          </p>
+          <pre class="overflow-scroll"><code id="sessionCode" style="white-space: pre;"></code></pre>
+        </div>
+      </div>
 
-      // Check to see if there is a serialized session in local storage.
-      const serializedSession = localStorage.getItem('__ARCGIS_REST_USER_SESSION__');
+      <div class="row">
+        <div class="col-xs-3">
+        </div>
+        <div class="col-xs-6 text-center">
+          <!-- Event listeners will be added to these buttons. -->
+          <button class="btn btn-primary btn-block btn-warning" id='signOutButton'>Sign Out</button>
+        </div>
+        <div class="col-xs-3">
+        </div>
+      </div>
+    </div>
+  </div>
 
-      // If there is a saved session, we can deserialize it into a session object.
-      if (serializedSession !== null) {
-        session = arcgisRest.ArcGISIdentityManager.deserialize(serializedSession);
-        updateSessionInfo(session);
+  <script src="config.js"></script>
+  <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
+  <script>
+    // Define a global session variable.
+    let session = null;
+
+    // Check to see if there is a serialized session in local storage.
+    const serializedSession = localStorage.getItem('__ARCGIS_REST_USER_SESSION__');
+
+    // If there is a saved session, we can deserialize it into a session object.
+    if (serializedSession !== null) {
+      session = arcgisRest.ArcGISIdentityManager.deserialize(serializedSession);
+      updateSessionInfo(session);
+    }
+
+    // Inject the config values onto the page.
+    document.getElementById('clientId').value = config.clientId;
+    document.getElementById('popupRedirectUri').value = config.popupRedirectUri;
+    document.getElementById('inlineRedirectUri').value = config.inlineRedirectUri;
+
+    // Function to update the UI with session info.
+    function updateSessionInfo(session) {
+      // Get the signed in users into and log it to the console
+      if (session) {
+        session.getUser().then((user) => {
+          console.log("User info:", user);
+        });
       }
 
-      // Inject the config values onto the page.
-      document.getElementById('clientId').value = config.clientId;
-      document.getElementById('popupRedirectUri').value = config.popupRedirectUri;
-      document.getElementById('inlineRedirectUri').value = config.inlineRedirectUri;
+      let sessionInfo = document.getElementById('sessionInfo')
+      let sessionCode = document.getElementById("sessionCode");
 
-      // Function to update the UI with session info.
-      function updateSessionInfo(session) {
-        // Get the signed in users into and log it to the console
-        if(session) {
-          session.getUser().then((user) => {
-            console.log("User info:", user);
-          });
-        }
-        
-        let sessionInfo = document.getElementById('sessionInfo')
-        let sessionCode = document.getElementById("sessionCode");
-        
-        if (session) {
-          sessionInfo.classList.remove('bg-info');
-          sessionInfo.classList.add('bg-success');
-          sessionInfo.innerHTML = 'Logged in as ' +  session.username;
-          sessionCode.innerHTML = JSON.stringify(session, null, 2);
-          localStorage.setItem('__ARCGIS_REST_USER_SESSION__', session.serialize());
-        } else {
-          sessionInfo.classList.remove('bg-success');
-          sessionInfo.classList.add('bg-info');
-          sessionInfo.innerHTML = 'Log in using one of the methods above to start a session.';
-          sessionCode.innerHTML = "No session info.";
-          localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
-        }
+      if (session) {
+        sessionInfo.classList.remove('bg-info');
+        sessionInfo.classList.add('bg-success');
+        sessionInfo.innerHTML = 'Logged in as ' + session.username;
+        sessionCode.innerHTML = JSON.stringify(session, null, 2);
+        localStorage.setItem('__ARCGIS_REST_USER_SESSION__', session.serialize());
+      } else {
+        sessionInfo.classList.remove('bg-success');
+        sessionInfo.classList.add('bg-info');
+        sessionInfo.innerHTML = 'Log in using one of the methods above to start a session.';
+        sessionCode.innerHTML = "No session info.";
+        localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
       }
+    }
 
-      // Generic function to handle errors from the authentication handlers.
-      function handleAuthError (e) {
-        switch (e.code) {
-          case "no-auth-state":
-            console.log("No auth state found to complete sign in. This error can be ignored.");
-            break;
-          case "access-denied-error":
-            console.log("The user hit cancel on the authorization screen.");
-            break;
-          default:
-            console.error(e);
-            break;
-        }
+    // Generic function to handle errors from the authentication handlers.
+    function handleAuthError(e) {
+      switch (e.code) {
+        case "no-auth-state":
+          console.log("No auth state found to complete sign in. This error can be ignored.");
+          break;
+        case "access-denied-error":
+          console.log("The user hit cancel on the authorization screen.");
+          break;
+        default:
+          console.error(e);
+          break;
       }
+    }
 
-      // Inline redirects will redirect to this page so we need to call `completeOAuth2()` here 
-      // If there is no auth process to complete a `no-auth-state` error will be returned.
-      let opts = {
-          clientId: config.clientId,
-          popup: true,
-          redirectUri: config.inlineRedirectUri
-        }
-        if (config.portal) {
-          opts.portal = config.portal
-        }
-      arcgisRest.ArcGISIdentityManager.completeOAuth2(opts).then(newSession => {
+    // Inline redirects will redirect to this page so we need to call `completeOAuth2()` here 
+    // If there is no auth process to complete a `no-auth-state` error will be returned.
+    let opts = {
+      clientId: config.clientId,
+      popup: true,
+      redirectUri: config.inlineRedirectUri
+    }
+    if (config.portal) {
+      opts.portal = config.portal
+    }
+    arcgisRest.ArcGISIdentityManager.completeOAuth2(opts).then(newSession => {
+      session = newSession;
+      updateSessionInfo(session);
+    }).catch(e => {
+      handleAuthError(e);
+    });
+
+    // Call the function on page load to set current state.
+    updateSessionInfo(session);
+
+    // Attach a listener to the sign in buttons.
+    document.getElementById('withPopupButton').addEventListener('click', function (event) {
+      // Begin an OAuth2 login using a popup.
+      const opts = {
+        clientId: config.clientId,
+        redirectUri: config.popupRedirectUri,
+        popup: true,
+      };
+      if (config.portal) {
+        opts.portal = config.portal;
+      }
+      arcgisRest.ArcGISIdentityManager.beginOAuth2(opts).then(function (newSession) {
+        // Upon a successful login, update the session with the new session.
         session = newSession;
         updateSessionInfo(session);
       }).catch(e => {
         handleAuthError(e);
       });
+    });
 
-      // Call the function on page load to set current state.
-      updateSessionInfo(session);
+    // Attach a listener to the sign in buttons.
+    document.getElementById('inlineRedirectButton').addEventListener('click', function (event) {
+      // Begin an OAuth2 login in the current window.
+      const opts = {
+        clientId: config.clientId,
+        redirectUri: config.inlineRedirectUri,
+        popup: false,
+      };
+      if (config.portal) {
+        opts.portal = config.portal;
+      }
+      arcgisRest.ArcGISIdentityManager.beginOAuth2(opts);
+    });
 
-      // Attach a listener to the sign in buttons.
-      document.getElementById('withPopupButton').addEventListener('click', function (event) {
-        // Begin an OAuth2 login using a popup.
-        const opts = {
-          clientId: config.clientId,
-          redirectUri: config.popupRedirectUri,
-          popup: true,
-        };
-        if (config.portal) {
-          opts.portal = config.portal;
+    // Attach a listener to the sign out button.
+    document.getElementById('signOutButton').addEventListener('click', function (event) {
+      // destroy the session and remove the item in local storage
+      arcgisRest.ArcGISIdentityManager.destroy(session).then(({ success }) => {
+        if (success) {
+          // Clear the previous session.
+          session = null;
+          localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
         }
-        arcgisRest.ArcGISIdentityManager.beginOAuth2(opts).then(function (newSession) {
-          // Upon a successful login, update the session with the new session.
-          session = newSession;
-          updateSessionInfo(session);
-        }).catch(e => {
-          handleAuthError(e);
-        });
+      }).finally(() => {
+        updateSessionInfo();
       });
+    });
+  </script>
+</body>
 
-      // Attach a listener to the sign in buttons.
-      document.getElementById('inlineRedirectButton').addEventListener('click', function (event) {
-        // Begin an OAuth2 login in the current window.
-        const opts = {
-          clientId: config.clientId,
-          redirectUri: config.inlineRedirectUri,
-          popup: false,
-        };
-        if (config.portal) {
-          opts.portal = config.portal;
-        }
-        arcgisRest.ArcGISIdentityManager.beginOAuth2(opts);
-      });
-
-      // Attach a listener to the sign out button.
-      document.getElementById('signOutButton').addEventListener('click', function (event) {
-        // destroy the session and remove the item in local storage
-        arcgisRest.ArcGISIdentityManager.destroy(session).then(({success})=>{
-          if(success) {
-            // Clear the previous session.
-            session = null;
-            localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
-          }
-        }).finally(()=>{
-          updateSessionInfo();
-        });
-      });
-    </script>
-  </body>
 </html>

--- a/demos/oauth2-browser/index.html
+++ b/demos/oauth2-browser/index.html
@@ -1,223 +1,231 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>ArcGIS REST JS Browser OAuth2</title>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <link rel="stylesheet" href="./style.css">
-  </head>
-  <body>
-    <div id="app-wrapper">
-      <div class="jumbotron">
-        <div class="container">
-          <div id="page-header" class="row">
-            <div id="logo-container" class="col-sm-3">
-              <img id="logo" src="./logo.svg">
-            </div>
-            <div class="col-sm-9">
-              <h2>
-                ArcGIS REST JS Browser OAuth2
-              </h2>
-              <p>
-                An application demonstrating browser-based named user login.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
+
+<head>
+  <meta charset="utf-8">
+  <title>ArcGIS REST JS Browser OAuth2</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+    integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="./style.css">
+</head>
+
+<body>
+  <div id="app-wrapper">
+    <div class="jumbotron">
       <div class="container">
-        <div class="row">
-          <div class="col-xs-12">
-            <div id="clientIdGroup" class="form-group">
-              <label class="control-label">Client ID</label>
-              <!-- This is input required for the app. -->
-              <input
-                id="clientId"
-                type="text"
-                class="form-control"
-                placeholder="Client ID"
-                readonly
-              >
-            </div>
-            <div class="form-group">
-              <label class="control-label">Popup Redirect URI</label>
-              <!-- This is input required for the app. -->
-              <input id="popupRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
-            </div>
-            <div class="form-group">
-              <label class="control-label">Inline Redirect URI</label>
-              <!-- This is input required for the app. -->
-              <input id="inlineRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
-            </div>
-            <p class="help-block">
-              To use this demo copy the <code>config.js.template</code> file and rename it to <code>config.js</code>. Then fill in your values for <code>clientId</code>, <code>popupRedirectUri</code> and <code>inlineRedirectUri</code>. To get you started quickly an app registered by the ArcGIS REST JS team has been configured.
+        <div id="page-header" class="row">
+          <div id="logo-container" class="col-sm-3">
+            <img id="logo" src="./logo.svg">
+          </div>
+          <div class="col-sm-9">
+            <h2>
+              ArcGIS REST JS Browser OAuth2
+            </h2>
+            <p>
+              An application demonstrating browser-based named user login.
             </p>
-            <p class="help-block">
-              Consult the documentation for <a href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/register-your-application/">registering an app</a> and <a href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/add-redirect-uri/">adding a redirect URI</a> for more information.
-            </p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-xs-6">
-            <!-- Event listeners will be added to these buttons. -->
-            <button class="btn btn-primary btn-block" id='withPopupButton'>Sign In (w/ popup + PKCE)</button>
-          </div>
-          <div class="col-xs-6">
-            <button class="btn btn-primary btn-block" id='inlineRedirectButton'>Sign In (inline + PKCE)</button>
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-xs-12">
-            <p id="sessionInfo" class="info-panel text-center">
-              <!-- Information will be injected here. -->
-            </p>
-            <pre class="overflow-scroll"><code id="sessionCode" style="white-space: pre;"></code></pre>
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-xs-3">
-          </div>
-          <div class="col-xs-6 text-center">
-            <!-- Event listeners will be added to these buttons. -->
-            <button class="btn btn-primary btn-block btn-warning" id='signOutButton'>Sign Out</button>
-          </div>
-          <div class="col-xs-3">
           </div>
         </div>
       </div>
     </div>
+    <div class="container">
+      <div class="row">
+        <div class="col-xs-12">
+          <div id="clientIdGroup" class="form-group">
+            <label class="control-label">Client ID</label>
+            <!-- This is input required for the app. -->
+            <input id="clientId" type="text" class="form-control" placeholder="Client ID" readonly>
+          </div>
+          <div class="form-group">
+            <label class="control-label">Popup Redirect URI</label>
+            <!-- This is input required for the app. -->
+            <input id="popupRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
+          </div>
+          <div class="form-group">
+            <label class="control-label">Inline Redirect URI</label>
+            <!-- This is input required for the app. -->
+            <input id="inlineRedirectUri" type="text" class="form-control" placeholder="redirectUri" readonly>
+          </div>
+          <p class="help-block">
+            To use this demo copy the <code>config.js.template</code> file and rename it to <code>config.js</code>. Then
+            fill in your values for <code>clientId</code>, <code>popupRedirectUri</code> and
+            <code>inlineRedirectUri</code>. To get you started quickly an app registered by the ArcGIS REST JS team has
+            been configured.
+          </p>
+          <p class="help-block">
+            Consult the documentation for <a
+              href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/register-your-application/">registering
+              an app</a> and <a
+              href="https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/add-redirect-uri/">adding
+              a redirect URI</a> for more information.
+          </p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-6">
+          <!-- Event listeners will be added to these buttons. -->
+          <button class="btn btn-primary btn-block" id='withPopupButton'>Sign In (w/ popup + PKCE)</button>
+        </div>
+        <div class="col-xs-6">
+          <button class="btn btn-primary btn-block" id='inlineRedirectButton'>Sign In (inline + PKCE)</button>
+        </div>
+      </div>
 
-    <script src="config.js"></script>
-    <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
-    <script>
-      // Define a global session variable.
-      let session = null;
+      <div class="row">
+        <div class="col-xs-12">
+          <p id="sessionInfo" class="info-panel text-center">
+            <!-- Information will be injected here. -->
+          </p>
+          <pre class="overflow-scroll"><code id="sessionCode" style="white-space: pre;"></code></pre>
+        </div>
+      </div>
 
-      // Check to see if there is a serialized session in local storage.
-      const serializedSession = localStorage.getItem('__ARCGIS_REST_USER_SESSION__');
+      <div class="row">
+        <div class="col-xs-3">
+        </div>
+        <div class="col-xs-6 text-center">
+          <!-- Event listeners will be added to these buttons. -->
+          <button class="btn btn-primary btn-block btn-warning" id='signOutButton'>Sign Out</button>
+        </div>
+        <div class="col-xs-3">
+        </div>
+      </div>
+    </div>
+  </div>
 
-      // If there is a saved session, we can deserialize it into a session object.
-      if (serializedSession !== null) {
-        session = arcgisRest.ArcGISIdentityManager.deserialize(serializedSession);
-        updateSessionInfo(session);
+  <script src="config.js"></script>
+  <script src="@esri/arcgis-rest-request/dist/bundled/request.umd.js"></script>
+  <script>
+    // Define a global session variable.
+    let session = null;
+
+    // Check to see if there is a serialized session in local storage.
+    const serializedSession = localStorage.getItem('__ARCGIS_REST_USER_SESSION__');
+
+    // If there is a saved session, we can deserialize it into a session object.
+    if (serializedSession !== null) {
+      session = arcgisRest.ArcGISIdentityManager.deserialize(serializedSession);
+      updateSessionInfo(session);
+    }
+
+    // Inject the config values onto the page.
+    document.getElementById('clientId').value = config.clientId;
+    document.getElementById('popupRedirectUri').value = config.popupRedirectUri;
+    document.getElementById('inlineRedirectUri').value = config.inlineRedirectUri;
+
+    // Function to update the UI with session info.
+    function updateSessionInfo(session) {
+      // Get the signed in users into and log it to the console
+      if (session) {
+        session.getUser().then((user) => {
+          console.log("User info:", user);
+        });
       }
 
-      // Inject the config values onto the page.
-      document.getElementById('clientId').value = config.clientId;
-      document.getElementById('popupRedirectUri').value = config.popupRedirectUri;
-      document.getElementById('inlineRedirectUri').value = config.inlineRedirectUri;
+      let sessionInfo = document.getElementById('sessionInfo')
+      let sessionCode = document.getElementById("sessionCode");
 
-      // Function to update the UI with session info.
-      function updateSessionInfo(session) {
-        // Get the signed in users into and log it to the console
-        if(session) {
-          session.getUser().then((user) => {
-            console.log("User info:", user);
-          });
-        }
-        
-        let sessionInfo = document.getElementById('sessionInfo')
-        let sessionCode = document.getElementById("sessionCode");
-        
-        if (session) {
-          sessionInfo.classList.remove('bg-info');
-          sessionInfo.classList.add('bg-success');
-          sessionInfo.innerHTML = 'Logged in as ' +  session.username;
-          sessionCode.innerHTML = JSON.stringify(session, null, 2);
-          localStorage.setItem('__ARCGIS_REST_USER_SESSION__', session.serialize());
-        } else {
-          sessionInfo.classList.remove('bg-success');
-          sessionInfo.classList.add('bg-info');
-          sessionInfo.innerHTML = 'Log in using one of the methods above to start a session.';
-          sessionCode.innerHTML = "No session info.";
-          localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
-        }
+      if (session) {
+        sessionInfo.classList.remove('bg-info');
+        sessionInfo.classList.add('bg-success');
+        sessionInfo.innerHTML = 'Logged in as ' + session.username;
+        sessionCode.innerHTML = JSON.stringify(session, null, 2);
+        localStorage.setItem('__ARCGIS_REST_USER_SESSION__', session.serialize());
+      } else {
+        sessionInfo.classList.remove('bg-success');
+        sessionInfo.classList.add('bg-info');
+        sessionInfo.innerHTML = 'Log in using one of the methods above to start a session.';
+        sessionCode.innerHTML = "No session info.";
+        localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
       }
+    }
 
-      // Generic function to handle errors from the authentication handlers.
-      function handleAuthError (e) {
-        switch (e.code) {
-          case "no-auth-state":
-            console.log("No auth state found to complete sign in. This error can be ignored.");
-            break;
-          case "access-denied-error":
-            console.log("The user hit cancel on the authorization screen.");
-            break;
-          default:
-            console.error(e);
-            break;
-        }
+    // Generic function to handle errors from the authentication handlers.
+    function handleAuthError(e) {
+      switch (e.code) {
+        case "no-auth-state":
+          console.log("No auth state found to complete sign in. This error can be ignored.");
+          break;
+        case "access-denied-error":
+          console.log("The user hit cancel on the authorization screen.");
+          break;
+        default:
+          console.error(e);
+          break;
       }
+    }
 
-      // Inline redirects will redirect to this page so we need to call `completeOAuth2()` here 
-      // If there is no auth process to complete a `no-auth-state` error will be returned.
-      let opts = {
-          clientId: config.clientId,
-          popup: true,
-          redirectUri: config.inlineRedirectUri
-        }
-        if (config.portal) {
-          opts.portal = config.portal
-        }
-      arcgisRest.ArcGISIdentityManager.completeOAuth2(opts).then(newSession => {
+    // Inline redirects will redirect to this page so we need to call `completeOAuth2()` here 
+    // If there is no auth process to complete a `no-auth-state` error will be thrown which you can
+    // ignore because you didn't start the oauth process.
+    let opts = {
+      clientId: config.clientId,
+      popup: true,
+      redirectUri: config.inlineRedirectUri
+    }
+
+    if (config.portal) {
+      opts.portal = config.portal
+    }
+
+    arcgisRest.ArcGISIdentityManager.completeOAuth2(opts).then(newSession => {
+      session = newSession;
+      updateSessionInfo(session);
+    }).catch(e => {
+      handleAuthError(e);
+    });
+
+    // Call the function on page load to set current state.
+    updateSessionInfo(session);
+
+    // Attach a listener to the sign in buttons.
+    document.getElementById('withPopupButton').addEventListener('click', function (event) {
+      // Begin an OAuth2 login using a popup.
+      const opts = {
+        clientId: config.clientId,
+        redirectUri: config.popupRedirectUri,
+        popup: true,
+      };
+      if (config.portal) {
+        opts.portal = config.portal;
+      }
+      arcgisRest.ArcGISIdentityManager.beginOAuth2(opts).then(function (newSession) {
+        // Upon a successful login, update the session with the new session.
         session = newSession;
         updateSessionInfo(session);
       }).catch(e => {
         handleAuthError(e);
       });
+    });
 
-      // Call the function on page load to set current state.
-      updateSessionInfo(session);
+    // Attach a listener to the sign in buttons.
+    document.getElementById('inlineRedirectButton').addEventListener('click', function (event) {
+      // Begin an OAuth2 login in the current window.
+      const opts = {
+        clientId: config.clientId,
+        redirectUri: config.inlineRedirectUri,
+        popup: false,
+      };
+      if (config.portal) {
+        opts.portal = config.portal;
+      }
+      arcgisRest.ArcGISIdentityManager.beginOAuth2(opts);
+    });
 
-      // Attach a listener to the sign in buttons.
-      document.getElementById('withPopupButton').addEventListener('click', function (event) {
-        // Begin an OAuth2 login using a popup.
-        const opts = {
-          clientId: config.clientId,
-          redirectUri: config.popupRedirectUri,
-          popup: true,
-        };
-        if (config.portal) {
-          opts.portal = config.portal;
+    // Attach a listener to the sign out button.
+    document.getElementById('signOutButton').addEventListener('click', function (event) {
+      // destroy the session and remove the item in local storage
+      arcgisRest.ArcGISIdentityManager.destroy(session).then(({ success }) => {
+        if (success) {
+          // Clear the previous session.
+          session = null;
+          localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
         }
-        arcgisRest.ArcGISIdentityManager.beginOAuth2(opts).then(function (newSession) {
-          // Upon a successful login, update the session with the new session.
-          session = newSession;
-          updateSessionInfo(session);
-        }).catch(e => {
-          handleAuthError(e);
-        });
+      }).finally(() => {
+        updateSessionInfo();
       });
+    });
+  </script>
+</body>
 
-      // Attach a listener to the sign in buttons.
-      document.getElementById('inlineRedirectButton').addEventListener('click', function (event) {
-        // Begin an OAuth2 login in the current window.
-        const opts = {
-          clientId: config.clientId,
-          redirectUri: config.inlineRedirectUri,
-          popup: false,
-        };
-        if (config.portal) {
-          opts.portal = config.portal;
-        }
-        arcgisRest.ArcGISIdentityManager.beginOAuth2(opts);
-      });
-
-      // Attach a listener to the sign out button.
-      document.getElementById('signOutButton').addEventListener('click', function (event) {
-        // destroy the session and remove the item in local storage
-        arcgisRest.ArcGISIdentityManager.destroy(session).then(({success})=>{
-          if(success) {
-            // Clear the previous session.
-            session = null;
-            localStorage.removeItem('__ARCGIS_REST_USER_SESSION__');
-          }
-        }).finally(()=>{
-          updateSessionInfo();
-        });
-      });
-    </script>
-  </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2860,20 +2860,13 @@
         "node": ">=v10.22.0"
       }
     },
-    "node_modules/@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@cspotcode/source-map-support": {
-      "version": "0.7.0",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
         "node": ">=12"
@@ -3852,6 +3845,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@lerna/add": {
@@ -37185,11 +37203,12 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.7.0",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -37200,7 +37219,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
@@ -38099,9 +38118,10 @@
       "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -39920,20 +39940,6 @@
       "peerDependencies": {
         "@esri/arcgis-rest-request": "^4.0.0"
       }
-    },
-    "packages/arcgis-rest-routing/node_modules/@esri/arcgis-rest-request": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.1.tgz",
-      "integrity": "sha512-ZpA4EPQAuKZfpAQPvTTZ1hS/revjEvwhJuWXyKocyEC1qxW5N+1QWVz+nodc1B/wq0Ola94y39R7H3ySI9ukWg==",
-      "dev": true,
-      "dependencies": {
-        "@esri/arcgis-rest-fetch": "4.0.0",
-        "@esri/arcgis-rest-form-data": "4.0.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
     }
   },
   "dependencies": {
@@ -41454,15 +41460,13 @@
       "version": "11.0.0",
       "dev": true
     },
-    "@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "dev": true
-    },
     "@cspotcode/source-map-support": {
-      "version": "0.7.0",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "requires": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@eslint/eslintrc": {
@@ -41636,19 +41640,6 @@
         "@terraformer/arcgis": "^2.0.7",
         "@types/terraformer__arcgis": "^2.0.0",
         "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "@esri/arcgis-rest-request": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.0.1.tgz",
-          "integrity": "sha512-ZpA4EPQAuKZfpAQPvTTZ1hS/revjEvwhJuWXyKocyEC1qxW5N+1QWVz+nodc1B/wq0Ola94y39R7H3ySI9ukWg==",
-          "dev": true,
-          "requires": {
-            "@esri/arcgis-rest-fetch": "4.0.0",
-            "@esri/arcgis-rest-form-data": "4.0.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@esri/arcgis-rest-tree-shaking-rollup": {
@@ -42405,6 +42396,28 @@
     "@istanbuljs/schema": {
       "version": "0.1.3",
       "dev": true
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "@lerna/add": {
       "version": "3.21.0",
@@ -65791,10 +65804,12 @@
       }
     },
     "ts-node": {
-      "version": "10.7.0",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -65805,7 +65820,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -66401,7 +66416,9 @@
       "dev": true
     },
     "v8-compile-cache-lib": {
-      "version": "3.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39874,7 +39874,7 @@
     },
     "packages/arcgis-rest-portal": {
       "name": "@esri/arcgis-rest-portal",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -27,11 +27,34 @@ import { NODEJS_DEFAULT_REFERER_HEADER } from "./index.js";
  * Options for {@linkcode ArcGISIdentityManager.fromToken}.
  */
 export interface IFromTokenOptions {
+  /**
+   * The token you want to create the {@linkcode ArcGISIdentityManager} instance with.
+   */
   token: string;
+  /**
+   * Date when this token will expire.
+   */
   tokenExpires?: Date;
+  /**
+   * The portal that the token was generated from. Defaults to `https://www.arcgis.com/sharing/rest`. Required if you are not using the default portal.
+   */
   portal?: string;
+  /**
+   * If the token is for a specific instance of ArcGIS Server, set `portal` to `null` or `undefined` and set `server` the URL of the ArcGIS Server.
+   */
   server?: string;
+  /**
+   * Optionally set the username. Recommended if available.
+   */
   username?: string;
+  /**
+   * Optional client ID. Used for refreshing expired tokens.
+   */
+  clientId?: string;
+  /**
+   * Optional set a valid redirect URL for the registered client ID. Used internally to refresh expired tokens.
+   */
+  redirectUri?: string;
 }
 
 /**
@@ -237,7 +260,7 @@ export interface IArcGISIdentityManagerOptions {
  *
  * **It is not recommended to construct `ArcGISIdentityManager` directly**. Instead there are several static methods used for specific workflows. The 2 primary workflows relate to oAuth 2.0:
  *
- * * {@linkcode ArcGISIdentityManager.beginOAuth2} and {@linkcode ArcGISIdentityManager.completeOAuth2} for oAuth 2.0 in browser-only environment.
+ * * {@linkcode ArcGISIdentityManager.beginOAuth2} and {@linkcode ArcGISIdentityManager.completeOAuth2()} for oAuth 2.0 in browser-only environment.
  * * {@linkcode ArcGISIdentityManager.authorize} and {@linkcode ArcGISIdentityManager.exchangeAuthorizationCode} for oAuth 2.0 for server-enabled application.
  *
  * Other more specialized helpers for less common workflows also exist:
@@ -302,7 +325,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
       return true;
     }
 
-    if (this.clientId && this.refreshToken) {
+    if (this.clientId && this.refreshToken && this.redirectUri) {
       return true;
     }
 
@@ -312,7 +335,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
   /**
    * Begins a new browser-based OAuth 2.0 sign in. If `options.popup` is `true` the authentication window will open in a new tab/window. Otherwise, the user will be redirected to the authorization page in their current tab/window and the function will return `undefined`.
    *
-   * If `popup` is `true` (the default) this method will return a `Promise` that resolves to an `ArcGISIdentityManager` instance and you must call {@linkcode ArcGISIdentityManager.completeOAuth2} on the page defined in the `redirectUri`. Otherwise it will return undefined and the {@linkcode ArcGISIdentityManager.completeOAuth2} method will return a `Promise` that resolves to an `ArcGISIdentityManager` instance.
+   * If `popup` is `true` (the default) this method will return a `Promise` that resolves to an `ArcGISIdentityManager` instance and you must call {@linkcode ArcGISIdentityManager.completeOAuth2()} on the page defined in the `redirectUri`. Otherwise it will return undefined and the {@linkcode ArcGISIdentityManager.completeOAuth2()} method will return a `Promise` that resolves to an `ArcGISIdentityManager` instance.
    *
    * A {@linkcode ArcGISAccessDeniedError} error will be thrown if the user denies the request on the authorization screen.
    *
@@ -435,7 +458,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
       if (popup) {
         // If we are authenticating a popup we need to return a Promise that will resolve to an ArcGISIdentityManager later.
         return new Promise((resolve, reject) => {
-          // Add an event listener to listen for when a user calls `ArcGISIdentityManager.completeOAuth2()` in the popup.
+          // Add an event listener to listen for when a user calls `ArcGISIdentityManager.completeOAuth2()()` in the popup.
           win.addEventListener(
             `arcgis-rest-js-popup-auth-${clientId}`,
             (e: CustomEvent<any>) => {
@@ -445,7 +468,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
                 return error;
               }
 
-              if (e.detail.error) {
+              if (e.detail.errorMessage) {
                 const error = new ArcGISAuthError(
                   e.detail.errorMessage,
                   e.detail.error
@@ -463,7 +486,8 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
                   tokenExpires: e.detail.expires,
                   username: e.detail.username,
                   refreshToken: e.detail.refreshToken,
-                  refreshTokenExpires: e.detail.refreshTokenExpires
+                  refreshTokenExpires: e.detail.refreshTokenExpires,
+                  redirectUri
                 })
               );
             },
@@ -499,7 +523,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
     }
 
     // pull out necessary options
-    const { portal, clientId, popup, pkce }: IOAuth2Options = {
+    const { portal, clientId, popup, pkce, redirectUri }: IOAuth2Options = {
       ...{
         portal: "https://www.arcgis.com/sharing/rest",
         popup: true,
@@ -539,6 +563,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
         );
 
         win.close();
+
         return;
       }
 
@@ -570,6 +595,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
         );
 
         win.close();
+
         return;
       }
 
@@ -583,7 +609,15 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
         tokenExpires: oauthInfo.expires,
         username: oauthInfo.username,
         refreshToken: oauthInfo.refreshToken,
-        refreshTokenExpires: oauthInfo.refreshTokenExpires
+        refreshTokenExpires: oauthInfo.refreshTokenExpires,
+        // At 4.0.0 it was possible (in JS code) to not pass redirectUri and fallback to win.location.href, however this broke support for redirect URIs with query params.
+        // Now similar to 3.x.x you must pass the redirectUri parameter explicitly. See https://github.com/Esri/arcgis-rest-js/issues/995
+        redirectUri:
+          redirectUri ||
+          /* istanbul ignore next: TypeScript wont compile if we omit redirectUri */ location.href.replace(
+            location.search,
+            ""
+          )
       });
     }
 
@@ -625,7 +659,9 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
           client_id: clientId,
           code_verifier: codeVerifier,
           grant_type: "authorization_code",
-          redirect_uri: location.href.replace(location.search, ""),
+          // using location.href here does not support query params but shipped with 4.0.0. See https://github.com/Esri/arcgis-rest-js/issues/995
+          redirect_uri:
+            redirectUri || location.href.replace(location.search, ""),
           code: params.code
         }
       })
@@ -636,7 +672,7 @@ export class ArcGISIdentityManager implements IAuthenticationManager {
           );
         })
         .catch((e) => {
-          return reportError(e.message, e.error, state.originalUrl);
+          return reportError(e.originalMessage, e.code, state.originalUrl);
         });
     }
 
@@ -1742,11 +1778,11 @@ UserSession.completeOAuth2 = function (
   ...args: Parameters<typeof ArcGISIdentityManager.completeOAuth2>
 ) {
   console.warn(
-    "DEPRECATED:, 'UserSession.completeOAuth2' is deprecated. Use 'ArcGISIdentityManager.completeOAuth2' instead."
+    "DEPRECATED:, 'UserSession.completeOAuth2()' is deprecated. Use 'ArcGISIdentityManager.completeOAuth2()' instead."
   );
   if (args.length <= 1) {
     console.warn(
-      "WARNING:, 'UserSession.completeOAuth2' is now async and returns a promise the resolves to an instance of `ArcGISIdentityManager`."
+      "WARNING:, 'UserSession.completeOAuth2()' is now async and returns a promise the resolves to an instance of `ArcGISIdentityManager`."
     );
   }
 

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -13,7 +13,8 @@ import {
   ArcGISTokenRequestError,
   ArcGISTokenRequestErrorCodes,
   IServerInfo,
-  ITokenRequestOptions
+  ITokenRequestOptions,
+  IOAuth2Options
 } from "../src/index.js";
 import { FormData } from "@esri/arcgis-rest-form-data";
 import {
@@ -832,7 +833,8 @@ describe("ArcGISIdentityManager", () => {
         token: "token",
         username: "c@sey",
         refreshToken: "refreshToken",
-        refreshTokenExpires: TOMORROW
+        refreshTokenExpires: TOMORROW,
+        redirectUri: "https://example-app.com/redirect-uri"
       });
 
       expect(session.canRefresh).toBe(true);
@@ -1526,6 +1528,57 @@ describe("ArcGISIdentityManager", () => {
             .then(() => {
               expect(MockWindow.location.href).toBe(
                 "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId12345&response_type=code&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=%7B%22id%22%3A%22AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%22%2C%22originalUrl%22%3A%22https%3A%2F%2Ftest.com%22%7D&locale=&style=&code_challenge_method=S256&code_challenge=DwBzhbb51LfusnSGBa_hqYSgo7-j8BTQnip4TOnlzRo"
+              );
+            })
+            .catch((e) => {
+              fail(e);
+            });
+        });
+
+        it("should fallback to window.location.href if redirect URI is omitted in a popup workflow", () => {
+          let PopupMockWindow: any;
+
+          fetchMock.once("*", {
+            access_token: "token",
+            expires_in: 1800,
+            username: "c@sey",
+            ssl: true,
+            refresh_token: "refresh_token",
+            refresh_token_expires_in: 1209600
+          });
+
+          window.addEventListener("arcgis-rest-js-popup-auth-start", () => {
+            PopupMockWindow = createMock();
+            PopupMockWindow.location.href = "http://example-app.com/redirect";
+            PopupMockWindow.location.search =
+              "?code=auth_code&state=%7B%22id%22%3A%22AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%22%2C%22originalUrl%22%3A%22https%3A%2F%2Ftest.com%22%7D";
+            PopupMockWindow.opener = MockWindow;
+
+            ArcGISIdentityManager.completeOAuth2(
+              {
+                clientId: "clientId1234"
+              } as any,
+              PopupMockWindow
+            );
+          });
+
+          return ArcGISIdentityManager.beginOAuth2(
+            {
+              clientId: "clientId1234",
+              redirectUri: "http://example-app.com/redirect"
+            },
+            MockWindow
+          )
+            .then((session) => {
+              expect(MockWindow.open).toHaveBeenCalledWith(
+                "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId1234&response_type=code&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=%7B%22id%22%3A%22AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%22%2C%22originalUrl%22%3A%22https%3A%2F%2Ftest.com%22%7D&locale=&style=&code_challenge_method=S256&code_challenge=DwBzhbb51LfusnSGBa_hqYSgo7-j8BTQnip4TOnlzRo",
+                "oauth-window",
+                "height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes"
+              );
+
+              expect(PopupMockWindow.close).toHaveBeenCalled();
+              expect(session.redirectUri).toBe(
+                "http://example-app.com/redirect"
               );
             })
             .catch((e) => {

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -589,7 +589,8 @@ describe("request()", () => {
         token: "INVALID_TOKEN",
         username: "c@sey",
         refreshToken: "refreshToken",
-        refreshTokenExpires: FIVE_DAYS_FROM_NOW
+        refreshTokenExpires: FIVE_DAYS_FROM_NOW,
+        redirectUri: "https://example-app.com/redirect-uri"
       });
 
       expect(session.canRefresh).toBe(true);
@@ -632,7 +633,8 @@ describe("request()", () => {
         token: "INVALID_TOKEN",
         username: "c@sey",
         refreshToken: "refreshToken",
-        refreshTokenExpires: TOMORROW
+        refreshTokenExpires: TOMORROW,
+        redirectUri: "https://example-app.com/redirect-uri"
       });
 
       expect(session.canRefresh).toBe(true);
@@ -670,7 +672,8 @@ describe("request()", () => {
         token: "INVALID_TOKEN",
         username: "c@sey",
         refreshToken: "refreshToken",
-        refreshTokenExpires: TOMORROW
+        refreshTokenExpires: TOMORROW,
+        redirectUri: "https://example-app.com/redirect-uri"
       });
 
       fetchMock.post("https://www.arcgis.com/sharing/rest/oauth2/token", {
@@ -708,7 +711,8 @@ describe("request()", () => {
         token: "TOKEN",
         username: "c@sey",
         refreshToken: "refreshToken",
-        refreshTokenExpires: FIVE_DAYS_FROM_NOW
+        refreshTokenExpires: FIVE_DAYS_FROM_NOW,
+        redirectUri: "https://example-app.com/redirect-uri"
       });
 
       fetchMock.post("https://www.arcgis.com/sharing/rest/oauth2/token", {


### PR DESCRIPTION
This fixes both #995 and #1006.

The root cause of #995 was assuming that query params could not be included in oAuth redirect URIs, when in fact they can be. Any query params in the redirect URI are expected to be placed back on the redirect URI in addition to any oauth query params like `code` and `error`. To resolve this you now must pass `redirectUri` in `completeOAuth2()` like you did in 3.x. This was still documented that was but some demo code committed it. I left the existing code path in for people who leave out `redirectUri`.

To resolve #1006 we now properly set `redirectUri` on the instance of `ArcGISIdentityManager` in `beginOAuth2()`, `completeOauth2()` and `fromToken()` when it is provided. `canRefresh()` now also checks for `redirectUri` since if it isn't defined you cannot exchange refresh tokens.

This also fixes a bug where if you did pass an invalid redirect URI or client id to `completeOauth2()` in a popup it would not register it as an error.

The changes to the browser oauth demo are just prettier + adding the redirect URL to the popup page.