### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: "Bug report"
+description: Report an issue with ArcGIS REST JS
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: Please include a clear and concise description of the bug. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: A link to a public repository, codepen, or jsbin (you can start with https://codepen.io/pen?template=YzpGqep) that reproduces the issue, along with a step by step explanation of how to see the issue. If no reproduction case is provided within a reasonable time-frame, the issue will be closed.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: "Please include browser console around the time this bug occurred. Please try not to insert an image but copy paste the log text."
+      render: shell
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Info
+      description: Please include which version of ArcGIS REST JS you are using and the output of `npx envinfo --system --binaries --browsers --npmPackages "{@esri/arcgis-rest-request,@esri/arcgis-rest-feature-service,@esri/arcgis-rest-geocoding,@esri/arcgis-rest-routing,@esri/arcgis-rest-demographics,@esri/arcgis-rest-portal}"`
+      render: shell
+      placeholder: "ArcGIS REST JS version: `v_._._`"
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Information
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Esri Community
+    url: https://community.esri.com/t5/arcgis-rest-js/ct-p/arcgis-rest-js
+    about: Ask questions and discuss with other ArcGIS REST JS users.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: "Feature Request"
+description: Suggest an idea for ArcGIS REST JS
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request this feature!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the problem
+      description: Please provide a clear and concise description the problem this feature would solve. The more information you can provide here, the better.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the proposed solution
+      description: Please provide a clear and concise description of what you would like to happen.
+      placeholder: I would like to see...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: "Please provide a clear and concise description of any alternative solutions or features you've considered."
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Information
+      description: Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Adds issue templates so that when someone clicks "new issue" in GitHub they will be presented with options something like this:
![image](https://user-images.githubusercontent.com/209355/189434613-377acc48-ea70-4cfc-94d6-2521c68cec94.png)
