### PR TITLE
fix: add error parameter to IEditFeatureResult

### DIFF
--- a/packages/arcgis-rest-feature-service/src/helpers.ts
+++ b/packages/arcgis-rest-feature-service/src/helpers.ts
@@ -50,24 +50,23 @@ export interface ISharedQueryOptions extends IGetLayerOptions {
 /**
  * Add, update and delete features result Object.
  */
-export type IEditFeatureResult = {
+export interface IEditFeatureResult {
   objectId: number;
   globalId?: string;
-  success: true;
-} | {
-  objectId: number;
-  globalId?: string;
-  success: false;
-  error: {
+  success: boolean;
+  /**
+   * Error is optional and is only returned when `success` is `false`.
+   */
+  error?: {
     code: number;
     description: string;
-  };
+  }
 }
 
 /**
  * `globalId` always returned with attachments via apply edits.
  */
-export type IApplyEditsAttachmentResult = IEditFeatureResult & {
+export interface IApplyEditsAttachmentResult extends IEditFeatureResult {
   globalId: string;
 }
 

--- a/packages/arcgis-rest-feature-service/src/helpers.ts
+++ b/packages/arcgis-rest-feature-service/src/helpers.ts
@@ -50,16 +50,24 @@ export interface ISharedQueryOptions extends IGetLayerOptions {
 /**
  * Add, update and delete features result Object.
  */
-export interface IEditFeatureResult {
+export type IEditFeatureResult = {
   objectId: number;
   globalId?: string;
-  success: boolean;
+  success: true;
+} | {
+  objectId: number;
+  globalId?: string;
+  success: false;
+  error: {
+    code: number;
+    description: string;
+  };
 }
 
 /**
  * `globalId` always returned with attachments via apply edits.
  */
-export interface IApplyEditsAttachmentResult extends IEditFeatureResult {
+export type IApplyEditsAttachmentResult = IEditFeatureResult & {
   globalId: string;
 }
 


### PR DESCRIPTION
the applyEdit results include an error object when success === false

see the spec here: https://developers.arcgis.com/rest/services-reference/enterprise/edit-result-object.htm
