### PR TITLE
Added Params Preprocessor for GP Mutilvalue Inputs

### DIFF
--- a/packages/arcgis-rest-request/src/job.ts
+++ b/packages/arcgis-rest-request/src/job.ts
@@ -45,6 +45,11 @@ export interface ISubmitJobOptions {
   params: any;
 
   /**
+   * Processes arrays to JSON strings for Geoprocessing services. See “GPMultiValue” in {@link https://developers.arcgis.com/rest/services-reference/enterprise/gp-data-types.htm}
+   */
+  processedParams: any;
+
+  /**
    * The base URL of the job without `/submitJob` or a trailing job id.
    */
   url: string;
@@ -188,10 +193,19 @@ export class Job {
       ...requestOptions
     };
 
+    /**
+     * Processes arrays to JSON strings for Geoprocessing services. See “GPMultiValue” in {@link https://developers.arcgis.com/rest/services-reference/enterprise/gp-data-types.htm}
+     */
+    const processedParams = Object.keys(params).reduce((newParams:any, key)=> {
+    const value = params[key]
+    const type = value.constructor.name;
+    newParams[key] = type === "Array" ? JSON.stringify(value) : value;
+    return newParams;
+    }, {});
     const baseUrl = cleanUrl(url.replace(/\/submitJob\/?/, ""));
     const submitUrl = baseUrl + "/submitJob";
     return request(submitUrl, {
-      params,
+      params: processedParams,
       authentication
     }).then(
       (response) =>

--- a/packages/arcgis-rest-request/src/job.ts
+++ b/packages/arcgis-rest-request/src/job.ts
@@ -4,6 +4,7 @@ import { ArcGISJobError } from "./utils/ArcGISJobError.js";
 import { JOB_STATUSES } from "./types/job-statuses.js";
 import { IAuthenticationManager } from "./utils/IAuthenticationManager.js";
 import mitt from "mitt";
+import { processJobParams } from "./utils/process-job-params.js";
 
 /**
  * Options for creating a new {@linkcode Job}.
@@ -169,20 +170,7 @@ export class Job {
       return new Job(jobOptions);
     });
   }
-  
-  /**
-   * Processes arrays to JSON strings for Geoprocessing services. See “GPMultiValue” in {@link https://developers.arcgis.com/rest/services-reference/enterprise/gp-data-types.htm}
-   */
-  static processedParamsFunc(params:any) {
-    const processedParams = Object.keys(params).reduce((newParams:any, key)=> {
-      const value = params[key]
-      const type = value.constructor.name;
-      newParams[key] = type === "Array" ? JSON.stringify(value) : value;
-      return newParams;
-      }, {});
-      
-      return processedParams
-  }
+
   /**
    * Submits a job request that will return a new instance of {@linkcode Job}.
    *
@@ -201,7 +189,7 @@ export class Job {
       ...requestOptions
     };
 
-    const processedParams = this.processedParamsFunc(params);
+    const processedParams = processJobParams(params);
     const baseUrl = cleanUrl(url.replace(/\/submitJob\/?/, ""));
     const submitUrl = baseUrl + "/submitJob";
     return request(submitUrl, {

--- a/packages/arcgis-rest-request/src/job.ts
+++ b/packages/arcgis-rest-request/src/job.ts
@@ -169,7 +169,20 @@ export class Job {
       return new Job(jobOptions);
     });
   }
-
+  
+  /**
+   * Processes arrays to JSON strings for Geoprocessing services. See “GPMultiValue” in {@link https://developers.arcgis.com/rest/services-reference/enterprise/gp-data-types.htm}
+   */
+  static processedParamsFunc(params:any) {
+    const processedParams = Object.keys(params).reduce((newParams:any, key)=> {
+      const value = params[key]
+      const type = value.constructor.name;
+      newParams[key] = type === "Array" ? JSON.stringify(value) : value;
+      return newParams;
+      }, {});
+      
+      return processedParams
+  }
   /**
    * Submits a job request that will return a new instance of {@linkcode Job}.
    *
@@ -188,15 +201,7 @@ export class Job {
       ...requestOptions
     };
 
-    /**
-     * Processes arrays to JSON strings for Geoprocessing services. See “GPMultiValue” in {@link https://developers.arcgis.com/rest/services-reference/enterprise/gp-data-types.htm}
-     */
-    const processedParams = Object.keys(params).reduce((newParams:any, key)=> {
-    const value = params[key]
-    const type = value.constructor.name;
-    newParams[key] = type === "Array" ? JSON.stringify(value) : value;
-    return newParams;
-    }, {});
+    const processedParams = this.processedParamsFunc(params);
     const baseUrl = cleanUrl(url.replace(/\/submitJob\/?/, ""));
     const submitUrl = baseUrl + "/submitJob";
     return request(submitUrl, {
@@ -244,6 +249,7 @@ export class Job {
    * Internal handler for `setInterval()` used when polling.;
    */
   private setIntervalHandler: any;
+
 
   constructor(options: IJobOptions) {
     const { url, id, pollingRate, authentication }: Partial<IJobOptions> = {

--- a/packages/arcgis-rest-request/src/job.ts
+++ b/packages/arcgis-rest-request/src/job.ts
@@ -45,11 +45,6 @@ export interface ISubmitJobOptions {
   params: any;
 
   /**
-   * Processes arrays to JSON strings for Geoprocessing services. See “GPMultiValue” in {@link https://developers.arcgis.com/rest/services-reference/enterprise/gp-data-types.htm}
-   */
-  processedParams: any;
-
-  /**
    * The base URL of the job without `/submitJob` or a trailing job id.
    */
   url: string;

--- a/packages/arcgis-rest-request/src/utils/process-job-params.ts
+++ b/packages/arcgis-rest-request/src/utils/process-job-params.ts
@@ -1,0 +1,13 @@
+ /**
+   * Processes arrays to JSON strings for Geoprocessing services. See “GPMultiValue” in {@link https://developers.arcgis.com/rest/services-reference/enterprise/gp-data-types.htm}
+   */
+  export function processJobParams(params: any) {
+  const processedParams = Object.keys(params).reduce((newParams: any, key) => {
+    const value = params[key]
+    const type = value.constructor.name;
+    newParams[key] = type === "Array" ? JSON.stringify(value) : value;
+    return newParams;
+  }, {});
+
+  return processedParams
+}

--- a/packages/arcgis-rest-request/test/job.test.ts
+++ b/packages/arcgis-rest-request/test/job.test.ts
@@ -473,9 +473,7 @@ describe("Job", () => {
             mockHotspot_Raster
           );
         });
-        
         return job.getResult("Hotspot_Raster");
-        
       })
       .then((result) => {
         expect(result).toEqual(mockHotspot_Raster);
@@ -681,6 +679,55 @@ describe("Job", () => {
     Job.submitJob(GPEndpointCall).then((job) => {
       expect(job.isMonitoring).toEqual(true);
       done();
+
+    });
+  });
+
+  it("parses params if there is multi-value input", () => {
+    Job.processedParamsFunc({
+      url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/submitJob",
+      params: {
+        summarizeType: "['CentralFeature', 'MeanCenter', 'MedianCenter', 'Ellipse']",
+        weightField: 'NUM_TREES',
+        ellipseSize: '1 standard deviation',
+        context: {
+          extent: {
+            xmin: -15034729.266472297,
+            ymin: 5716733.479048933,
+            xmax: -12070195.56146081,
+            ymax: 7808050.572930799,
+            spatialReference: { wkid: 102100, latestWkid: 3857 },
+          },
+        },
+      }
+    });
+
+    expect(Job.processedParamsFunc({
+      summarizeType: ['CentralFeature', 'MeanCenter', 'MedianCenter', 'Ellipse'],
+      weightField: 'NUM_TREES',
+      ellipseSize: '1 standard deviation',
+      context: {
+        extent: {
+          xmin: -15034729.266472297,
+          ymin: 5716733.479048933,
+          xmax: -12070195.56146081,
+          ymax: 7808050.572930799,
+          spatialReference: { wkid: 102100, latestWkid: 3857 },
+        },
+      }
+    })).toEqual({
+      summarizeType:'["CentralFeature","MeanCenter","MedianCenter","Ellipse"]',
+      weightField: 'NUM_TREES',
+      ellipseSize: '1 standard deviation',
+      context: {
+        extent: {
+          xmin: -15034729.266472297,
+          ymin: 5716733.479048933,
+          xmax: -12070195.56146081,
+          ymax: 7808050.572930799,
+          spatialReference: { wkid: 102100, latestWkid: 3857 },
+        },
+      }
     });
   });
 

--- a/packages/arcgis-rest-request/test/job.test.ts
+++ b/packages/arcgis-rest-request/test/job.test.ts
@@ -1,5 +1,6 @@
 import fetchMock, { done } from "fetch-mock";
 import { Job, JOB_STATUSES, ArcGISRequestError } from "../src/index.js";
+import { processJobParams } from "../src/utils/process-job-params.js";
 import {
   GPJobIdResponse,
   GPEndpointCall,
@@ -684,7 +685,7 @@ describe("Job", () => {
   });
 
   it("parses params if there is multi-value input", () => {
-    Job.processedParamsFunc({
+    processJobParams({
       url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/submitJob",
       params: {
         summarizeType: "['CentralFeature', 'MeanCenter', 'MedianCenter', 'Ellipse']",
@@ -702,7 +703,7 @@ describe("Job", () => {
       }
     });
 
-    expect(Job.processedParamsFunc({
+    expect(processJobParams({
       summarizeType: ['CentralFeature', 'MeanCenter', 'MedianCenter', 'Ellipse'],
       weightField: 'NUM_TREES',
       ellipseSize: '1 standard deviation',

--- a/packages/arcgis-rest-request/test/mocks/job-mock-fetches.ts
+++ b/packages/arcgis-rest-request/test/mocks/job-mock-fetches.ts
@@ -1,8 +1,9 @@
 export const GPEndpointCall = {
   url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/submitJob",
   params: {
-    Query: `"DATE" > date '1998-01-01 00:00:00' AND "DATE" < date '1998-01-31 00:00:00') AND ("Day" = 'SUN' OR "Day"= 'SAT')
-  `
+    Query: `"DATE" > date '1998-01-01 00:00:00' AND "DATE" < date '1998-01-31 00:00:00') AND ("Day" = 'SUN' OR "Day"= 'SAT'),
+  `,
+    distance: [1, 2]
   },
   startMonitoring: true,
   pollingRate: 5000

--- a/packages/arcgis-rest-request/test/mocks/job-mock-fetches.ts
+++ b/packages/arcgis-rest-request/test/mocks/job-mock-fetches.ts
@@ -2,8 +2,7 @@ export const GPEndpointCall = {
   url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/submitJob",
   params: {
     Query: `"DATE" > date '1998-01-01 00:00:00' AND "DATE" < date '1998-01-31 00:00:00') AND ("Day" = 'SUN' OR "Day"= 'SAT'),
-  `,
-    distance: [1, 2]
+  `
   },
   startMonitoring: true,
   pollingRate: 5000


### PR DESCRIPTION
In `static submitJob`, the params passed in will be processed to check if there is a top level array, if so, `JSON.stringify(Array)`. 

Any MultiValue inputs can only be read as a JSON array. We do this before hitting the REST endpoint. Doubled checked with Mark Torrey with an example of his that this does in fact work.