### PR TITLE
fix(arcgis-rest-request): added social providers

### DIFF
--- a/packages/arcgis-rest-request/src/types/user.ts
+++ b/packages/arcgis-rest-request/src/types/user.ts
@@ -45,6 +45,12 @@ export interface IUser {
   created?: number;
   modified?: number;
   groups?: IGroup[];
-  provider?: "arcgis" | "enterprise" | "facebook" | "google";
+  provider?:
+    | "arcgis"
+    | "enterprise"
+    | "facebook"
+    | "google"
+    | "apple"
+    | "github";
   id?: string;
 }


### PR DESCRIPTION
added the correct social providers:
https://developers.arcgis.com/rest/users-groups-and-items/user.htm#GUID-32113100-DC2C-41AA-924E-08E2CF686B00
![image](https://user-images.githubusercontent.com/209355/211402804-1f8a245b-e172-4d48-8f74-5b5c070deeac.png)

#978