### PR TITLE
chore: updated parcel demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ packages/**/test/mocks/**/*.d.ts
 packages/**/test/mocks/**/*.js
 packages/**/test/mocks/**/*.map
 
+# Parcel cache (for Parcel demo)
+.parcel-cache
+
 # Ignore built TypeDoc files
 typedoc
 

--- a/demos/parcel/.gitignore
+++ b/demos/parcel/.gitignore
@@ -1,1 +1,1 @@
-.cache
+.parcel-cache

--- a/demos/parcel/index.html
+++ b/demos/parcel/index.html
@@ -10,7 +10,7 @@
 
 <body>
   <h1>Welcome to Parcel!</h1>
-  <script src="/index.js"></script>
+  <script type="module" src="index.js"></script>
 </body>
 
 </html>

--- a/demos/parcel/index.js
+++ b/demos/parcel/index.js
@@ -4,5 +4,5 @@ let element = document.createElement("pre");
 document.body.appendChild(element);
 
 searchItems("water").then((response) => {
-  element.textContent = JSON.stringify(respons, null, 2); // false
+  element.textContent = JSON.stringify(response, null, 2); // false
 });

--- a/demos/parcel/package.json
+++ b/demos/parcel/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@esri/arcgis-rest-demo-parcel",
   "version": "3.3.0",
-  "description": "Demo of @esri/arcgis-rest-* w/ Snowpack",
+  "description": "Demo of @esri/arcgis-rest-* w/ Parcel",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
     "@esri/arcgis-rest-request": "^4.0.0"
   },
   "devDependencies": {
-    "parcel-bundler": "^1.12.5"
+    "parcel": "^2.0.0"
   },
   "author": ""
 }


### PR DESCRIPTION
Parcel v1 [is deprecated](https://www.npmjs.com/package/parcel-bundler). This PR updates our "Parcel" demo to the latest version of Parcel (v2) (by following the [upgrade documentation](https://v2.parceljs.org/getting-started/migration))

