### PR TITLE
types(feature-service) add/update attachment interfaces for apply edits

### DIFF
--- a/packages/arcgis-rest-feature-service/src/applyEdits.ts
+++ b/packages/arcgis-rest-feature-service/src/applyEdits.ts
@@ -8,7 +8,12 @@ import {
   IFeature
 } from "@esri/arcgis-rest-request";
 
-import { ISharedEditOptions, IApplyEditsResult } from "./helpers.js";
+import {
+  ISharedEditOptions,
+  IApplyEditsResult,
+  IApplyEditsAddAttachmentOptions,
+  IApplyEditsUpdateAttachmentOptions
+} from "./helpers.js";
 
 /**
  * Apply edits request options. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/apply-edits-feature-service-layer-.htm) for more information.
@@ -40,8 +45,8 @@ export interface IApplyEditsOptions extends ISharedEditOptions {
    * See [attachment](https://developers.arcgis.com/rest/services-reference/apply-edits-feature-service-layer-.htm) param details.
    */
   attachments?: {
-    adds?: any[];
-    updates?: any[];
+    adds?: IApplyEditsAddAttachmentOptions[];
+    updates?: IApplyEditsUpdateAttachmentOptions[];
     deletes?: string[];
   };
 }

--- a/packages/arcgis-rest-feature-service/src/helpers.ts
+++ b/packages/arcgis-rest-feature-service/src/helpers.ts
@@ -57,6 +57,54 @@ export interface IEditFeatureResult {
 }
 
 /**
+ * Shared add/update attachment options for apply edits.
+ */
+interface IApplyEditsSharedAttachmentOptions {
+  /**
+   * Attachment file content type.
+   */
+  contentType: string;
+  /**
+   * Name of the file including extension.
+   */
+  name: string;
+  /**
+   * Upload id of file to be attached.
+   */
+  uploadId?: string;
+  /**
+   * Base 64 encoded data of attachment.
+   */
+  data?: string;
+}
+
+/**
+ * Add attachment options for apply edits.
+ */
+export interface IApplyEditsAddAttachmentOptions
+  extends IApplyEditsSharedAttachmentOptions {
+  /**
+   * Global id of attachment (must be provided by client).
+   */
+  globalId: string;
+  /**
+   * Global id of feature to attach.
+   */
+  parentGlobalId: string;
+}
+
+/**
+ * Update attachment options for apply edits.
+ */
+export interface IApplyEditsUpdateAttachmentOptions
+  extends IApplyEditsSharedAttachmentOptions {
+  /**
+   * Global id of attachment.
+   */
+  globalId: string;
+}
+
+/**
  * `globalId` always returned with attachments via apply edits.
  */
 export interface IApplyEditsAttachmentResult extends IEditFeatureResult {


### PR DESCRIPTION
Add add/update attachment interfaces for apply edits.

Looking back at `applyEdits` not sure why I didn't include these at the time @patrickarlt. Here they are if you want to add them.