### PR TITLE
Add Node 18 to tests, update to fetch-mock@9

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16]
+        node: [18]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
 
       - name: NPM Install
         run: npm install
@@ -29,7 +29,7 @@ jobs:
         run: npm run docs:build
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: docs/build # The folder the action should deploy.

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [14, 16]
+        node: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16]
+        node: [18]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 
@@ -59,10 +59,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16.13
+          node-version: 18
 
       - name: Install
         run: npm ci

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -13,9 +13,8 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // "packages/!(arcgis-rest-auth)/{src,test}/**/!(*.test.live).ts",
-      "packages/!(arcgis-rest-auth)/src/**/!(*.test.live).ts",
-      "packages/arcgis-rest-demographics/test/getAvailableCountries.test.ts",
+      // uncomment this line to restore the full test suite
+      "packages/!(arcgis-rest-auth)/{src,test}/**/!(*.test.live).ts",
       "scripts/test-helpers.ts"
     ],
 
@@ -49,7 +48,20 @@ module.exports = function (config) {
       },
       tsconfig: "./tsconfig.json",
       bundlerOptions: {
-        transforms: [require("karma-typescript-es6-transform")()],
+        transforms: [
+          require("karma-typescript-es6-transform")({
+            presets: [
+              [
+                "env",
+                {
+                  targets: {
+                    browsers: ["last 2 Chrome versions"]
+                  }
+                }
+              ]
+            ]
+          })
+        ],
         resolve: {
           // karmas resolver cant figure out the symlinked deps from lerna
           // so we need to manually alias each package here.

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -13,7 +13,6 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // uncomment this line to restore the full test suite
       "packages/!(arcgis-rest-auth)/{src,test}/**/!(*.test.live).ts",
       "scripts/test-helpers.ts"
     ],
@@ -26,7 +25,7 @@ module.exports = function (config) {
 
     karmaTypescriptConfig: {
       coverageOptions: {
-        instrumentation: false,
+        instrumentation: true,
         threshold: {
           global: {
             statements: 100,

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -13,7 +13,9 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      "packages/!(arcgis-rest-auth)/{src,test}/**/!(*.test.live).ts",
+      // "packages/!(arcgis-rest-auth)/{src,test}/**/!(*.test.live).ts",
+      "packages/!(arcgis-rest-auth)/src/**/!(*.test.live).ts",
+      "packages/arcgis-rest-demographics/test/getAvailableCountries.test.ts",
       "scripts/test-helpers.ts"
     ],
 
@@ -25,6 +27,7 @@ module.exports = function (config) {
 
     karmaTypescriptConfig: {
       coverageOptions: {
+        instrumentation: false,
         threshold: {
           global: {
             statements: 100,

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@types/node": "^12.20.4",
         "@typescript-eslint/eslint-plugin": "^4.4.0",
         "@typescript-eslint/parser": "^4.31.0",
+        "babel-preset-env": "^1.7.0",
         "browser-sync": "^2.27.9",
         "eslint": "^7.11.0",
         "eslint-config-prettier": "^6.12.0",
@@ -444,9 +445,10 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.15.0",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
+      "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -508,57 +510,54 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.16.0",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
+      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.16.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.20.7",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/generator/node_modules/source-map": {
-      "version": "0.5.7",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.15.4",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.18.9.tgz",
+      "integrity": "sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-explode-assignable-expression": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-explode-assignable-expression": "^7.18.6",
+        "@babel/types": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.15.4",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.15.0",
-        "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.16.6",
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -566,6 +565,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -576,17 +584,26 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.16.0",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz",
+      "integrity": "sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-member-expression-to-functions": "^7.16.0",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/helper-replace-supers": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-member-expression-to-functions": "^7.20.7",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/helper-replace-supers": "^7.20.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/helper-split-export-declaration": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -596,12 +613,13 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.14.5",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.20.5.tgz",
+      "integrity": "sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.14.5",
-        "regexpu-core": "^4.7.1"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "regexpu-core": "^5.2.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -611,14 +629,13 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.2.4",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+      "integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
@@ -630,202 +647,231 @@
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-explode-assignable-expression": {
-      "version": "7.15.4",
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-explode-assignable-expression": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz",
+      "integrity": "sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==",
+      "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.16.0",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.16.0",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
+      "integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.15.4",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.15.4",
-        "@babel/helper-replace-supers": "^7.15.4",
-        "@babel/helper-simple-access": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.15.4",
-        "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.10",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
+      "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.14.5",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.15.4",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.18.9.tgz",
+      "integrity": "sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.15.4",
-        "@babel/helper-wrap-function": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-wrap-function": "^7.18.9",
+        "@babel/types": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.16.0",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz",
+      "integrity": "sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.16.0",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-member-expression-to-functions": "^7.20.7",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.15.4",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.15.4",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
+      "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.20.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.15.4",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.20.5.tgz",
+      "integrity": "sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.20.5",
+        "@babel/types": "^7.20.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -845,11 +891,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -871,9 +918,10 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.16.0",
+      "version": "7.20.15",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz",
+      "integrity": "sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -881,14 +929,30 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.15.4",
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.18.6.tgz",
+      "integrity": "sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.15.4",
-        "@babel/plugin-proposal-optional-chaining": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.20.7.tgz",
+      "integrity": "sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -898,12 +962,14 @@
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.15.4",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz",
+      "integrity": "sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-remap-async-to-generator": "^7.15.4",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-remap-async-to-generator": "^7.18.9",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
       },
       "engines": {
@@ -914,12 +980,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -929,12 +996,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-class-static-block": {
-      "version": "7.15.4",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.20.7.tgz",
+      "integrity": "sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-create-class-features-plugin": "^7.20.7",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       },
       "engines": {
@@ -945,11 +1013,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-dynamic-import": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.18.6.tgz",
+      "integrity": "sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3"
       },
       "engines": {
@@ -960,11 +1029,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz",
+      "integrity": "sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.9",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
       },
       "engines": {
@@ -975,11 +1045,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-json-strings": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.18.6.tgz",
+      "integrity": "sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-json-strings": "^7.8.3"
       },
       "engines": {
@@ -990,11 +1061,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.14.5",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz",
+      "integrity": "sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       },
       "engines": {
@@ -1005,11 +1077,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
+      "integrity": "sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
       },
       "engines": {
@@ -1020,11 +1093,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-numeric-separator": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.18.6.tgz",
+      "integrity": "sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
       },
       "engines": {
@@ -1035,15 +1109,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.15.6",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
+      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.15.4"
+        "@babel/plugin-transform-parameters": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1053,11 +1128,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.18.6.tgz",
+      "integrity": "sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       },
       "engines": {
@@ -1068,12 +1144,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.14.5",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.20.7.tgz",
+      "integrity": "sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       },
       "engines": {
@@ -1084,12 +1161,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-methods": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1099,13 +1177,14 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.15.4",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.20.5.tgz",
+      "integrity": "sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.15.4",
-        "@babel/helper-create-class-features-plugin": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.20.5",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       },
       "engines": {
@@ -1116,12 +1195,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.18.6.tgz",
+      "integrity": "sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=4"
@@ -1132,8 +1212,9 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -1154,8 +1235,9 @@
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -1168,8 +1250,9 @@
     },
     "node_modules/@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -1179,8 +1262,9 @@
     },
     "node_modules/@babel/plugin-syntax-export-namespace-from": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.3"
       },
@@ -1188,10 +1272,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.20.0.tgz",
+      "integrity": "sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.19.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -1201,8 +1301,9 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -1212,8 +1313,9 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -1223,8 +1325,9 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -1234,8 +1337,9 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -1245,8 +1349,9 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -1256,8 +1361,9 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -1267,8 +1373,9 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -1294,11 +1401,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.14.5",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.20.7.tgz",
+      "integrity": "sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1308,13 +1416,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.14.5",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.20.7.tgz",
+      "integrity": "sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-remap-async-to-generator": "^7.14.5"
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-remap-async-to-generator": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1324,11 +1433,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.18.6.tgz",
+      "integrity": "sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1338,11 +1448,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.15.3",
+      "version": "7.20.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.15.tgz",
+      "integrity": "sha512-Vv4DMZ6MiNOhu/LdaZsT/bsLRxgL94d269Mv4R/9sp6+Mp++X/JqypZYypJXLlM4mlL352/Egzbzr98iABH1CA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1352,16 +1463,19 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.15.4",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.7.tgz",
+      "integrity": "sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-optimise-call-expression": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-replace-supers": "^7.20.7",
+        "@babel/helper-split-export-declaration": "^7.18.6",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1373,18 +1487,21 @@
     },
     "node_modules/@babel/plugin-transform-classes/node_modules/globals": {
       "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.14.5",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.20.7.tgz",
+      "integrity": "sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/template": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1394,11 +1511,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.14.7",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.7.tgz",
+      "integrity": "sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1408,12 +1526,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.18.6.tgz",
+      "integrity": "sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1423,11 +1542,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.18.9.tgz",
+      "integrity": "sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1437,12 +1557,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.18.6.tgz",
+      "integrity": "sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1452,11 +1573,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.15.4",
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.8.tgz",
+      "integrity": "sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1466,12 +1588,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.18.9.tgz",
+      "integrity": "sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1481,11 +1605,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.18.9.tgz",
+      "integrity": "sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1495,11 +1620,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.18.6.tgz",
+      "integrity": "sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1509,13 +1635,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.14.5",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.20.11.tgz",
+      "integrity": "sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1525,14 +1651,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.15.4",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
+      "integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-simple-access": "^7.15.4",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-simple-access": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1542,15 +1668,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.15.4",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.20.11.tgz",
+      "integrity": "sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-module-transforms": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-validator-identifier": "^7.19.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1560,12 +1686,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.18.6.tgz",
+      "integrity": "sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-module-transforms": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1575,11 +1702,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.14.9",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.20.5.tgz",
+      "integrity": "sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.14.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.20.5",
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1589,11 +1718,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.18.6.tgz",
+      "integrity": "sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1603,12 +1733,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
+      "integrity": "sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-replace-supers": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1618,11 +1749,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.15.4",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.7.tgz",
+      "integrity": "sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1632,11 +1764,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.18.6.tgz",
+      "integrity": "sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1646,11 +1779,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.14.5",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.20.5.tgz",
+      "integrity": "sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "regenerator-transform": "^0.14.2"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "regenerator-transform": "^0.15.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1660,11 +1795,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.18.6.tgz",
+      "integrity": "sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1674,11 +1810,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.18.6.tgz",
+      "integrity": "sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1688,12 +1825,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.14.6",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.20.7.tgz",
+      "integrity": "sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1703,11 +1841,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.18.6.tgz",
+      "integrity": "sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1717,11 +1856,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.18.9.tgz",
+      "integrity": "sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1731,11 +1871,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.18.9.tgz",
+      "integrity": "sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1745,11 +1886,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.14.5",
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz",
+      "integrity": "sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1759,12 +1901,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.18.6.tgz",
+      "integrity": "sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1774,35 +1917,38 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.15.6",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
+      "integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
-        "@babel/plugin-proposal-async-generator-functions": "^7.15.4",
-        "@babel/plugin-proposal-class-properties": "^7.14.5",
-        "@babel/plugin-proposal-class-static-block": "^7.15.4",
-        "@babel/plugin-proposal-dynamic-import": "^7.14.5",
-        "@babel/plugin-proposal-export-namespace-from": "^7.14.5",
-        "@babel/plugin-proposal-json-strings": "^7.14.5",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
-        "@babel/plugin-proposal-numeric-separator": "^7.14.5",
-        "@babel/plugin-proposal-object-rest-spread": "^7.15.6",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
-        "@babel/plugin-proposal-optional-chaining": "^7.14.5",
-        "@babel/plugin-proposal-private-methods": "^7.14.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.15.4",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
+        "@babel/compat-data": "^7.20.1",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
+        "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-class-static-block": "^7.18.6",
+        "@babel/plugin-proposal-dynamic-import": "^7.18.6",
+        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
+        "@babel/plugin-proposal-json-strings": "^7.18.6",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
+        "@babel/plugin-proposal-numeric-separator": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.2",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
+        "@babel/plugin-proposal-optional-chaining": "^7.18.9",
+        "@babel/plugin-proposal-private-methods": "^7.18.6",
+        "@babel/plugin-proposal-private-property-in-object": "^7.18.6",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.18.6",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
         "@babel/plugin-syntax-class-static-block": "^7.14.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -1812,44 +1958,44 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
-        "@babel/plugin-transform-arrow-functions": "^7.14.5",
-        "@babel/plugin-transform-async-to-generator": "^7.14.5",
-        "@babel/plugin-transform-block-scoped-functions": "^7.14.5",
-        "@babel/plugin-transform-block-scoping": "^7.15.3",
-        "@babel/plugin-transform-classes": "^7.15.4",
-        "@babel/plugin-transform-computed-properties": "^7.14.5",
-        "@babel/plugin-transform-destructuring": "^7.14.7",
-        "@babel/plugin-transform-dotall-regex": "^7.14.5",
-        "@babel/plugin-transform-duplicate-keys": "^7.14.5",
-        "@babel/plugin-transform-exponentiation-operator": "^7.14.5",
-        "@babel/plugin-transform-for-of": "^7.15.4",
-        "@babel/plugin-transform-function-name": "^7.14.5",
-        "@babel/plugin-transform-literals": "^7.14.5",
-        "@babel/plugin-transform-member-expression-literals": "^7.14.5",
-        "@babel/plugin-transform-modules-amd": "^7.14.5",
-        "@babel/plugin-transform-modules-commonjs": "^7.15.4",
-        "@babel/plugin-transform-modules-systemjs": "^7.15.4",
-        "@babel/plugin-transform-modules-umd": "^7.14.5",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
-        "@babel/plugin-transform-new-target": "^7.14.5",
-        "@babel/plugin-transform-object-super": "^7.14.5",
-        "@babel/plugin-transform-parameters": "^7.15.4",
-        "@babel/plugin-transform-property-literals": "^7.14.5",
-        "@babel/plugin-transform-regenerator": "^7.14.5",
-        "@babel/plugin-transform-reserved-words": "^7.14.5",
-        "@babel/plugin-transform-shorthand-properties": "^7.14.5",
-        "@babel/plugin-transform-spread": "^7.14.6",
-        "@babel/plugin-transform-sticky-regex": "^7.14.5",
-        "@babel/plugin-transform-template-literals": "^7.14.5",
-        "@babel/plugin-transform-typeof-symbol": "^7.14.5",
-        "@babel/plugin-transform-unicode-escapes": "^7.14.5",
-        "@babel/plugin-transform-unicode-regex": "^7.14.5",
-        "@babel/preset-modules": "^0.1.4",
-        "@babel/types": "^7.15.6",
-        "babel-plugin-polyfill-corejs2": "^0.2.2",
-        "babel-plugin-polyfill-corejs3": "^0.2.2",
-        "babel-plugin-polyfill-regenerator": "^0.2.2",
-        "core-js-compat": "^3.16.0",
+        "@babel/plugin-transform-arrow-functions": "^7.18.6",
+        "@babel/plugin-transform-async-to-generator": "^7.18.6",
+        "@babel/plugin-transform-block-scoped-functions": "^7.18.6",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/plugin-transform-classes": "^7.20.2",
+        "@babel/plugin-transform-computed-properties": "^7.18.9",
+        "@babel/plugin-transform-destructuring": "^7.20.2",
+        "@babel/plugin-transform-dotall-regex": "^7.18.6",
+        "@babel/plugin-transform-duplicate-keys": "^7.18.9",
+        "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
+        "@babel/plugin-transform-for-of": "^7.18.8",
+        "@babel/plugin-transform-function-name": "^7.18.9",
+        "@babel/plugin-transform-literals": "^7.18.9",
+        "@babel/plugin-transform-member-expression-literals": "^7.18.6",
+        "@babel/plugin-transform-modules-amd": "^7.19.6",
+        "@babel/plugin-transform-modules-commonjs": "^7.19.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.19.6",
+        "@babel/plugin-transform-modules-umd": "^7.18.6",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
+        "@babel/plugin-transform-new-target": "^7.18.6",
+        "@babel/plugin-transform-object-super": "^7.18.6",
+        "@babel/plugin-transform-parameters": "^7.20.1",
+        "@babel/plugin-transform-property-literals": "^7.18.6",
+        "@babel/plugin-transform-regenerator": "^7.18.6",
+        "@babel/plugin-transform-reserved-words": "^7.18.6",
+        "@babel/plugin-transform-shorthand-properties": "^7.18.6",
+        "@babel/plugin-transform-spread": "^7.19.0",
+        "@babel/plugin-transform-sticky-regex": "^7.18.6",
+        "@babel/plugin-transform-template-literals": "^7.18.9",
+        "@babel/plugin-transform-typeof-symbol": "^7.18.9",
+        "@babel/plugin-transform-unicode-escapes": "^7.18.10",
+        "@babel/plugin-transform-unicode-regex": "^7.18.6",
+        "@babel/preset-modules": "^0.1.5",
+        "@babel/types": "^7.20.2",
+        "babel-plugin-polyfill-corejs2": "^0.3.3",
+        "babel-plugin-polyfill-corejs3": "^0.6.0",
+        "babel-plugin-polyfill-regenerator": "^0.4.1",
+        "core-js-compat": "^3.25.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -1868,9 +2014,10 @@
       }
     },
     "node_modules/@babel/preset-modules": {
-      "version": "0.1.4",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
+      "integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
@@ -1881,6 +2028,12 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==",
+      "dev": true
     },
     "node_modules/@babel/runtime": {
       "version": "7.15.4",
@@ -1899,41 +2052,45 @@
       "license": "MIT"
     },
     "node_modules/@babel/template": {
-      "version": "7.16.0",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.16.0"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.16.0",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.20.13",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1942,11 +2099,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.16.0"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1961,11 +2119,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.16.0",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -15938,6 +16098,150 @@
         "follow-redirects": "^1.14.0"
       }
     },
+    "node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
+      "dev": true
+    },
+    "node_modules/babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha512-gCtfYORSG1fUMX4kKraymq607FWgMWg+j42IFPc18kFQEsmtaibP4UrqsXt8FlEJle25HUd4tsoDR7H2wDhe9Q==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha512-RL8n2NiEj+kKztlrVJM9JT1cXzzAdvWFh76xh/H1I4nKwunzE4INBXn8ieCZ+wh4zWszZk7NBS1s/8HR5jDkzQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha512-bHkmjcC9lM1kmZcVpA5t2om2nzT/xiZpo6TJq7UlZ3wqKfzia4veeXbIhKvJXAMzhhEBd3cR1IElL5AenWEUpA==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha512-qe5csbhbvq6ccry9G7tkXbzNtcDiH4r51rrPUbwwoTzZ18AqxWYRZT6AOmxrpxKnQBW0pYlBI/8vh73Z//78nQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha512-Oo6+e2iX+o9eVvJ9Y5eKL5iryeRdsIkwRYheCuhYdVHsdEQysbc2z2QkqCLIYnNxkT5Ss3ggrHdXiDI7Dhrn4Q==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha512-WfgKFX6swFB1jS2vo+DwivRN4NB8XUdM3ij0Y1gnC21y1tdBoe6xjVnd7NSI6alv+gZXCtJqvrTeMW3fR/c0ng==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha512-zAYl3tqerLItvG5cKYw7f1SpvIxS9zi7ohyGHaI9cgDUjAT6YcY9jIEH5CstetP5wHIVSceXwNS7Z5BpJg+rOw==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha512-Op9IhEaxhbRT8MDXx2iNuMgciu2V8lDvYCNQbDGjdBNCjaMvyLf4wl4A3b8IgndCyQF8TwfgsQ8T3VD8aX1/pA==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha512-VlPiWmqmGJp0x0oK27Out1D+71nVVCTSdlbhIVoaBAj2lUgrNjBCRR9+llO4lTSb2O4r7PJg+RobRkhBrf6ofg==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha512-RYqaPD0mQyQIFRu7Ho5wE2yvA/5jxqCIj/Lv4BXNq23mHYu/vxikOy2JueLiBxQknwapwrJeNCesvY0ZcfnlHg==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha512-sLI+u7sXJh6+ToqDr57Bv973kCepItDhMou0xCP2YPVmR1jkHSCY+p1no8xErbV1Siz5QE8qKT1WIwybSWlqjw==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
     "node_modules/babel-loader": {
       "version": "8.2.3",
       "dev": true,
@@ -15956,21 +16260,32 @@
         "webpack": ">=2"
       }
     },
-    "node_modules/babel-plugin-dynamic-import-node": {
-      "version": "2.3.3",
+    "node_modules/babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "object.assign": "^4.1.0"
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha512-B1M5KBP29248dViEo1owyY32lk1ZSH2DaNNrXLGt8lyjjHm7pBqAdQ7VKUPR6EEDO323+OvT3MQXbCin8ooWdA==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.2.3",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+      "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
         "semver": "^6.1.1"
       },
       "peerDependencies": {
@@ -15979,33 +16294,372 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.2.4",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+      "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.2.2",
-        "core-js-compat": "^3.14.0"
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
+        "core-js-compat": "^3.25.1"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.2.3",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+      "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.2.4"
+        "@babel/helper-define-polyfill-provider": "^0.3.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha512-4Zp4unmHgw30A1eWI5EpACji2qMocisdXhAftfhXoSV9j0Tvj6nRFE3tOmRY912E0FMRm/L5xWE7MGVT2FoLnw==",
+      "dev": true
+    },
+    "node_modules/babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha512-Z/flU+T9ta0aIEKl1tGEmN/pZiI1uXmCiGFRegKacQfEJzp7iNsKloZmyJlQr+75FCJtiFfGIK03SiCvCt9cPQ==",
+      "dev": true
+    },
+    "node_modules/babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha512-Gx9CH3Q/3GKbhs07Bszw5fPTlU+ygrOGfAhEt7W2JICwufpC4SuO0mG0+4NykPBSYPMJhqvVlDBU17qB1D+hMQ==",
+      "dev": true
+    },
+    "node_modules/babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha512-7BgYJujNCg0Ti3x0c/DL3tStvnKS6ktIYOmo9wginv/dfZOrbSZ+qG4IRRHMBOzZ5Awb1skTiAsQXg/+IWkZYw==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha512-PCqwwzODXW7JMrzu+yZIaYbPQSKjDTAsNNlK2l5Gg9g4rz2VzLnZsStvp/3c46GfXpwkyufb3NCyG9+50FF1Vg==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha512-2+ujAT2UMBzYFm7tidUsYh+ZoIutxJ3pN9IYrF1/H6dCKtECfhmB8UkHVpyxDwkj0CYbQG35ykoz925TUnBc3A==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha512-YiN6sFAQ5lML8JjCmr7uerS5Yc/EMbgg9G8ZNmk2E3nYX4ckHR01wrkeeMijEf5WHNK5TW0Sl0Uu3pv3EdOJWw==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha512-5Dy7ZbRinGrNtmWpquZKZ3EGY8sDgIVB4CU8Om8q8tnMLrD/m94cKglVcHps0BCTdZ0TJeeAWOq2TK9MIY6cag==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha512-C/uAv4ktFP/Hmh01gMTvYvICrKze0XVX9f2PdIXuriCSvUmV9j+u+BB9f5fJK3+878yMK6dkdcq+Ymr9mrcLzw==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha512-aNv/GDAW0j/f4Uy1OEPZn1mqD+Nfy9viFGBfQ5bZyT35YqOiqx7/tXdyfZkJ1sC21NyEsBdfDY6PYmLHF4r5iA==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha512-ossocTuPOssfxO2h+Z3/Ea1Vo1wWx31Uqy9vIiJusOP4TbF7tPs9U0sJ9pX9OJPf4lXRGj5+6Gkl/HHKiAP5ug==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha512-DLuRwoygCoXx+YfxHLkVx5/NpeSbVwfoTeBykpJK7JhYWlL/O8hgAK/reforUnZDlxasOrVPPJVI/guE3dCwkw==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha512-iFp5KIcorf11iBqu/y/a7DK3MN5di3pNCzto61FqCNnUX4qeBwcV1SLqe10oXNnCaxBUImX3SckX2/o1nsrTcg==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha512-tjFl0cwMPpDYyoqYA9li1/7mGFit39XiNX5DKC/uCNjBctMxyL1/PT/l4rSlbvBG1pOKI88STRdUsWXB3/Q9hQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha512-LnIIdGWIKdw7zwckqx+eGjcS8/cl8D74A3BpJbGjKTFFNJSMrjN4bIh22HY1AlkUbeLG6X6OZj56BDvWD+OeFA==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha512-ONFIPsq8y4bls5PPsAWYXH/21Hqv64TBxdje0FvU3MhIV6QM2j5YS7KvAzg/nTIVLot2D2fmFQrFWCbgHlFEjg==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha512-LpVbiT9CLsuAIp3IG0tfbVo81QIhn6pE8xBJ7XSeCtFlMltuar5VuBV6y6Q45tpui9QWcy5i0vLQfCfrnF7Kiw==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha512-8G5hpZMecb53vpD3mjs64NhI1au24TAmokQ4B+TBFBjN9cVoGoOvotdrMMRmHvVZUEvqGUPWL514woru1ChZMA==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha512-8HxlW+BB5HqniD+nLkQ4xSAVq3bR/pcYW9IigY+2y0dI+Y7INFeTbfAQr+63T3E4UDsZGjyb+l9txUnABWxlOQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha512-mDdocSfUVm1/7Jw/FIRNw9vPrBQNePy6wZJlR8HAUBLybNp1w/6lr6zZ2pjMShee65t/ybR5pT8ulkLzD1xwiw==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha512-3Ghhi26r4l3d0Js933E5+IhHwk0A1yiutj9gwvzmFbVV0sPMYk2lekhOufHBswX7NCoSeF4Xrl3sCIuSIa+zOg==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha512-CYP359ADryTo3pCsH0oxRo/0yn6UsEZLqYohHmvLQdfS9xkf+MbCzE3/Kolw9OYIY4ZMilH25z/5CbQbwDD+lQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha512-x8b9W0ngnKzDMHimVtTfn5ryimars1ByTqsfBDwAqLibmuuQY6pgBQi5z1ErIsUOWBdw1bW9FSz5RZUojM4apg==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha512-fz6J2Sf4gYN6gWgRZaoFXmq93X+Li/8vf+fb0sGDVtdeWvxC9y5/bTD7bvfWMEq6zetGEHpWjtzRGSugt5kNqw==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha512-v61Dbbihf5XxnYjtBN04B/JBvsScY37R1cZT5r9permN1cp+b70DY3Ib3fIkgn1DI9U3tGgBJZVD8p/mE/4JbQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-unicode-regex/node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-unicode-regex/node_modules/regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha512-tJ9+S4oKjxY8IZ9jmjnp/mtytu1u3iyIQAfmI51IKWH6bFf7XR1ybtaO6j7INhZKXOTYADk7V5qxaqLkmNxiZQ==",
+      "dev": true,
+      "dependencies": {
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
+      }
+    },
+    "node_modules/babel-plugin-transform-es2015-unicode-regex/node_modules/regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha512-jlQ9gYLfk2p3V5Ag5fYhA7fv7OHzd1KUH0PRP46xc3TgwjwgROIW572AfYg/X9kaNq/LJnu6oJcFRXlIrGoTRw==",
+      "dev": true,
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha512-LzXDmbMkklvNhprr20//RStKVcT8Cu+SQtX18eMHLhjHf2yFzwtQ0S2f0jQ+89rokoNdmwoSqYzAhq86FxlLSQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha512-LS+dBkUGlNR15/5WHKe/8Neawx663qttS6AGqoOUhICc9d1KciBvtrQSuc0PI+CxQ2Q/S1aKuJ+u64GtLdcEZg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-transform": "^0.10.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-regenerator/node_modules/regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
+      }
+    },
+    "node_modules/babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha512-j3KtSpjyLSJxNoCDrhwiJad8kw0gJ9REGj8/CqL0HeRyLnvUNYV9zcqluL6QJSXh3nfsLEmSLvwRfGzrgR96Pw==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "node_modules/babel-polyfill": {
@@ -16023,6 +16677,66 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
+      }
+    },
+    "node_modules/babel-preset-env/node_modules/browserslist": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "dev": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      }
+    },
+    "node_modules/babel-preset-env/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/babel-runtime": {
       "version": "6.26.0",
       "dev": true,
@@ -16030,6 +16744,90 @@
       "dependencies": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "node_modules/babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
+      "dev": true,
+      "dependencies": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "node_modules/babel-types/node_modules/to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true,
+      "bin": {
+        "babylon": "bin/babylon.js"
       }
     },
     "node_modules/backo2": {
@@ -18825,24 +19623,16 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.19.0",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.28.0.tgz",
+      "integrity": "sha512-myzPgE7QodMg4nnd3K1TDoES/nADRStM8Gpz0D6nhkwbmwEnE0ZGJgoWsvQ722FR8D7xS0n0LV556RcEicjTyg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.17.5",
-        "semver": "7.0.0"
+        "browserslist": "^4.21.5"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-compat/node_modules/semver": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/core-util-is": {
@@ -24012,6 +24802,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ip": {
       "version": "1.1.5",
       "dev": true,
@@ -26456,8 +27255,9 @@
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -26647,6 +27447,18 @@
       "version": "2.0.2",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/loud-rejection": {
       "version": "1.6.0",
@@ -33726,6 +34538,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/proc-log": {
       "version": "1.0.0",
       "dev": true,
@@ -34468,15 +35289,17 @@
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
     },
     "node_modules/regenerate-unicode-properties": {
-      "version": "8.2.0",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "regenerate": "^1.4.0"
+        "regenerate": "^1.4.2"
       },
       "engines": {
         "node": ">=4"
@@ -34488,9 +35311,10 @@
       "license": "MIT"
     },
     "node_modules/regenerator-transform": {
-      "version": "0.14.5",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
+      "integrity": "sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4"
       }
@@ -34542,30 +35366,33 @@
       }
     },
     "node_modules/regexpu-core": {
-      "version": "4.7.1",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.0.tgz",
+      "integrity": "sha512-ZdhUQlng0RoscyW7jADnUZ25F5eVtHdMyXSb2PiwafvteRAOJUjFoUPEYZSIfP99fBIs3maLIRfpEddT78wAAQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.2.0",
-        "regjsgen": "^0.5.1",
-        "regjsparser": "^0.6.4",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.2.0"
+        "@babel/regjsgen": "^0.8.0",
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsparser": "^0.9.1",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
       },
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/regjsgen": {
-      "version": "0.5.2",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha512-x+Y3yA24uF68m5GA+tBjbGYo64xXVJpbToBaWCoSNSc1hdk6dfctaRWrNFTVJZIIhL5GxW8zwjoixbnifnK59g==",
+      "dev": true
     },
     "node_modules/regjsparser": {
-      "version": "0.6.9",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~0.5.0"
       },
@@ -34575,6 +35402,8 @@
     },
     "node_modules/regjsparser/node_modules/jsesc": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
@@ -42310,37 +43139,41 @@
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/unicode-match-property-ecmascript": {
-      "version": "1.0.4",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
       },
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/unicode-match-property-value-ecmascript": {
-      "version": "1.2.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/unicode-property-aliases-ecmascript": {
-      "version": "1.1.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -44519,7 +45352,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.15.0",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
+      "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
       "dev": true
     },
     "@babel/core": {
@@ -44561,79 +45396,103 @@
       }
     },
     "@babel/generator": {
-      "version": "7.16.0",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
+      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "dev": true
-        }
+        "@babel/types": "^7.20.7",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.15.4",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.18.9.tgz",
+      "integrity": "sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-explode-assignable-expression": "^7.18.6",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.15.4",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.15.0",
-        "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.16.6",
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
         "semver": {
           "version": "6.3.0",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.16.0",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz",
+      "integrity": "sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-member-expression-to-functions": "^7.16.0",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/helper-replace-supers": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-member-expression-to-functions": "^7.20.7",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/helper-replace-supers": "^7.20.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/helper-split-export-declaration": "^7.18.6"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.14.5",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.20.5.tgz",
+      "integrity": "sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.14.5",
-        "regexpu-core": "^4.7.1"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "regexpu-core": "^5.2.1"
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.2.4",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+      "integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
       "dev": true,
       "requires": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
@@ -44642,135 +45501,176 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
     },
+    "@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
+    },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.15.4",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz",
+      "integrity": "sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.16.0",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.19.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.16.0",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
+      "integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.15.4",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.15.4",
-        "@babel/helper-replace-supers": "^7.15.4",
-        "@babel/helper-simple-access": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.15.4",
-        "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.10",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
+      "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.14.5",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.15.4",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.18.9.tgz",
+      "integrity": "sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.15.4",
-        "@babel/helper-wrap-function": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-wrap-function": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.16.0",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz",
+      "integrity": "sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.16.0",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-member-expression-to-functions": "^7.20.7",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.15.4",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.20.2"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.15.4",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
+      "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.20.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.18.6"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "dev": true
+    },
     "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
       "dev": true
     },
     "@babel/helper-wrap-function": {
-      "version": "7.15.4",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.20.5.tgz",
+      "integrity": "sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.20.5",
+        "@babel/types": "^7.20.5"
       }
     },
     "@babel/helpers": {
@@ -44783,10 +45683,12 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.16.0",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -44803,148 +45705,194 @@
       }
     },
     "@babel/parser": {
-      "version": "7.16.0",
+      "version": "7.20.15",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz",
+      "integrity": "sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==",
       "dev": true
     },
-    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.15.4",
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.18.6.tgz",
+      "integrity": "sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.15.4",
-        "@babel/plugin-proposal-optional-chaining": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.20.7.tgz",
+      "integrity": "sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.20.7"
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.15.4",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz",
+      "integrity": "sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-remap-async-to-generator": "^7.15.4",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-remap-async-to-generator": "^7.18.9",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-proposal-class-static-block": {
-      "version": "7.15.4",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.20.7.tgz",
+      "integrity": "sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-create-class-features-plugin": "^7.20.7",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.18.6.tgz",
+      "integrity": "sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz",
+      "integrity": "sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.9",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-json-strings": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.18.6.tgz",
+      "integrity": "sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-json-strings": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.14.5",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz",
+      "integrity": "sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
+      "integrity": "sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-numeric-separator": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.18.6.tgz",
+      "integrity": "sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.15.6",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
+      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.15.4"
+        "@babel/plugin-transform-parameters": "^7.20.7"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.18.6.tgz",
+      "integrity": "sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.14.5",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.20.7.tgz",
+      "integrity": "sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-private-methods": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.15.4",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.20.5.tgz",
+      "integrity": "sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.15.4",
-        "@babel/helper-create-class-features-plugin": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.20.5",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.18.6.tgz",
+      "integrity": "sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -44959,6 +45907,8 @@
     },
     "@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -44966,6 +45916,8 @@
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -44973,13 +45925,26 @@
     },
     "@babel/plugin-syntax-export-namespace-from": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-syntax-import-assertions": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.20.0.tgz",
+      "integrity": "sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.19.0"
+      }
+    },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -44987,6 +45952,8 @@
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -44994,6 +45961,8 @@
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -45001,6 +45970,8 @@
     },
     "@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -45008,6 +45979,8 @@
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -45015,6 +45988,8 @@
     },
     "@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -45022,6 +45997,8 @@
     },
     "@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -45029,6 +46006,8 @@
     },
     "@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -45042,288 +46021,361 @@
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.14.5",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.20.7.tgz",
+      "integrity": "sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.14.5",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.20.7.tgz",
+      "integrity": "sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-remap-async-to-generator": "^7.14.5"
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-remap-async-to-generator": "^7.18.9"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.18.6.tgz",
+      "integrity": "sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.15.3",
+      "version": "7.20.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.15.tgz",
+      "integrity": "sha512-Vv4DMZ6MiNOhu/LdaZsT/bsLRxgL94d269Mv4R/9sp6+Mp++X/JqypZYypJXLlM4mlL352/Egzbzr98iABH1CA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.15.4",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.7.tgz",
+      "integrity": "sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-optimise-call-expression": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-replace-supers": "^7.20.7",
+        "@babel/helper-split-export-declaration": "^7.18.6",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "globals": {
           "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         }
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.14.5",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.20.7.tgz",
+      "integrity": "sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/template": "^7.20.7"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.14.7",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.7.tgz",
+      "integrity": "sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.18.6.tgz",
+      "integrity": "sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.18.9.tgz",
+      "integrity": "sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.18.6.tgz",
+      "integrity": "sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.15.4",
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.8.tgz",
+      "integrity": "sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.18.9.tgz",
+      "integrity": "sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.18.9.tgz",
+      "integrity": "sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.18.6.tgz",
+      "integrity": "sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.14.5",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.20.11.tgz",
+      "integrity": "sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.15.4",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
+      "integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-simple-access": "^7.15.4",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-simple-access": "^7.20.2"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.15.4",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.20.11.tgz",
+      "integrity": "sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-module-transforms": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-validator-identifier": "^7.19.1"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.18.6.tgz",
+      "integrity": "sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-module-transforms": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.14.9",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.20.5.tgz",
+      "integrity": "sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.14.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.20.5",
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.18.6.tgz",
+      "integrity": "sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
+      "integrity": "sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-replace-supers": "^7.18.6"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.15.4",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.7.tgz",
+      "integrity": "sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-property-literals": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.18.6.tgz",
+      "integrity": "sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.14.5",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.20.5.tgz",
+      "integrity": "sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.14.2"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "regenerator-transform": "^0.15.1"
       }
     },
     "@babel/plugin-transform-reserved-words": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.18.6.tgz",
+      "integrity": "sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.18.6.tgz",
+      "integrity": "sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.14.6",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.20.7.tgz",
+      "integrity": "sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.18.6.tgz",
+      "integrity": "sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.18.9.tgz",
+      "integrity": "sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.14.5",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.18.9.tgz",
+      "integrity": "sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-unicode-escapes": {
-      "version": "7.14.5",
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz",
+      "integrity": "sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.14.5",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.18.6.tgz",
+      "integrity": "sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/preset-env": {
-      "version": "7.15.6",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
+      "integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.4",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
-        "@babel/plugin-proposal-async-generator-functions": "^7.15.4",
-        "@babel/plugin-proposal-class-properties": "^7.14.5",
-        "@babel/plugin-proposal-class-static-block": "^7.15.4",
-        "@babel/plugin-proposal-dynamic-import": "^7.14.5",
-        "@babel/plugin-proposal-export-namespace-from": "^7.14.5",
-        "@babel/plugin-proposal-json-strings": "^7.14.5",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
-        "@babel/plugin-proposal-numeric-separator": "^7.14.5",
-        "@babel/plugin-proposal-object-rest-spread": "^7.15.6",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
-        "@babel/plugin-proposal-optional-chaining": "^7.14.5",
-        "@babel/plugin-proposal-private-methods": "^7.14.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.15.4",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
+        "@babel/compat-data": "^7.20.1",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
+        "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-class-static-block": "^7.18.6",
+        "@babel/plugin-proposal-dynamic-import": "^7.18.6",
+        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
+        "@babel/plugin-proposal-json-strings": "^7.18.6",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
+        "@babel/plugin-proposal-numeric-separator": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.2",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
+        "@babel/plugin-proposal-optional-chaining": "^7.18.9",
+        "@babel/plugin-proposal-private-methods": "^7.18.6",
+        "@babel/plugin-proposal-private-property-in-object": "^7.18.6",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.18.6",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
         "@babel/plugin-syntax-class-static-block": "^7.14.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -45333,44 +46385,44 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
-        "@babel/plugin-transform-arrow-functions": "^7.14.5",
-        "@babel/plugin-transform-async-to-generator": "^7.14.5",
-        "@babel/plugin-transform-block-scoped-functions": "^7.14.5",
-        "@babel/plugin-transform-block-scoping": "^7.15.3",
-        "@babel/plugin-transform-classes": "^7.15.4",
-        "@babel/plugin-transform-computed-properties": "^7.14.5",
-        "@babel/plugin-transform-destructuring": "^7.14.7",
-        "@babel/plugin-transform-dotall-regex": "^7.14.5",
-        "@babel/plugin-transform-duplicate-keys": "^7.14.5",
-        "@babel/plugin-transform-exponentiation-operator": "^7.14.5",
-        "@babel/plugin-transform-for-of": "^7.15.4",
-        "@babel/plugin-transform-function-name": "^7.14.5",
-        "@babel/plugin-transform-literals": "^7.14.5",
-        "@babel/plugin-transform-member-expression-literals": "^7.14.5",
-        "@babel/plugin-transform-modules-amd": "^7.14.5",
-        "@babel/plugin-transform-modules-commonjs": "^7.15.4",
-        "@babel/plugin-transform-modules-systemjs": "^7.15.4",
-        "@babel/plugin-transform-modules-umd": "^7.14.5",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
-        "@babel/plugin-transform-new-target": "^7.14.5",
-        "@babel/plugin-transform-object-super": "^7.14.5",
-        "@babel/plugin-transform-parameters": "^7.15.4",
-        "@babel/plugin-transform-property-literals": "^7.14.5",
-        "@babel/plugin-transform-regenerator": "^7.14.5",
-        "@babel/plugin-transform-reserved-words": "^7.14.5",
-        "@babel/plugin-transform-shorthand-properties": "^7.14.5",
-        "@babel/plugin-transform-spread": "^7.14.6",
-        "@babel/plugin-transform-sticky-regex": "^7.14.5",
-        "@babel/plugin-transform-template-literals": "^7.14.5",
-        "@babel/plugin-transform-typeof-symbol": "^7.14.5",
-        "@babel/plugin-transform-unicode-escapes": "^7.14.5",
-        "@babel/plugin-transform-unicode-regex": "^7.14.5",
-        "@babel/preset-modules": "^0.1.4",
-        "@babel/types": "^7.15.6",
-        "babel-plugin-polyfill-corejs2": "^0.2.2",
-        "babel-plugin-polyfill-corejs3": "^0.2.2",
-        "babel-plugin-polyfill-regenerator": "^0.2.2",
-        "core-js-compat": "^3.16.0",
+        "@babel/plugin-transform-arrow-functions": "^7.18.6",
+        "@babel/plugin-transform-async-to-generator": "^7.18.6",
+        "@babel/plugin-transform-block-scoped-functions": "^7.18.6",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/plugin-transform-classes": "^7.20.2",
+        "@babel/plugin-transform-computed-properties": "^7.18.9",
+        "@babel/plugin-transform-destructuring": "^7.20.2",
+        "@babel/plugin-transform-dotall-regex": "^7.18.6",
+        "@babel/plugin-transform-duplicate-keys": "^7.18.9",
+        "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
+        "@babel/plugin-transform-for-of": "^7.18.8",
+        "@babel/plugin-transform-function-name": "^7.18.9",
+        "@babel/plugin-transform-literals": "^7.18.9",
+        "@babel/plugin-transform-member-expression-literals": "^7.18.6",
+        "@babel/plugin-transform-modules-amd": "^7.19.6",
+        "@babel/plugin-transform-modules-commonjs": "^7.19.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.19.6",
+        "@babel/plugin-transform-modules-umd": "^7.18.6",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
+        "@babel/plugin-transform-new-target": "^7.18.6",
+        "@babel/plugin-transform-object-super": "^7.18.6",
+        "@babel/plugin-transform-parameters": "^7.20.1",
+        "@babel/plugin-transform-property-literals": "^7.18.6",
+        "@babel/plugin-transform-regenerator": "^7.18.6",
+        "@babel/plugin-transform-reserved-words": "^7.18.6",
+        "@babel/plugin-transform-shorthand-properties": "^7.18.6",
+        "@babel/plugin-transform-spread": "^7.19.0",
+        "@babel/plugin-transform-sticky-regex": "^7.18.6",
+        "@babel/plugin-transform-template-literals": "^7.18.9",
+        "@babel/plugin-transform-typeof-symbol": "^7.18.9",
+        "@babel/plugin-transform-unicode-escapes": "^7.18.10",
+        "@babel/plugin-transform-unicode-regex": "^7.18.6",
+        "@babel/preset-modules": "^0.1.5",
+        "@babel/types": "^7.20.2",
+        "babel-plugin-polyfill-corejs2": "^0.3.3",
+        "babel-plugin-polyfill-corejs3": "^0.6.0",
+        "babel-plugin-polyfill-regenerator": "^0.4.1",
+        "core-js-compat": "^3.25.1",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -45381,7 +46433,9 @@
       }
     },
     "@babel/preset-modules": {
-      "version": "0.1.4",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
+      "integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -45390,6 +46444,12 @@
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
       }
+    },
+    "@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==",
+      "dev": true
     },
     "@babel/runtime": {
       "version": "7.15.4",
@@ -45405,43 +46465,52 @@
       }
     },
     "@babel/template": {
-      "version": "7.16.0",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.16.0",
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+          "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.16.0"
+            "@babel/highlight": "^7.18.6"
           }
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.16.0",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.20.13",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.16.0",
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+          "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.16.0"
+            "@babel/highlight": "^7.18.6"
           }
         },
         "globals": {
@@ -45451,10 +46520,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.16.0",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -55404,6 +56476,152 @@
         "follow-redirects": "^1.14.0"
       }
     },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha512-gCtfYORSG1fUMX4kKraymq607FWgMWg+j42IFPc18kFQEsmtaibP4UrqsXt8FlEJle25HUd4tsoDR7H2wDhe9Q==",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha512-RL8n2NiEj+kKztlrVJM9JT1cXzzAdvWFh76xh/H1I4nKwunzE4INBXn8ieCZ+wh4zWszZk7NBS1s/8HR5jDkzQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha512-bHkmjcC9lM1kmZcVpA5t2om2nzT/xiZpo6TJq7UlZ3wqKfzia4veeXbIhKvJXAMzhhEBd3cR1IElL5AenWEUpA==",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha512-qe5csbhbvq6ccry9G7tkXbzNtcDiH4r51rrPUbwwoTzZ18AqxWYRZT6AOmxrpxKnQBW0pYlBI/8vh73Z//78nQ==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha512-Oo6+e2iX+o9eVvJ9Y5eKL5iryeRdsIkwRYheCuhYdVHsdEQysbc2z2QkqCLIYnNxkT5Ss3ggrHdXiDI7Dhrn4Q==",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha512-WfgKFX6swFB1jS2vo+DwivRN4NB8XUdM3ij0Y1gnC21y1tdBoe6xjVnd7NSI6alv+gZXCtJqvrTeMW3fR/c0ng==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha512-zAYl3tqerLItvG5cKYw7f1SpvIxS9zi7ohyGHaI9cgDUjAT6YcY9jIEH5CstetP5wHIVSceXwNS7Z5BpJg+rOw==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha512-Op9IhEaxhbRT8MDXx2iNuMgciu2V8lDvYCNQbDGjdBNCjaMvyLf4wl4A3b8IgndCyQF8TwfgsQ8T3VD8aX1/pA==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha512-VlPiWmqmGJp0x0oK27Out1D+71nVVCTSdlbhIVoaBAj2lUgrNjBCRR9+llO4lTSb2O4r7PJg+RobRkhBrf6ofg==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha512-RYqaPD0mQyQIFRu7Ho5wE2yvA/5jxqCIj/Lv4BXNq23mHYu/vxikOy2JueLiBxQknwapwrJeNCesvY0ZcfnlHg==",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha512-sLI+u7sXJh6+ToqDr57Bv973kCepItDhMou0xCP2YPVmR1jkHSCY+p1no8xErbV1Siz5QE8qKT1WIwybSWlqjw==",
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
     "babel-loader": {
       "version": "8.2.3",
       "dev": true,
@@ -55414,41 +56632,394 @@
         "schema-utils": "^2.6.5"
       }
     },
-    "babel-plugin-dynamic-import-node": {
-      "version": "2.3.3",
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
       "dev": true,
       "requires": {
-        "object.assign": "^4.1.0"
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha512-B1M5KBP29248dViEo1owyY32lk1ZSH2DaNNrXLGt8lyjjHm7pBqAdQ7VKUPR6EEDO323+OvT3MQXbCin8ooWdA==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.2.3",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+      "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
         "semver": "^6.1.1"
       },
       "dependencies": {
         "semver": {
           "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.2.4",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+      "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
       "dev": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.2",
-        "core-js-compat": "^3.14.0"
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
+        "core-js-compat": "^3.25.1"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.2.3",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+      "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
       "dev": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.4"
+        "@babel/helper-define-polyfill-provider": "^0.3.3"
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha512-4Zp4unmHgw30A1eWI5EpACji2qMocisdXhAftfhXoSV9j0Tvj6nRFE3tOmRY912E0FMRm/L5xWE7MGVT2FoLnw==",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha512-Z/flU+T9ta0aIEKl1tGEmN/pZiI1uXmCiGFRegKacQfEJzp7iNsKloZmyJlQr+75FCJtiFfGIK03SiCvCt9cPQ==",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha512-Gx9CH3Q/3GKbhs07Bszw5fPTlU+ygrOGfAhEt7W2JICwufpC4SuO0mG0+4NykPBSYPMJhqvVlDBU17qB1D+hMQ==",
+      "dev": true
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha512-7BgYJujNCg0Ti3x0c/DL3tStvnKS6ktIYOmo9wginv/dfZOrbSZ+qG4IRRHMBOzZ5Awb1skTiAsQXg/+IWkZYw==",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha512-PCqwwzODXW7JMrzu+yZIaYbPQSKjDTAsNNlK2l5Gg9g4rz2VzLnZsStvp/3c46GfXpwkyufb3NCyG9+50FF1Vg==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha512-2+ujAT2UMBzYFm7tidUsYh+ZoIutxJ3pN9IYrF1/H6dCKtECfhmB8UkHVpyxDwkj0CYbQG35ykoz925TUnBc3A==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha512-YiN6sFAQ5lML8JjCmr7uerS5Yc/EMbgg9G8ZNmk2E3nYX4ckHR01wrkeeMijEf5WHNK5TW0Sl0Uu3pv3EdOJWw==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha512-5Dy7ZbRinGrNtmWpquZKZ3EGY8sDgIVB4CU8Om8q8tnMLrD/m94cKglVcHps0BCTdZ0TJeeAWOq2TK9MIY6cag==",
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha512-C/uAv4ktFP/Hmh01gMTvYvICrKze0XVX9f2PdIXuriCSvUmV9j+u+BB9f5fJK3+878yMK6dkdcq+Ymr9mrcLzw==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha512-aNv/GDAW0j/f4Uy1OEPZn1mqD+Nfy9viFGBfQ5bZyT35YqOiqx7/tXdyfZkJ1sC21NyEsBdfDY6PYmLHF4r5iA==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha512-ossocTuPOssfxO2h+Z3/Ea1Vo1wWx31Uqy9vIiJusOP4TbF7tPs9U0sJ9pX9OJPf4lXRGj5+6Gkl/HHKiAP5ug==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha512-DLuRwoygCoXx+YfxHLkVx5/NpeSbVwfoTeBykpJK7JhYWlL/O8hgAK/reforUnZDlxasOrVPPJVI/guE3dCwkw==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha512-iFp5KIcorf11iBqu/y/a7DK3MN5di3pNCzto61FqCNnUX4qeBwcV1SLqe10oXNnCaxBUImX3SckX2/o1nsrTcg==",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha512-tjFl0cwMPpDYyoqYA9li1/7mGFit39XiNX5DKC/uCNjBctMxyL1/PT/l4rSlbvBG1pOKI88STRdUsWXB3/Q9hQ==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha512-LnIIdGWIKdw7zwckqx+eGjcS8/cl8D74A3BpJbGjKTFFNJSMrjN4bIh22HY1AlkUbeLG6X6OZj56BDvWD+OeFA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha512-ONFIPsq8y4bls5PPsAWYXH/21Hqv64TBxdje0FvU3MhIV6QM2j5YS7KvAzg/nTIVLot2D2fmFQrFWCbgHlFEjg==",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha512-LpVbiT9CLsuAIp3IG0tfbVo81QIhn6pE8xBJ7XSeCtFlMltuar5VuBV6y6Q45tpui9QWcy5i0vLQfCfrnF7Kiw==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha512-8G5hpZMecb53vpD3mjs64NhI1au24TAmokQ4B+TBFBjN9cVoGoOvotdrMMRmHvVZUEvqGUPWL514woru1ChZMA==",
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha512-8HxlW+BB5HqniD+nLkQ4xSAVq3bR/pcYW9IigY+2y0dI+Y7INFeTbfAQr+63T3E4UDsZGjyb+l9txUnABWxlOQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha512-mDdocSfUVm1/7Jw/FIRNw9vPrBQNePy6wZJlR8HAUBLybNp1w/6lr6zZ2pjMShee65t/ybR5pT8ulkLzD1xwiw==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha512-3Ghhi26r4l3d0Js933E5+IhHwk0A1yiutj9gwvzmFbVV0sPMYk2lekhOufHBswX7NCoSeF4Xrl3sCIuSIa+zOg==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha512-CYP359ADryTo3pCsH0oxRo/0yn6UsEZLqYohHmvLQdfS9xkf+MbCzE3/Kolw9OYIY4ZMilH25z/5CbQbwDD+lQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha512-x8b9W0ngnKzDMHimVtTfn5ryimars1ByTqsfBDwAqLibmuuQY6pgBQi5z1ErIsUOWBdw1bW9FSz5RZUojM4apg==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha512-fz6J2Sf4gYN6gWgRZaoFXmq93X+Li/8vf+fb0sGDVtdeWvxC9y5/bTD7bvfWMEq6zetGEHpWjtzRGSugt5kNqw==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha512-v61Dbbihf5XxnYjtBN04B/JBvsScY37R1cZT5r9permN1cp+b70DY3Ib3fIkgn1DI9U3tGgBJZVD8p/mE/4JbQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+          "integrity": "sha512-tJ9+S4oKjxY8IZ9jmjnp/mtytu1u3iyIQAfmI51IKWH6bFf7XR1ybtaO6j7INhZKXOTYADk7V5qxaqLkmNxiZQ==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "integrity": "sha512-jlQ9gYLfk2p3V5Ag5fYhA7fv7OHzd1KUH0PRP46xc3TgwjwgROIW572AfYg/X9kaNq/LJnu6oJcFRXlIrGoTRw==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha512-LzXDmbMkklvNhprr20//RStKVcT8Cu+SQtX18eMHLhjHf2yFzwtQ0S2f0jQ+89rokoNdmwoSqYzAhq86FxlLSQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha512-LS+dBkUGlNR15/5WHKe/8Neawx663qttS6AGqoOUhICc9d1KciBvtrQSuc0PI+CxQ2Q/S1aKuJ+u64GtLdcEZg==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.10.0"
+      },
+      "dependencies": {
+        "regenerator-transform": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+          "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
+          }
+        }
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha512-j3KtSpjyLSJxNoCDrhwiJad8kw0gJ9REGj8/CqL0HeRyLnvUNYV9zcqluL6QJSXh3nfsLEmSLvwRfGzrgR96Pw==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-polyfill": {
@@ -55466,6 +57037,62 @@
         }
       }
     },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "3.2.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "dev": true,
@@ -55473,6 +57100,85 @@
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
       }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
+          "dev": true
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "backo2": {
       "version": "1.0.2",
@@ -57495,17 +59201,12 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.19.0",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.28.0.tgz",
+      "integrity": "sha512-myzPgE7QodMg4nnd3K1TDoES/nADRStM8Gpz0D6nhkwbmwEnE0ZGJgoWsvQ722FR8D7xS0n0LV556RcEicjTyg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.17.5",
-        "semver": "7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.0.0",
-          "dev": true
-        }
+        "browserslist": "^4.21.5"
       }
     },
     "core-util-is": {
@@ -61020,6 +62721,15 @@
         "p-is-promise": "^3.0.0"
       }
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "ip": {
       "version": "1.1.5",
       "dev": true
@@ -62652,6 +64362,8 @@
     },
     "lodash.debounce": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
     "lodash.escaperegexp": {
@@ -62800,6 +64512,15 @@
           "version": "2.0.2",
           "dev": true
         }
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -67717,6 +69438,12 @@
         }
       }
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
     "proc-log": {
       "version": "1.0.0",
       "dev": true
@@ -68255,13 +69982,17 @@
     },
     "regenerate": {
       "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
       "dev": true
     },
     "regenerate-unicode-properties": {
-      "version": "8.2.0",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0"
+        "regenerate": "^1.4.2"
       }
     },
     "regenerator-runtime": {
@@ -68269,7 +70000,9 @@
       "dev": true
     },
     "regenerator-transform": {
-      "version": "0.14.5",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
+      "integrity": "sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.4"
@@ -68305,23 +70038,29 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "4.7.1",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.0.tgz",
+      "integrity": "sha512-ZdhUQlng0RoscyW7jADnUZ25F5eVtHdMyXSb2PiwafvteRAOJUjFoUPEYZSIfP99fBIs3maLIRfpEddT78wAAQ==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.2.0",
-        "regjsgen": "^0.5.1",
-        "regjsparser": "^0.6.4",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.2.0"
+        "@babel/regjsgen": "^0.8.0",
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsparser": "^0.9.1",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
       }
     },
     "regjsgen": {
-      "version": "0.5.2",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha512-x+Y3yA24uF68m5GA+tBjbGYo64xXVJpbToBaWCoSNSc1hdk6dfctaRWrNFTVJZIIhL5GxW8zwjoixbnifnK59g==",
       "dev": true
     },
     "regjsparser": {
-      "version": "0.6.9",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
@@ -68329,6 +70068,8 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
           "dev": true
         }
       }
@@ -73644,23 +75385,31 @@
       }
     },
     "unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
       "dev": true
     },
     "unicode-match-property-ecmascript": {
-      "version": "1.0.4",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
       }
     },
     "unicode-match-property-value-ecmascript": {
-      "version": "1.2.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
-      "version": "1.1.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "dev": true
     },
     "union-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/npm": "^8.0.0",
         "@skypack/package-check": "^0.2.2",
-        "@types/fetch-mock": "^6.0.6",
+        "@types/fetch-mock": "^7.3.5",
         "@types/jasmine": "^2.8.2",
         "@types/node": "^12.20.4",
         "@typescript-eslint/eslint-plugin": "^4.4.0",
@@ -40,7 +40,7 @@
         "eslint-config-prettier": "^6.12.0",
         "eslint-import-resolver-typescript": "^2.4.0",
         "eslint-plugin-import": "^2.24.2",
-        "fetch-mock": "^5.13.1",
+        "fetch-mock": "^9.0.0",
         "gh-pages": "^1.1.0",
         "globby": "^12.0.2",
         "husky": "^4.3.0",
@@ -348,7 +348,7 @@
         "@esri/arcgis-rest-request": "^4.0.0"
       },
       "devDependencies": {
-        "parcel-bundler": "^1.12.5"
+        "parcel": "^2.0.0"
       }
     },
     "demos/snowpack": {
@@ -1188,40 +1188,12 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -1479,21 +1451,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-flow-strip-types": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/plugin-syntax-flow": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-for-of": {
       "version": "7.15.4",
       "dev": true,
@@ -1680,24 +1637,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/plugin-syntax-jsx": "^7.16.0",
-        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3858,11 +3797,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@iarna/toml": {
-      "version": "2.2.5",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
       "dev": true,
@@ -3876,6 +3810,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
@@ -3883,6 +3831,25 @@
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -6609,6 +6576,99 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
+      "dev": true
+    },
+    "node_modules/@lezer/lr": {
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
+      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^0.15.0"
+      }
+    },
+    "node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@manypkg/find-root": {
       "version": "1.1.0",
       "dev": true,
@@ -6758,10 +6818,25 @@
         "node": ">= 4"
       }
     },
+    "node_modules/@mischnic/json-sourcemap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
+      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^0.15.7",
+        "@lezer/lr": "^0.15.4",
+        "json5": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
@@ -6769,6 +6844,84 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.0.tgz",
+      "integrity": "sha512-5qpnNHUyyEj9H3sm/4Um/bnx1lrQGhe8iqry/1d+cQYCRd/gzYA0YLeq0ezlk4hKx4vO+dsEsNyeowqRqslwQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.0.tgz",
+      "integrity": "sha512-ZphTFFd6SFweNAMKD+QJCrWpgkjf4qBuHltiMkKkD6FFrB3NOTRVmetAGTkJ57pa+s6J0yCH06LujWB9rZe94g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.0.tgz",
+      "integrity": "sha512-ztKVV1dO/sSZyGse0PBCq3Pk1PkYjsA/dsEWE7lfrGoAK3i9HpS2o7XjGQ7V4va6nX+xPPOiuYpQwa4Bi6vlww==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.0.tgz",
+      "integrity": "sha512-NEX6hdSvP4BmVyegaIbrGxvHzHvTzzsPaxXCsUt0mbLbPpEftsvNwaEVKOowXnLoeuGeD4MaqSwL3BUK2elsUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.0.tgz",
+      "integrity": "sha512-9uvdAkZMOPCY7SPRxZLW8XGqBOVNVEhqlgffenN8shA1XR9FWVsSM13nr/oHtNgXg6iVyML7RwWPyqUeThlwxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.0.tgz",
+      "integrity": "sha512-Wg0+9615kHKlr9iLVcG5I+/CHnf6w3x5UADRv8Ad16yA0Bu5l9eVOROjV7aHPG6uC8ZPFIVVaoSjDChD+Y0pzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7366,138 +7519,5839 @@
         "@octokit/openapi-types": "^11.2.0"
       }
     },
-    "node_modules/@parcel/fs": {
-      "version": "1.11.0",
+    "node_modules/@parcel/bundler-default": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.8.3.tgz",
+      "integrity": "sha512-yJvRsNWWu5fVydsWk3O2L4yIy3UZiKWO2cPDukGOIWMgp/Vbpp+2Ct5IygVRtE22bnseW/E/oe0PV3d2IkEJGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@parcel/utils": "^1.11.0",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.2"
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/graph": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/logger": {
-      "version": "1.11.1",
+    "node_modules/@parcel/bundler-default/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@parcel/workers": "^1.11.0",
-        "chalk": "^2.1.0",
-        "grapheme-breaker": "^0.3.2",
-        "ora": "^2.1.0",
-        "strip-ansi": "^4.0.0"
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/logger/node_modules/ansi-regex": {
-      "version": "3.0.0",
+    "node_modules/@parcel/bundler-default/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@parcel/logger/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/logger/node_modules/cli-spinners": {
-      "version": "1.3.1",
+    "node_modules/@parcel/bundler-default/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@parcel/logger/node_modules/ora": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "chalk": "^2.3.1",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^1.1.0",
-        "log-symbols": "^2.2.0",
-        "strip-ansi": "^4.0.0",
-        "wcwidth": "^1.0.1"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@parcel/logger/node_modules/strip-ansi": {
+    "node_modules/@parcel/bundler-default/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/bundler-default/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/bundler-default/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/bundler-default/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/bundler-default/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": "^3.0.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
-    "node_modules/@parcel/utils": {
-      "version": "1.11.0",
+    "node_modules/@parcel/cache": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.3.tgz",
+      "integrity": "sha512-k7xv5vSQrJLdXuglo+Hv3yF4BCSs1tQ/8Vbd6CHTkOhf7LcGg6CPtLw053R/KdMpd/4GPn0QrAsOLdATm1ELtQ==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@parcel/watcher": {
-      "version": "1.12.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@parcel/utils": "^1.11.0",
-        "chokidar": "^2.1.5"
-      }
-    },
-    "node_modules/@parcel/watcher/node_modules/chokidar": {
-      "version": "2.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
-      },
-      "optionalDependencies": {
-        "fsevents": "^1.2.7"
-      }
-    },
-    "node_modules/@parcel/workers": {
-      "version": "1.11.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/utils": "^1.11.0",
-        "physical-cpu-count": "^2.0.0"
+        "@parcel/fs": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "lmdb": "2.5.2"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/cache/node_modules/@parcel/fs": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+      "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/fs-search": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/cache/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/cache/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/cache/node_modules/@parcel/watcher": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.1.0.tgz",
+      "integrity": "sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^3.2.1",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/cache/node_modules/@parcel/workers": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/cache/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/cache/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/cache/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/cache/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/cache/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/cache/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true
+    },
+    "node_modules/@parcel/cache/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/codeframe": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.3.tgz",
+      "integrity": "sha512-FE7sY53D6n/+2Pgg6M9iuEC6F5fvmyBkRE4d9VdnOoxhTXtkEqpqYgX7RJ12FAQwNlxKq4suBJQMgQHMF2Kjeg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/codeframe/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/codeframe/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/codeframe/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/codeframe/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/codeframe/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/codeframe/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/compressor-raw": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.8.3.tgz",
+      "integrity": "sha512-bVDsqleBUxRdKMakWSlWC9ZjOcqDKE60BE+Gh3JSN6WJrycJ02P5wxjTVF4CStNP/G7X17U+nkENxSlMG77ySg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/config-default": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.8.3.tgz",
+      "integrity": "sha512-o/A/mbrO6X/BfGS65Sib8d6SSG45NYrNooNBkH/o7zbOBSRQxwyTlysleK1/3Wa35YpvFyLOwgfakqCtbGy4fw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/bundler-default": "2.8.3",
+        "@parcel/compressor-raw": "2.8.3",
+        "@parcel/namer-default": "2.8.3",
+        "@parcel/optimizer-css": "2.8.3",
+        "@parcel/optimizer-htmlnano": "2.8.3",
+        "@parcel/optimizer-image": "2.8.3",
+        "@parcel/optimizer-svgo": "2.8.3",
+        "@parcel/optimizer-terser": "2.8.3",
+        "@parcel/packager-css": "2.8.3",
+        "@parcel/packager-html": "2.8.3",
+        "@parcel/packager-js": "2.8.3",
+        "@parcel/packager-raw": "2.8.3",
+        "@parcel/packager-svg": "2.8.3",
+        "@parcel/reporter-dev-server": "2.8.3",
+        "@parcel/resolver-default": "2.8.3",
+        "@parcel/runtime-browser-hmr": "2.8.3",
+        "@parcel/runtime-js": "2.8.3",
+        "@parcel/runtime-react-refresh": "2.8.3",
+        "@parcel/runtime-service-worker": "2.8.3",
+        "@parcel/transformer-babel": "2.8.3",
+        "@parcel/transformer-css": "2.8.3",
+        "@parcel/transformer-html": "2.8.3",
+        "@parcel/transformer-image": "2.8.3",
+        "@parcel/transformer-js": "2.8.3",
+        "@parcel/transformer-json": "2.8.3",
+        "@parcel/transformer-postcss": "2.8.3",
+        "@parcel/transformer-posthtml": "2.8.3",
+        "@parcel/transformer-raw": "2.8.3",
+        "@parcel/transformer-react-refresh-wrap": "2.8.3",
+        "@parcel/transformer-svg": "2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/core": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.3.tgz",
+      "integrity": "sha512-Euf/un4ZAiClnlUXqPB9phQlKbveU+2CotZv7m7i+qkgvFn5nAGnrV4h1OzQU42j9dpgOxWi7AttUDMrvkbhCQ==",
+      "dev": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/cache": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/graph": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/package-manager": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "abortcontroller-polyfill": "^1.1.9",
+        "base-x": "^3.0.8",
+        "browserslist": "^4.6.6",
+        "clone": "^2.1.1",
+        "dotenv": "^7.0.0",
+        "dotenv-expand": "^5.1.0",
+        "json5": "^2.2.0",
+        "msgpackr": "^1.5.4",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/@parcel/fs": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+      "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/fs-search": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/@parcel/watcher": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.1.0.tgz",
+      "integrity": "sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^3.2.1",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/@parcel/workers": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/core/node_modules/dotenv": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true
+    },
+    "node_modules/@parcel/core/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/diagnostic": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
+      "integrity": "sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==",
+      "dev": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.3.tgz",
+      "integrity": "sha512-hoIS4tAxWp8FJk3628bsgKxEvR7bq2scCVYHSqZ4fTi/s0+VymEATrRCUqf+12e5H47uw1/ZjoqrGtBI02pz4w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/fs-search": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.3.tgz",
+      "integrity": "sha512-DJBT2N8knfN7Na6PP2mett3spQLTqxFrvl0gv+TJRp61T8Ljc4VuUTb0hqBj+belaASIp3Q+e8+SgaFQu7wLiQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/graph": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.8.3.tgz",
+      "integrity": "sha512-26GL8fYZPdsRhSXCZ0ZWliloK6DHlMJPWh6Z+3VVZ5mnDSbYg/rRKWmrkhnr99ZWmL9rJsv4G74ZwvDEXTMPBg==",
+      "dev": true,
+      "dependencies": {
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/hash": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.3.tgz",
+      "integrity": "sha512-FVItqzjWmnyP4ZsVgX+G00+6U2IzOvqDtdwQIWisCcVoXJFCqZJDy6oa2qDDFz96xCCCynjRjPdQx2jYBCpfYw==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "xxhash-wasm": "^0.4.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/markdown-ansi": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.3.tgz",
+      "integrity": "sha512-4v+pjyoh9f5zuU/gJlNvNFGEAb6J90sOBwpKJYJhdWXLZMNFCVzSigxrYO+vCsi8G4rl6/B2c0LcwIMjGPHmFQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/markdown-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/markdown-ansi/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/markdown-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/markdown-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/markdown-ansi/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/markdown-ansi/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/namer-default": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.8.3.tgz",
+      "integrity": "sha512-tJ7JehZviS5QwnxbARd8Uh63rkikZdZs1QOyivUhEvhN+DddSAVEdQLHGPzkl3YRk0tjFhbqo+Jci7TpezuAMw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/node-resolver-core": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.8.3.tgz",
+      "integrity": "sha512-12YryWcA5Iw2WNoEVr/t2HDjYR1iEzbjEcxfh1vaVDdZ020PiGw67g5hyIE/tsnG7SRJ0xdRx1fQ2hDgED+0Ww==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/node-resolver-core/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/node-resolver-core/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/node-resolver-core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/node-resolver-core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/node-resolver-core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/node-resolver-core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/node-resolver-core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/node-resolver-core/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@parcel/node-resolver-core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/optimizer-css": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.8.3.tgz",
+      "integrity": "sha512-JotGAWo8JhuXsQDK0UkzeQB0UR5hDAKvAviXrjqB4KM9wZNLhLleeEAW4Hk8R9smCeQFP6Xg/N/NkLDpqMwT3g==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "browserslist": "^4.6.6",
+        "lightningcss": "^1.16.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-css/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-css/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-css/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/optimizer-css/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/optimizer-css/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-css/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/optimizer-css/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/optimizer-css/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.8.3.tgz",
+      "integrity": "sha512-L8/fHbEy8Id2a2E0fwR5eKGlv9VYDjrH9PwdJE9Za9v1O/vEsfl/0T/79/x129l5O0yB6EFQkFa20MiK3b+vOg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "htmlnano": "^2.0.0",
+        "nullthrows": "^1.1.1",
+        "posthtml": "^0.16.5",
+        "svgo": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/css-declaration-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/cssnano": {
+      "version": "5.1.14",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.14.tgz",
+      "integrity": "sha512-Oou7ihiTocbKqi0J1bB+TRJIQX5RMR3JghA8hcWSw9mjBLQ5Y3RWqEDoYG3sRNlAbCIXpqMoZGbq5KDR3vdzgw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cssnano-preset-default": "^5.2.13",
+        "lilconfig": "^2.0.3",
+        "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/cssnano"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/cssnano-preset-default": {
+      "version": "5.2.13",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.13.tgz",
+      "integrity": "sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "css-declaration-sorter": "^6.3.1",
+        "cssnano-utils": "^3.1.0",
+        "postcss-calc": "^8.2.3",
+        "postcss-colormin": "^5.3.0",
+        "postcss-convert-values": "^5.1.3",
+        "postcss-discard-comments": "^5.1.2",
+        "postcss-discard-duplicates": "^5.1.0",
+        "postcss-discard-empty": "^5.1.1",
+        "postcss-discard-overridden": "^5.1.0",
+        "postcss-merge-longhand": "^5.1.7",
+        "postcss-merge-rules": "^5.1.3",
+        "postcss-minify-font-values": "^5.1.0",
+        "postcss-minify-gradients": "^5.1.1",
+        "postcss-minify-params": "^5.1.4",
+        "postcss-minify-selectors": "^5.2.1",
+        "postcss-normalize-charset": "^5.1.0",
+        "postcss-normalize-display-values": "^5.1.0",
+        "postcss-normalize-positions": "^5.1.1",
+        "postcss-normalize-repeat-style": "^5.1.1",
+        "postcss-normalize-string": "^5.1.0",
+        "postcss-normalize-timing-functions": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.1",
+        "postcss-normalize-url": "^5.1.0",
+        "postcss-normalize-whitespace": "^5.1.1",
+        "postcss-ordered-values": "^5.1.3",
+        "postcss-reduce-initial": "^5.1.1",
+        "postcss-reduce-transforms": "^5.1.0",
+        "postcss-svgo": "^5.1.0",
+        "postcss-unique-selectors": "^5.1.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/cssnano-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/htmlnano": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.3.tgz",
+      "integrity": "sha512-S4PGGj9RbdgW8LhbILNK7W9JhmYP8zmDY7KDV/8eCiJBQJlbmltp5I0gv8c5ntLljfdxxfmJ+UJVSqyH4mb41A==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^7.0.1",
+        "posthtml": "^0.16.5",
+        "timsort": "^0.3.0"
+      },
+      "peerDependencies": {
+        "cssnano": "^5.0.11",
+        "postcss": "^8.3.11",
+        "purgecss": "^5.0.0",
+        "relateurl": "^0.2.7",
+        "srcset": "4.0.0",
+        "svgo": "^2.8.0",
+        "terser": "^5.10.0",
+        "uncss": "^0.17.3"
+      },
+      "peerDependenciesMeta": {
+        "cssnano": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "purgecss": {
+          "optional": true
+        },
+        "relateurl": {
+          "optional": true
+        },
+        "srcset": {
+          "optional": true
+        },
+        "svgo": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "uncss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "dev": true
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss": {
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-calc": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
+      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.2"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-colormin": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
+      "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "browserslist": "^4.16.6",
+        "caniuse-api": "^3.0.0",
+        "colord": "^2.9.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-convert-values": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-discard-comments": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-discard-duplicates": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-discard-empty": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-discard-overridden": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-merge-longhand": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "stylehacks": "^5.1.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-merge-rules": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.3.tgz",
+      "integrity": "sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "caniuse-api": "^3.0.0",
+        "cssnano-utils": "^3.1.0",
+        "postcss-selector-parser": "^6.0.5"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-minify-font-values": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+      "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-minify-gradients": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
+      "integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "colord": "^2.9.1",
+        "cssnano-utils": "^3.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-minify-params": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "cssnano-utils": "^3.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-minify-selectors": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
+      "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.5"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-normalize-charset": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-normalize-display-values": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+      "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-normalize-positions": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
+      "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-normalize-repeat-style": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
+      "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-normalize-string": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+      "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-normalize-timing-functions": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+      "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-normalize-unicode": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-normalize-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+      "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "normalize-url": "^6.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-normalize-whitespace": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
+      "integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-ordered-values": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
+      "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cssnano-utils": "^3.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-reduce-initial": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.1.tgz",
+      "integrity": "sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "caniuse-api": "^3.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-reduce-transforms": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+      "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-svgo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+      "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "svgo": "^2.7.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-unique-selectors": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
+      "integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.5"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/posthtml": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+      "dev": true,
+      "dependencies": {
+        "posthtml-parser": "^0.11.0",
+        "posthtml-render": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/posthtml-parser": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/posthtml-render": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "dev": true,
+      "dependencies": {
+        "is-json": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/purgecss": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-5.0.0.tgz",
+      "integrity": "sha512-RAnuxrGuVyLLTr8uMbKaxDRGWMgK5CCYDfRyUNNcaz5P3kGgD2b7ymQGYEyo2ST7Tl/ScwFgf5l3slKMxHSbrw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^9.0.0",
+        "glob": "^8.0.3",
+        "postcss": "^8.4.4",
+        "postcss-selector-parser": "^6.0.7"
+      },
+      "bin": {
+        "purgecss": "bin/purgecss.js"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/srcset": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
+      "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/stylehacks": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/svgo": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "dev": true,
+      "dependencies": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^4.1.3",
+        "css-tree": "^1.1.3",
+        "csso": "^4.2.0",
+        "picocolors": "^1.0.0",
+        "stable": "^0.1.8"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@parcel/optimizer-image": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.8.3.tgz",
+      "integrity": "sha512-SD71sSH27SkCDNUNx9A3jizqB/WIJr3dsfp+JZGZC42tpD/Siim6Rqy9M4To/BpMMQIIiEXa5ofwS+DgTEiEHQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-image/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-image/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-image/node_modules/@parcel/workers": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/optimizer-image/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/optimizer-image/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/optimizer-image/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-image/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/optimizer-image/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/optimizer-image/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.8.3.tgz",
+      "integrity": "sha512-9KQed99NZnQw3/W4qBYVQ7212rzA9EqrQG019TIWJzkA9tjGBMIm2c/nXpK1tc3hQ3e7KkXkFCQ3C+ibVUnHNA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "svgo": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "dev": true
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/svgo": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "dev": true,
+      "dependencies": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^4.1.3",
+        "css-tree": "^1.1.3",
+        "csso": "^4.2.0",
+        "picocolors": "^1.0.0",
+        "stable": "^0.1.8"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-terser": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.8.3.tgz",
+      "integrity": "sha512-9EeQlN6zIeUWwzrzu6Q2pQSaYsYGah8MtiQ/hog9KEPlYTP60hBv/+utDyYEHSQhL7y5ym08tPX5GzBvwAD/dA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "terser": "^5.2.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-terser/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-terser/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-terser/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/optimizer-terser/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/optimizer-terser/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-terser/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/optimizer-terser/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/optimizer-terser/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/package-manager": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.3.tgz",
+      "integrity": "sha512-tIpY5pD2lH53p9hpi++GsODy6V3khSTX4pLEGuMpeSYbHthnOViobqIlFLsjni+QA1pfc8NNNIQwSNdGjYflVA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/@parcel/fs": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+      "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/fs-search": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/@parcel/watcher": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.1.0.tgz",
+      "integrity": "sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^3.2.1",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/@parcel/workers": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/package-manager/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true
+    },
+    "node_modules/@parcel/package-manager/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/packager-css": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.8.3.tgz",
+      "integrity": "sha512-WyvkMmsurlHG8d8oUVm7S+D+cC/T3qGeqogb7sTI52gB6uiywU7lRCizLNqGFyFGIxcVTVHWnSHqItBcLN76lA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-css/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-css/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-css/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/packager-css/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/packager-css/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/packager-css/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/packager-css/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/packager-css/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/packager-html": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.8.3.tgz",
+      "integrity": "sha512-OhPu1Hx1RRKJodpiu86ZqL8el2Aa4uhBHF6RAL1Pcrh2EhRRlPf70Sk0tC22zUpYL7es+iNKZ/n0Rl+OWSHWEw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "posthtml": "^0.16.5"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/packager-html/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/posthtml": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+      "dev": true,
+      "dependencies": {
+        "posthtml-parser": "^0.11.0",
+        "posthtml-render": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/posthtml-parser": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/posthtml-render": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "dev": true,
+      "dependencies": {
+        "is-json": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/packager-html/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/packager-js": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.8.3.tgz",
+      "integrity": "sha512-0pGKC3Ax5vFuxuZCRB+nBucRfFRz4ioie19BbDxYnvBxrd4M3FIu45njf6zbBYsI9eXqaDnL1b3DcZJfYqtIzw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "globals": "^13.2.0",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-js/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-js/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-js/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/packager-js/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/packager-js/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/packager-js/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/packager-js/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/packager-js/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/packager-raw": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.8.3.tgz",
+      "integrity": "sha512-BA6enNQo1RCnco9MhkxGrjOk59O71IZ9DPKu3lCtqqYEVd823tXff2clDKHK25i6cChmeHu6oB1Rb73hlPqhUA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-svg": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.8.3.tgz",
+      "integrity": "sha512-mvIoHpmv5yzl36OjrklTDFShLUfPFTwrmp1eIwiszGdEBuQaX7JVI3Oo2jbVQgcN4W7J6SENzGQ3Q5hPTW3pMw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "posthtml": "^0.16.4"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/packager-svg/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/posthtml": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+      "dev": true,
+      "dependencies": {
+        "posthtml-parser": "^0.11.0",
+        "posthtml-render": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/posthtml-parser": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/posthtml-render": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "dev": true,
+      "dependencies": {
+        "is-json": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/packager-svg/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/plugin": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.3.tgz",
+      "integrity": "sha512-jZ6mnsS4D9X9GaNnvrixDQwlUQJCohDX2hGyM0U0bY2NWU8Km97SjtoCpWjq+XBCx/gpC4g58+fk9VQeZq2vlw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/types": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-cli": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.8.3.tgz",
+      "integrity": "sha512-3sJkS6tFFzgIOz3u3IpD/RsmRxvOKKiQHOTkiiqRt1l44mMDGKS7zANRnJYsQzdCsgwc9SOP30XFgJwtoVlMbw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chalk": "^4.1.0",
+        "term-size": "^2.2.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-cli/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-cli/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/reporter-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/reporter-cli/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/reporter-cli/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/reporter-cli/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/reporter-cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/reporter-dev-server": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.8.3.tgz",
+      "integrity": "sha512-Y8C8hzgzTd13IoWTj+COYXEyCkXfmVJs3//GDBsH22pbtSFMuzAZd+8J9qsCo0EWpiDow7V9f1LischvEh3FbQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-dev-server/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-dev-server/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-dev-server/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/reporter-dev-server/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/reporter-dev-server/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/reporter-dev-server/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/reporter-dev-server/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/reporter-dev-server/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/resolver-default": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.8.3.tgz",
+      "integrity": "sha512-k0B5M/PJ+3rFbNj4xZSBr6d6HVIe6DH/P3dClLcgBYSXAvElNDfXgtIimbjCyItFkW9/BfcgOVKEEIZOeySH/A==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/node-resolver-core": "2.8.3",
+        "@parcel/plugin": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-browser-hmr": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.8.3.tgz",
+      "integrity": "sha512-2O1PYi2j/Q0lTyGNV3JdBYwg4rKo6TEVFlYGdd5wCYU9ZIN9RRuoCnWWH2qCPj3pjIVtBeppYxzfVjPEHINWVg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-browser-hmr/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/runtime-browser-hmr/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/runtime-browser-hmr/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/runtime-browser-hmr/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/runtime-browser-hmr/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/runtime-browser-hmr/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/runtime-js": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.8.3.tgz",
+      "integrity": "sha512-IRja0vNKwvMtPgIqkBQh0QtRn0XcxNC8HU1jrgWGRckzu10qJWO+5ULgtOeR4pv9krffmMPqywGXw6l/gvJKYQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/runtime-js/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/runtime-react-refresh": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.8.3.tgz",
+      "integrity": "sha512-2v/qFKp00MfG0234OdOgQNAo6TLENpFYZMbVbAsPMY9ITiqG73MrEsrGXVoGbYiGTMB/Toer/lSWlJxtacOCuA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "react-error-overlay": "6.0.9",
+        "react-refresh": "^0.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-react-refresh/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-react-refresh/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-react-refresh/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/runtime-react-refresh/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/runtime-react-refresh/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/runtime-react-refresh/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/runtime-react-refresh/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/runtime-react-refresh/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/runtime-service-worker": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.8.3.tgz",
+      "integrity": "sha512-/Skkw+EeRiwzOJso5fQtK8c9b452uWLNhQH1ISTodbmlcyB4YalAiSsyHCtMYD0c3/t5Sx4ZS7vxBAtQd0RvOw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-service-worker/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-service-worker/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-service-worker/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/runtime-service-worker/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/runtime-service-worker/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/runtime-service-worker/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/runtime-service-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/runtime-service-worker/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/source-map": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.1.tgz",
+      "integrity": "sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": "^12.18.3 || >=14"
+      }
+    },
+    "node_modules/@parcel/transformer-babel": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.8.3.tgz",
+      "integrity": "sha512-L6lExfpvvC7T/g3pxf3CIJRouQl+sgrSzuWQ0fD4PemUDHvHchSP4SNUVnd6gOytF3Y1KpnEZIunQGi5xVqQCQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "browserslist": "^4.6.6",
+        "json5": "^2.2.0",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-babel/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-babel/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-babel/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-babel/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-babel/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/transformer-babel/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/transformer-babel/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-babel/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@parcel/transformer-babel/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-css": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.8.3.tgz",
+      "integrity": "sha512-xTqFwlSXtnaYen9ivAgz+xPW7yRl/u4QxtnDyDpz5dr8gSeOpQYRcjkd4RsYzKsWzZcGtB5EofEk8ayUbWKEUg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "browserslist": "^4.6.6",
+        "lightningcss": "^1.16.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-css/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-css/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-css/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-css/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-css/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/transformer-css/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/transformer-css/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-css/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-html": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.8.3.tgz",
+      "integrity": "sha512-kIZO3qsMYTbSnSpl9cnZog+SwL517ffWH54JeB410OSAYF1ouf4n5v9qBnALZbuCCmPwJRGs4jUtE452hxwN4g==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "posthtml": "^0.16.5",
+        "posthtml-parser": "^0.10.1",
+        "posthtml-render": "^3.0.0",
+        "semver": "^5.7.1",
+        "srcset": "4"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-html/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-html/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/@parcel/transformer-html/node_modules/posthtml": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+      "dev": true,
+      "dependencies": {
+        "posthtml-parser": "^0.11.0",
+        "posthtml-render": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@parcel/transformer-html/node_modules/posthtml-parser": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.2.tgz",
+      "integrity": "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/transformer-html/node_modules/posthtml-render": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "dev": true,
+      "dependencies": {
+        "is-json": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/transformer-html/node_modules/posthtml/node_modules/posthtml-parser": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/transformer-html/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@parcel/transformer-html/node_modules/srcset": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
+      "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@parcel/transformer-image": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.8.3.tgz",
+      "integrity": "sha512-cO4uptcCGTi5H6bvTrAWEFUsTNhA4kCo8BSvRSCHA2sf/4C5tGQPHt3JhdO0GQLPwZRCh/R41EkJs5HZ8A8DAg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/transformer-image/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-image/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-image/node_modules/@parcel/workers": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/transformer-image/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-image/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-image/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/transformer-image/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/transformer-image/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-image/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-js": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.8.3.tgz",
+      "integrity": "sha512-9Qd6bib+sWRcpovvzvxwy/PdFrLUXGfmSW9XcVVG8pvgXsZPFaNjnNT8stzGQj1pQiougCoxMY4aTM5p1lGHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "@swc/helpers": "^0.4.12",
+        "browserslist": "^4.6.6",
+        "detect-libc": "^1.0.3",
+        "nullthrows": "^1.1.1",
+        "regenerator-runtime": "^0.13.7",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/transformer-js/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-js/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-js/node_modules/@parcel/workers": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/transformer-js/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-js/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-js/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/transformer-js/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/transformer-js/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-js/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
+    },
+    "node_modules/@parcel/transformer-js/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@parcel/transformer-js/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-json": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.8.3.tgz",
+      "integrity": "sha512-B7LmVq5Q7bZO4ERb6NHtRuUKWGysEeaj9H4zelnyBv+wLgpo4f5FCxSE1/rTNmP9u1qHvQ3scGdK6EdSSokGPg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "json5": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-postcss": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.8.3.tgz",
+      "integrity": "sha512-e8luB/poIlz6jBsD1Izms+6ElbyzuoFVa4lFVLZnTAChI3UxPdt9p/uTsIO46HyBps/Bk8ocvt3J4YF84jzmvg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "clone": "^2.1.1",
+        "nullthrows": "^1.1.1",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-postcss/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-postcss/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-postcss/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-postcss/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-postcss/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/@parcel/transformer-postcss/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/transformer-postcss/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/transformer-postcss/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-postcss/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@parcel/transformer-postcss/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.8.3.tgz",
+      "integrity": "sha512-pkzf9Smyeaw4uaRLsT41RGrPLT5Aip8ZPcntawAfIo+KivBQUV0erY1IvHYjyfFzq1ld/Fo2Ith9He6mxpPifA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "posthtml": "^0.16.5",
+        "posthtml-parser": "^0.10.1",
+        "posthtml-render": "^3.0.0",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/posthtml": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+      "dev": true,
+      "dependencies": {
+        "posthtml-parser": "^0.11.0",
+        "posthtml-render": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/posthtml-parser": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.2.tgz",
+      "integrity": "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/posthtml-render": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "dev": true,
+      "dependencies": {
+        "is-json": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/posthtml/node_modules/posthtml-parser": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@parcel/transformer-posthtml/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-raw": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.8.3.tgz",
+      "integrity": "sha512-G+5cXnd2/1O3nV/pgRxVKZY/HcGSseuhAe71gQdSQftb8uJEURyUHoQ9Eh0JUD3MgWh9V+nIKoyFEZdf9T0sUQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-react-refresh-wrap": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.8.3.tgz",
+      "integrity": "sha512-q8AAoEvBnCf/nPvgOwFwKZfEl/thwq7c2duxXkhl+tTLDRN2vGmyz4355IxCkavSX+pLWSQ5MexklSEeMkgthg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "react-refresh": "^0.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-react-refresh-wrap/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-react-refresh-wrap/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-react-refresh-wrap/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/transformer-react-refresh-wrap/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/transformer-react-refresh-wrap/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-react-refresh-wrap/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/transformer-svg": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.8.3.tgz",
+      "integrity": "sha512-3Zr/gBzxi1ZH1fftH/+KsZU7w5GqkmxlB0ZM8ovS5E/Pl1lq1t0xvGJue9m2VuQqP8Mxfpl5qLFmsKlhaZdMIQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "posthtml": "^0.16.5",
+        "posthtml-parser": "^0.10.1",
+        "posthtml-render": "^3.0.0",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-svg/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/transformer-svg/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/@parcel/transformer-svg/node_modules/posthtml": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+      "dev": true,
+      "dependencies": {
+        "posthtml-parser": "^0.11.0",
+        "posthtml-render": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@parcel/transformer-svg/node_modules/posthtml-parser": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.2.tgz",
+      "integrity": "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/transformer-svg/node_modules/posthtml-render": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "dev": true,
+      "dependencies": {
+        "is-json": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/transformer-svg/node_modules/posthtml/node_modules/posthtml-parser": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@parcel/transformer-svg/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@parcel/types": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.3.tgz",
+      "integrity": "sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/cache": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/package-manager": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/workers": "2.8.3",
+        "utility-types": "^3.10.0"
+      }
+    },
+    "node_modules/@parcel/types/node_modules/@parcel/fs": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+      "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/fs-search": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/types/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/types/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/types/node_modules/@parcel/watcher": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.1.0.tgz",
+      "integrity": "sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^3.2.1",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/types/node_modules/@parcel/workers": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/types/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/types/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/types/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/types/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true
+    },
+    "node_modules/@parcel/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -8731,6 +14585,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "dev": true,
@@ -8759,6 +14622,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@trysound/sax": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -8820,9 +14692,10 @@
       "license": "MIT"
     },
     "node_modules/@types/fetch-mock": {
-      "version": "6.0.6",
-      "dev": true,
-      "license": "MIT"
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-7.3.5.tgz",
+      "integrity": "sha512-sLecm9ohBdGIpYUP9rWk5/XIKY2xHMYTBJIcJuBBM8IJWnYoQ1DAj8F4OVjnfD0API1drlkWEV0LPNk+ACuhsg==",
+      "dev": true
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.8",
@@ -8889,11 +14762,6 @@
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/q": {
-      "version": "1.5.5",
       "dev": true,
       "license": "MIT"
     },
@@ -9300,12 +15168,20 @@
     "node_modules/abab": {
       "version": "2.0.5",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
+      "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -9333,6 +15209,8 @@
       "version": "4.3.4",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
@@ -9342,6 +15220,8 @@
       "version": "6.4.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9353,6 +15233,8 @@
       "version": "6.2.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -9461,11 +15343,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/alphanum-sort": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ansi-align": {
       "version": "3.0.0",
       "dev": true,
@@ -9565,20 +15442,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/ansi-to-html": {
-      "version": "0.6.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^2.0.0"
-      },
-      "bin": {
-        "ansi-to-html": "bin/ansi-to-html"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/ansicolors": {
       "version": "0.3.2",
       "dev": true,
@@ -9594,6 +15457,7 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
@@ -9603,6 +15467,7 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -9615,6 +15480,7 @@
       "version": "3.0.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -9627,6 +15493,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "kind-of": "^6.0.0"
       },
@@ -9638,6 +15505,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "kind-of": "^6.0.0"
       },
@@ -9649,6 +15517,7 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-accessor-descriptor": "^1.0.0",
         "is-data-descriptor": "^1.0.0",
@@ -9662,6 +15531,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-plain-object": "^2.0.4"
       },
@@ -9673,6 +15543,7 @@
       "version": "6.0.3",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9681,6 +15552,7 @@
       "version": "3.1.10",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -9704,6 +15576,7 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "remove-trailing-separator": "^1.0.1"
       },
@@ -9803,7 +15676,9 @@
     "node_modules/array-equal": {
       "version": "1.0.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/array-find-index": {
       "version": "1.0.2",
@@ -9969,7 +15844,8 @@
     "node_modules/async-each": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/async-each-series": {
       "version": "0.1.1",
@@ -9983,7 +15859,9 @@
     "node_modules/async-limiter": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -10154,35 +16032,6 @@
         "regenerator-runtime": "^0.11.0"
       }
     },
-    "node_modules/babel-types": {
-      "version": "6.26.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "node_modules/babel-types/node_modules/to-fast-properties": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babylon-walk": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.11.6",
-        "babel-types": "^6.15.0",
-        "lodash.clone": "^4.5.0"
-      }
-    },
     "node_modules/backo2": {
       "version": "1.0.2",
       "dev": true,
@@ -10212,6 +16061,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base-x": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/base/node_modules/define-property": {
@@ -10375,6 +16233,7 @@
       "version": "1.13.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10383,6 +16242,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -10648,66 +16508,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/brfs": {
-      "version": "1.6.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quote-stream": "^1.0.1",
-        "resolve": "^1.1.5",
-        "static-module": "^2.2.0",
-        "through2": "^2.0.0"
-      },
-      "bin": {
-        "brfs": "bin/cmd.js"
-      }
-    },
-    "node_modules/brfs/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/brfs/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/brfs/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/brfs/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/brfs/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/brfs/node_modules/through2": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
     "node_modules/brorand": {
       "version": "1.1.0",
       "dev": true,
@@ -10731,7 +16531,9 @@
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/browser-resolve": {
       "version": "2.0.0",
@@ -11084,31 +16886,32 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.17.5",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "dev": true,
-      "license": "MIT",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001271",
-        "electron-to-chromium": "^1.3.878",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
       }
-    },
-    "node_modules/browserslist/node_modules/picocolors": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/bs-recipes": {
       "version": "1.3.4",
@@ -11149,14 +16952,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buffer-equal": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/buffer-from": {
@@ -11426,12 +17221,14 @@
     "node_modules/call-me-maybe": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/caller-callsite": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "callsites": "^2.0.0"
       },
@@ -11443,6 +17240,7 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -11494,6 +17292,8 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "browserslist": "^4.0.0",
         "caniuse-lite": "^1.0.0",
@@ -11504,16 +17304,25 @@
     "node_modules/caniuse-api/node_modules/lodash.memoize": {
       "version": "4.1.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001274",
+      "version": "1.0.30001451",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz",
+      "integrity": "sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==",
       "dev": true,
-      "license": "CC-BY-4.0",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -11802,6 +17611,7 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^2.0.0"
       },
@@ -12009,32 +17819,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/coa": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/q": "^1.5.1",
-        "chalk": "^2.4.1",
-        "q": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/coa/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "dev": true,
@@ -12055,15 +17839,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/color": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "license": "MIT",
@@ -12075,14 +17850,13 @@
       "version": "1.1.3",
       "license": "MIT"
     },
-    "node_modules/color-string": {
-      "version": "1.6.0",
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
+      "optional": true,
+      "peer": true
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -12159,11 +17933,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/command-exists": {
-      "version": "1.2.9",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -13198,87 +18967,6 @@
         "node": "*"
       }
     },
-    "node_modules/css-color-names": {
-      "version": "0.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/css-declaration-sorter": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.1",
-        "timsort": "^0.3.0"
-      },
-      "engines": {
-        "node": ">4"
-      }
-    },
-    "node_modules/css-modules-loader-core": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.1",
-        "postcss-modules-extract-imports": "1.1.0",
-        "postcss-modules-local-by-default": "1.2.0",
-        "postcss-modules-scope": "1.1.0",
-        "postcss-modules-values": "1.3.0"
-      }
-    },
-    "node_modules/css-modules-loader-core/node_modules/has-flag": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/css-modules-loader-core/node_modules/postcss": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^1.1.3",
-        "source-map": "^0.5.6",
-        "supports-color": "^3.2.3"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/css-modules-loader-core/node_modules/postcss-modules-extract-imports": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "postcss": "^6.0.1"
-      }
-    },
-    "node_modules/css-modules-loader-core/node_modules/source-map": {
-      "version": "0.5.7",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/css-modules-loader-core/node_modules/supports-color": {
-      "version": "3.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/css-select": {
       "version": "4.1.3",
       "dev": true,
@@ -13292,32 +18980,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-select-base-adapter": {
-      "version": "0.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/css-selector-tokenizer": {
-      "version": "0.7.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "1.0.0-alpha.37",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.4",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/css-what": {
@@ -13338,152 +19000,6 @@
       "bin": {
         "cssesc": "bin/cssesc"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano": {
-      "version": "4.1.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cosmiconfig": "^5.0.0",
-        "cssnano-preset-default": "^4.0.8",
-        "is-resolvable": "^1.0.0",
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-preset-default": {
-      "version": "4.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-declaration-sorter": "^4.0.1",
-        "cssnano-util-raw-cache": "^4.0.1",
-        "postcss": "^7.0.0",
-        "postcss-calc": "^7.0.1",
-        "postcss-colormin": "^4.0.3",
-        "postcss-convert-values": "^4.0.1",
-        "postcss-discard-comments": "^4.0.2",
-        "postcss-discard-duplicates": "^4.0.2",
-        "postcss-discard-empty": "^4.0.1",
-        "postcss-discard-overridden": "^4.0.1",
-        "postcss-merge-longhand": "^4.0.11",
-        "postcss-merge-rules": "^4.0.3",
-        "postcss-minify-font-values": "^4.0.2",
-        "postcss-minify-gradients": "^4.0.2",
-        "postcss-minify-params": "^4.0.2",
-        "postcss-minify-selectors": "^4.0.2",
-        "postcss-normalize-charset": "^4.0.1",
-        "postcss-normalize-display-values": "^4.0.2",
-        "postcss-normalize-positions": "^4.0.2",
-        "postcss-normalize-repeat-style": "^4.0.2",
-        "postcss-normalize-string": "^4.0.2",
-        "postcss-normalize-timing-functions": "^4.0.2",
-        "postcss-normalize-unicode": "^4.0.1",
-        "postcss-normalize-url": "^4.0.1",
-        "postcss-normalize-whitespace": "^4.0.2",
-        "postcss-ordered-values": "^4.1.2",
-        "postcss-reduce-initial": "^4.0.3",
-        "postcss-reduce-transforms": "^4.0.2",
-        "postcss-svgo": "^4.0.3",
-        "postcss-unique-selectors": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-util-get-arguments": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-util-get-match": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-util-raw-cache": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-util-same-parent": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano/node_modules/caller-path": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "caller-callsite": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano/node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano/node_modules/import-fresh": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano/node_modules/parse-json": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -13519,12 +19035,16 @@
     "node_modules/cssom": {
       "version": "0.3.8",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cssstyle": {
       "version": "1.4.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cssom": "0.3.x"
       }
@@ -13581,6 +19101,8 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.0",
         "whatwg-mimetype": "^2.2.0",
@@ -13606,19 +19128,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/deasync": {
-      "version": "0.1.23",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      },
-      "engines": {
-        "node": ">=0.11.0"
       }
     },
     "node_modules/debug": {
@@ -13845,6 +19354,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "dev": true,
@@ -14009,6 +19530,8 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "webidl-conversions": "^4.0.2"
       }
@@ -14119,9 +19642,10 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.885",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.4.295",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.295.tgz",
+      "integrity": "sha512-lEO94zqf1bDA3aepxwnWoHUjA8sZ+2owgcSZjYQy0+uOSEclJX0VieZC+r+wLpSxUHRd6gG32znTWmr+5iGzFw==",
+      "dev": true
     },
     "node_modules/elegant-spinner": {
       "version": "1.0.1",
@@ -14484,6 +20008,7 @@
       "version": "7.8.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "envinfo": "dist/cli.js"
       },
@@ -14627,85 +20152,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "1.9.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/esprima": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/escodegen/node_modules/levn": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/optionator": {
-      "version": "0.8.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/type-check": {
-      "version": "0.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/esinstall": {
@@ -15844,25 +21290,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/falafel": {
-      "version": "2.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^7.1.1",
-        "foreach": "^2.0.5",
-        "isarray": "^2.0.1",
-        "object-keys": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/falafel/node_modules/isarray": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -15901,11 +21328,6 @@
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fastparse": {
-      "version": "1.1.2",
       "dev": true,
       "license": "MIT"
     },
@@ -15948,22 +21370,64 @@
       }
     },
     "node_modules/fetch-mock": {
-      "version": "5.13.1",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.3.0",
-        "node-fetch": "^1.3.3",
-        "path-to-regexp": "^1.7.0"
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "funding": {
+        "type": "charity",
+        "url": "https://www.justgiving.com/refugee-support-europe"
+      },
+      "peerDependencies": {
+        "node-fetch": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
       }
     },
-    "node_modules/fetch-mock/node_modules/node-fetch": {
-      "version": "1.7.3",
+    "node_modules/fetch-mock/node_modules/core-js": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+      "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw==",
       "dev": true,
-      "license": "MIT",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/fetch-mock/node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
+    },
+    "node_modules/fetch-mock/node_modules/whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
       "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/figgy-pudding": {
@@ -15996,7 +21460,8 @@
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/filename-reserved-regex": {
       "version": "1.0.0",
@@ -16946,14 +22411,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/get-port": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/get-stdin": {
       "version": "6.0.0",
       "dev": true,
@@ -17415,7 +22872,8 @@
     "node_modules/glob-to-regexp": {
       "version": "0.3.0",
       "dev": true,
-      "license": "BSD"
+      "license": "BSD",
+      "peer": true
     },
     "node_modules/global-dirs": {
       "version": "0.1.1",
@@ -17520,15 +22978,6 @@
     "node_modules/graceful-fs": {
       "version": "4.2.8",
       "license": "ISC"
-    },
-    "node_modules/grapheme-breaker": {
-      "version": "0.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "brfs": "^1.2.0",
-        "unicode-trie": "^0.3.1"
-      }
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -17748,11 +23197,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "node_modules/hex-color-regex": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "dev": true,
@@ -17787,20 +23231,12 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/hsl-regex": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/hsla-regex": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-encoding": "^1.0.1"
       }
@@ -17809,45 +23245,6 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/htmlnano": {
-      "version": "0.2.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano": "^4.1.11",
-        "posthtml": "^0.15.1",
-        "purgecss": "^2.3.0",
-        "relateurl": "^0.2.7",
-        "srcset": "^3.0.0",
-        "svgo": "^1.3.2",
-        "terser": "^5.6.1",
-        "timsort": "^0.3.0",
-        "uncss": "^0.17.3"
-      }
-    },
-    "node_modules/htmlnano/node_modules/posthtml": {
-      "version": "0.15.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "posthtml-parser": "^0.7.2",
-        "posthtml-render": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/htmlnano/node_modules/posthtml-parser": {
-      "version": "0.7.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "htmlparser2": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
@@ -18375,7 +23772,9 @@
     "node_modules/indexes-of": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/indexof": {
       "version": "0.0.1",
@@ -18625,14 +24024,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-absolute-url": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "dev": true,
@@ -18679,6 +24070,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "binary-extensions": "^1.0.0"
       },
@@ -18715,19 +24107,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-color-stop": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-color-names": "^0.0.4",
-        "hex-color-regex": "^1.1.0",
-        "hsl-regex": "^1.0.0",
-        "hsla-regex": "^1.0.0",
-        "rgb-regex": "^1.0.1",
-        "rgba-regex": "^1.0.0"
       }
     },
     "node_modules/is-core-module": {
@@ -18791,6 +24170,7 @@
       "version": "0.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18862,9 +24242,10 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -18876,6 +24257,8 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "html-tags": "^1.0.0"
       },
@@ -18887,9 +24270,17 @@
       "version": "1.2.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
+      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
+      "dev": true
     },
     "node_modules/is-lambda": {
       "version": "1.0.1",
@@ -19032,11 +24423,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-resolvable": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.1",
       "dev": true,
@@ -19075,6 +24461,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
+      "dev": true
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -19121,11 +24513,6 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/is-url": {
-      "version": "1.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-utf8": {
@@ -19193,11 +24580,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "4.0.8",
@@ -19453,6 +24835,8 @@
       "version": "14.1.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.0",
         "acorn": "^6.0.4",
@@ -19489,6 +24873,8 @@
       "version": "6.4.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -19500,6 +24886,8 @@
       "version": "1.14.3",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -19521,6 +24909,8 @@
       "version": "0.3.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -19533,6 +24923,8 @@
       "version": "0.8.3",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -19548,11 +24940,15 @@
     "node_modules/jsdom/node_modules/parse5": {
       "version": "5.1.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jsdom/node_modules/prelude-ls": {
       "version": "1.1.2",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -19561,6 +24957,8 @@
       "version": "0.3.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
       },
@@ -19572,6 +24970,8 @@
       "version": "6.2.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
@@ -19630,12 +25030,10 @@
       "license": "ISC"
     },
     "node_modules/json5": {
-      "version": "2.2.0",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -20400,6 +25798,203 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.19.0.tgz",
+      "integrity": "sha512-yV5UR7og+Og7lQC+70DA7a8ta1uiOPnWPJfxa0wnxylev5qfo4P+4iMpzWAdYWOca4jdNQZii+bDL/l+4hUXIA==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.19.0",
+        "lightningcss-darwin-x64": "1.19.0",
+        "lightningcss-linux-arm-gnueabihf": "1.19.0",
+        "lightningcss-linux-arm64-gnu": "1.19.0",
+        "lightningcss-linux-arm64-musl": "1.19.0",
+        "lightningcss-linux-x64-gnu": "1.19.0",
+        "lightningcss-linux-x64-musl": "1.19.0",
+        "lightningcss-win32-x64-msvc": "1.19.0"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.19.0.tgz",
+      "integrity": "sha512-wIJmFtYX0rXHsXHSr4+sC5clwblEMji7HHQ4Ub1/CznVRxtCFha6JIt5JZaNf8vQrfdZnBxLLC6R8pC818jXqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.19.0.tgz",
+      "integrity": "sha512-Lif1wD6P4poaw9c/4Uh2z+gmrWhw/HtXFoeZ3bEsv6Ia4tt8rOJBdkfVaUJ6VXmpKHALve+iTyP2+50xY1wKPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.19.0.tgz",
+      "integrity": "sha512-P15VXY5682mTXaiDtbnLYQflc8BYb774j2R84FgDLJTN6Qp0ZjWEFyN1SPqyfTj2B2TFjRHRUvQSSZ7qN4Weig==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.19.0.tgz",
+      "integrity": "sha512-zwXRjWqpev8wqO0sv0M1aM1PpjHz6RVIsBcxKszIG83Befuh4yNysjgHVplF9RTU7eozGe3Ts7r6we1+Qkqsww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.19.0.tgz",
+      "integrity": "sha512-vSCKO7SDnZaFN9zEloKSZM5/kC5gbzUjoJQ43BvUpyTFUX7ACs/mDfl2Eq6fdz2+uWhUh7vf92c4EaaP4udEtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.19.0.tgz",
+      "integrity": "sha512-0AFQKvVzXf9byrXUq9z0anMGLdZJS+XSDqidyijI5njIwj6MdbvX2UZK/c4FfNmeRa2N/8ngTffoIuOUit5eIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.19.0.tgz",
+      "integrity": "sha512-SJoM8CLPt6ECCgSuWe+g0qo8dqQYVcPiW2s19dxkmSI5+Uu1GIRzyKA0b7QqmEXolA+oSJhQqCmJpzjY4CuZAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.19.0.tgz",
+      "integrity": "sha512-C+VuUTeSUOAaBZZOPT7Etn/agx/MatzJzGRkeV+zEABmPuntv1zihncsi+AyGmjkkzq3wVedEy7h0/4S84mUtg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -20641,6 +26236,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lmdb": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "msgpackr": "^1.5.4",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "5.0.3",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
+      },
+      "optionalDependencies": {
+        "@lmdb/lmdb-darwin-arm64": "2.5.2",
+        "@lmdb/lmdb-darwin-x64": "2.5.2",
+        "@lmdb/lmdb-linux-arm": "2.5.2",
+        "@lmdb/lmdb-linux-arm64": "2.5.2",
+        "@lmdb/lmdb-linux-x64": "2.5.2",
+        "@lmdb/lmdb-win32-x64": "2.5.2"
+      }
+    },
+    "node_modules/lmdb/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "dev": true,
@@ -20826,11 +26449,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.clone": {
-      "version": "4.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "dev": true,
@@ -20851,6 +26469,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
     },
     "node_modules/lodash.isfinite": {
       "version": "3.3.2",
@@ -20921,7 +26545,8 @@
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",
@@ -21246,11 +26871,6 @@
         "safe-buffer": "^5.1.2"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "license": "MIT",
@@ -21530,12 +27150,13 @@
       "license": "MIT"
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -21630,6 +27251,7 @@
       "version": "1.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -21950,6 +27572,49 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.3.tgz",
+      "integrity": "sha512-m2JefwcKNzoHYXkH/5jzHRxAw7XLWsAdvu0FOJ+OLwwozwOV/J6UA62iLkfIMbg7G8+dIuRwgg6oz+QoQ4YkoA==",
+      "dev": true,
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.0"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.0.tgz",
+      "integrity": "sha512-oy6KCk1+X4Bn5m6Ycq5N1EWl9npqG/cLrE8ga8NX7ZqfqYUUBS08beCQaGq80fjbKBySur0E6x//yZjzNJDt3A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.0.7"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.0",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.0",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.0",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.0"
+      }
+    },
+    "node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+      "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/multi-semantic-release": {
       "version": "2.11.1",
@@ -22912,9 +28577,10 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.30",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -23048,11 +28714,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-addon-api": {
-      "version": "1.7.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/node-cli": {
       "resolved": "demos/ago-node-cli",
       "link": true
@@ -23134,14 +28795,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/node-forge": {
-      "version": "0.10.0",
-      "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/node-gyp": {
       "version": "5.1.1",
       "dev": true,
@@ -23175,6 +28828,17 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "dev": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-gyp/node_modules/semver": {
@@ -23351,9 +29015,10 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
+      "dev": true
     },
     "node_modules/nopt": {
       "version": "4.0.3",
@@ -26567,6 +32232,12 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true
+    },
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "dev": true,
@@ -26578,7 +32249,9 @@
     "node_modules/nwsapi": {
       "version": "2.2.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
@@ -26671,6 +32344,7 @@
       "version": "2.1.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -26745,6 +32419,7 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^1.0.0"
       },
@@ -26889,6 +32564,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ordered-binary": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.4.0.tgz",
+      "integrity": "sha512-EHQ/jk4/a9hLupIKxTfUsQRej1Yd/0QLQs3vGvIqg5ZtCYSzNhkzHoZc7Zf4e4kUlDaC3Uw8Q/1opOLNN2OKRQ==",
+      "dev": true
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
@@ -27257,302 +32938,236 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/parcel-bundler": {
-      "version": "1.12.5",
+    "node_modules/parcel": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.8.3.tgz",
+      "integrity": "sha512-5rMBpbNE72g6jZvkdR5gS2nyhwIXaJy8i65osOqs/+5b7zgf3eMKgjSsDrv6bhz3gzifsba6MBJiZdBckl+vnA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/config-default": "2.8.3",
+        "@parcel/core": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/package-manager": "2.8.3",
+        "@parcel/reporter-cli": "2.8.3",
+        "@parcel/reporter-dev-server": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chalk": "^4.1.0",
+        "commander": "^7.0.0",
+        "get-port": "^4.2.0",
+        "v8-compile-cache": "^2.0.0"
+      },
+      "bin": {
+        "parcel": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/parcel/node_modules/@parcel/fs": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+      "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/fs-search": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/parcel/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/parcel/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/parcel/node_modules/@parcel/watcher": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.1.0.tgz",
+      "integrity": "sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/core": "^7.4.4",
-        "@babel/generator": "^7.4.4",
-        "@babel/parser": "^7.4.4",
-        "@babel/plugin-transform-flow-strip-types": "^7.4.4",
-        "@babel/plugin-transform-modules-commonjs": "^7.4.4",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/preset-env": "^7.4.4",
-        "@babel/runtime": "^7.4.4",
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "@iarna/toml": "^2.2.0",
-        "@parcel/fs": "^1.11.0",
-        "@parcel/logger": "^1.11.1",
-        "@parcel/utils": "^1.11.0",
-        "@parcel/watcher": "^1.12.1",
-        "@parcel/workers": "^1.11.0",
-        "ansi-to-html": "^0.6.4",
-        "babylon-walk": "^1.0.2",
-        "browserslist": "^4.1.0",
-        "chalk": "^2.1.0",
-        "clone": "^2.1.1",
-        "command-exists": "^1.2.6",
-        "commander": "^2.11.0",
-        "core-js": "^2.6.5",
-        "cross-spawn": "^6.0.4",
-        "css-modules-loader-core": "^1.1.0",
-        "cssnano": "^4.0.0",
-        "deasync": "^0.1.14",
-        "dotenv": "^5.0.0",
-        "dotenv-expand": "^5.1.0",
-        "envinfo": "^7.3.1",
-        "fast-glob": "^2.2.2",
-        "filesize": "^3.6.0",
-        "get-port": "^3.2.0",
-        "htmlnano": "^0.2.2",
-        "is-glob": "^4.0.0",
-        "is-url": "^1.2.2",
-        "js-yaml": "^3.10.0",
-        "json5": "^1.0.1",
-        "micromatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "node-forge": "^0.10.0",
-        "node-libs-browser": "^2.0.0",
-        "opn": "^5.1.0",
-        "postcss": "^7.0.11",
-        "postcss-value-parser": "^3.3.1",
-        "posthtml": "^0.11.2",
-        "posthtml-parser": "^0.4.0",
-        "posthtml-render": "^1.1.3",
-        "resolve": "^1.4.0",
-        "semver": "^5.4.1",
-        "serialize-to-js": "^3.0.0",
-        "serve-static": "^1.12.4",
-        "source-map": "0.6.1",
-        "terser": "^3.7.3",
-        "v8-compile-cache": "^2.0.0",
-        "ws": "^5.1.1"
-      },
-      "bin": {
-        "parcel": "bin/cli.js"
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^3.2.1",
+        "node-gyp-build": "^4.3.0"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/parcel-bundler/node_modules/@nodelib/fs.stat": {
-      "version": "1.1.3",
+    "node_modules/parcel/node_modules/@parcel/workers": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
       }
     },
-    "node_modules/parcel-bundler/node_modules/clone": {
-      "version": "2.1.2",
+    "node_modules/parcel/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=4.8"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/parcel-bundler/node_modules/define-property": {
-      "version": "2.0.2",
+    "node_modules/parcel/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/parcel-bundler/node_modules/dotenv": {
-      "version": "5.0.1",
+    "node_modules/parcel/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.6.0"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "color-name": "~1.1.4"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=7.0.0"
       }
     },
-    "node_modules/parcel-bundler/node_modules/fast-glob": {
-      "version": "2.2.7",
+    "node_modules/parcel/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/parcel/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/parcel/node_modules/get-port": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
+      "integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parcel/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parcel/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true
+    },
+    "node_modules/parcel/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/filesize": {
-      "version": "3.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/is-accessor-descriptor": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/is-data-descriptor": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/is-descriptor": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/json5": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/kind-of": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/micromatch": {
-      "version": "3.1.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/parcel-bundler/node_modules/semver": {
-      "version": "5.7.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/terser": {
-      "version": "3.17.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "commander": "^2.19.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
-      },
-      "bin": {
-        "terser": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/parcel-bundler/node_modules/ws": {
-      "version": "5.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
+        "node": ">=8"
       }
     },
     "node_modules/parent-module": {
@@ -27786,12 +33401,10 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -27835,20 +33448,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/physical-cpu-count": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/picocolors": {
       "version": "0.2.1",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -27944,7 +33555,9 @@
     "node_modules/pn": {
       "version": "1.1.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/portscanner": {
       "version": "2.1.1",
@@ -27978,6 +33591,8 @@
       "version": "7.0.39",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "picocolors": "^0.2.1",
         "source-map": "^0.6.1"
@@ -27990,592 +33605,11 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
-    "node_modules/postcss-calc": {
-      "version": "7.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.27",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.0.2"
-      }
-    },
-    "node_modules/postcss-colormin": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "color": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-colormin/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-convert-values": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-convert-values/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-discard-comments": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-discard-duplicates": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-discard-empty": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-discard-overridden": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-merge-longhand": {
-      "version": "4.0.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-color-names": "0.0.4",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "stylehacks": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-merge-longhand/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-merge-rules": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "cssnano-util-same-parent": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0",
-        "vendors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-merge-rules/node_modules/dot-prop": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-merge-rules/node_modules/is-obj": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-minify-font-values": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-font-values/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-minify-gradients": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "is-color-stop": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-gradients/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-minify-params": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "alphanum-sort": "^1.0.0",
-        "browserslist": "^4.0.0",
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "uniqs": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-params/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-minify-selectors": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "alphanum-sort": "^1.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-selectors/node_modules/dot-prop": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-minify-selectors/node_modules/is-obj": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default/node_modules/postcss": {
-      "version": "6.0.23",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-modules-scope": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
-      }
-    },
-    "node_modules/postcss-modules-scope/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-modules-scope/node_modules/postcss": {
-      "version": "6.0.23",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-modules-values": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "icss-replace-symbols": "^1.1.0",
-        "postcss": "^6.0.1"
-      }
-    },
-    "node_modules/postcss-modules-values/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-modules-values/node_modules/postcss": {
-      "version": "6.0.23",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-normalize-charset": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-display-values": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-display-values/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-positions": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-positions/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-repeat-style": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-repeat-style/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-string": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-string/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-timing-functions": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-timing-functions/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-unicode": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-unicode/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-url": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-url/node_modules/normalize-url": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/postcss-normalize-url/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-whitespace": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-whitespace/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-ordered-values": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-ordered-values/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-reduce-initial": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-reduce-transforms": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-match": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-reduce-transforms/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.6",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -28584,150 +33618,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/postcss-svgo": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "svgo": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-svgo/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/postcss-unique-selectors": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "alphanum-sort": "^1.0.0",
-        "postcss": "^7.0.0",
-        "uniqs": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/postcss-value-parser": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/posthtml": {
-      "version": "0.11.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "posthtml-parser": "^0.4.1",
-        "posthtml-render": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/posthtml-parser": {
-      "version": "0.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "htmlparser2": "^3.9.2"
-      }
-    },
-    "node_modules/posthtml-parser/node_modules/dom-serializer": {
-      "version": "0.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/posthtml-parser/node_modules/dom-serializer/node_modules/domelementtype": {
-      "version": "2.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/posthtml-parser/node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/posthtml-parser/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/posthtml-parser/node_modules/domhandler": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/posthtml-parser/node_modules/domutils": {
-      "version": "1.7.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/posthtml-parser/node_modules/entities": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/posthtml-parser/node_modules/htmlparser2": {
-      "version": "3.10.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "node_modules/posthtml-parser/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/posthtml-render": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -29030,69 +33925,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/purgecss": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^5.0.0",
-        "glob": "^7.0.0",
-        "postcss": "7.0.32",
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "bin": {
-        "purgecss": "bin/purgecss"
-      }
-    },
-    "node_modules/purgecss/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/purgecss/node_modules/commander": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/purgecss/node_modules/postcss": {
-      "version": "7.0.32",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/postcss"
-      }
-    },
-    "node_modules/purgecss/node_modules/postcss/node_modules/supports-color": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/q": {
       "version": "1.5.1",
       "dev": true,
@@ -29170,65 +34002,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/quote-stream": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal": "0.0.1",
-        "minimist": "^1.1.3",
-        "through2": "^2.0.0"
-      },
-      "bin": {
-        "quote-stream": "bin/cmd.js"
-      }
-    },
-    "node_modules/quote-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/quote-stream/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/quote-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/quote-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/quote-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/quote-stream/node_modules/through2": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
       }
     },
     "node_modules/random-bytes": {
@@ -29353,6 +34126,21 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
+      "dev": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29505,6 +34293,7 @@
       "version": "2.2.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
@@ -29518,6 +34307,7 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -29530,6 +34320,7 @@
       "version": "3.0.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -29542,6 +34333,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "kind-of": "^6.0.0"
       },
@@ -29553,6 +34345,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "kind-of": "^6.0.0"
       },
@@ -29564,6 +34357,7 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-accessor-descriptor": "^1.0.0",
         "is-data-descriptor": "^1.0.0",
@@ -29577,6 +34371,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-plain-object": "^2.0.4"
       },
@@ -29588,6 +34383,7 @@
       "version": "6.0.3",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29596,6 +34392,7 @@
       "version": "3.1.10",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -29787,6 +34584,8 @@
       "version": "0.2.7",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -29857,6 +34656,8 @@
       "version": "1.1.4",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19"
       },
@@ -29871,6 +34672,8 @@
       "version": "1.0.9",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
@@ -30092,6 +34895,7 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -30126,16 +34930,6 @@
     },
     "node_modules/rfdc": {
       "version": "1.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rgb-regex": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rgba-regex": {
-      "version": "1.0.0",
       "dev": true,
       "license": "MIT"
     },
@@ -30451,15 +35245,12 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/saxes": {
       "version": "3.1.11",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xmlchars": "^2.1.1"
       },
@@ -33895,14 +38686,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/serialize-to-js": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -34080,11 +38863,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/shallow-copy": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/shebang-command": {
       "version": "1.2.0",
       "dev": true,
@@ -34166,19 +38944,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -35331,17 +40096,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/srcset": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/sri-toolbox": {
       "version": "0.2.0",
       "dev": true,
@@ -35395,81 +40149,6 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/static-eval": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escodegen": "^1.11.1"
-      }
-    },
-    "node_modules/static-eval/node_modules/escodegen": {
-      "version": "1.14.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/static-eval/node_modules/levn": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/optionator": {
-      "version": "0.8.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/type-check": {
-      "version": "0.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "dev": true,
@@ -35480,110 +40159,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-module": {
-      "version": "2.2.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "concat-stream": "~1.6.0",
-        "convert-source-map": "^1.5.1",
-        "duplexer2": "~0.1.4",
-        "escodegen": "~1.9.0",
-        "falafel": "^2.1.0",
-        "has": "^1.0.1",
-        "magic-string": "^0.22.4",
-        "merge-source-map": "1.0.4",
-        "object-inspect": "~1.4.0",
-        "quote-stream": "~1.0.2",
-        "readable-stream": "~2.3.3",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "^2.0.0",
-        "through2": "~2.0.3"
-      }
-    },
-    "node_modules/static-module/node_modules/duplexer2": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/static-module/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/magic-string": {
-      "version": "0.22.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "vlq": "^0.2.2"
-      }
-    },
-    "node_modules/static-module/node_modules/merge-source-map": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "^0.5.6"
-      }
-    },
-    "node_modules/static-module/node_modules/object-inspect": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/static-module/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/source-map": {
-      "version": "0.5.7",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-module/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/static-module/node_modules/through2": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
       }
     },
     "node_modules/statuses": {
@@ -35599,6 +40174,8 @@
       "version": "1.1.1",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -35936,51 +40513,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/stylehacks": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/stylehacks/node_modules/dot-prop": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/stylehacks/node_modules/is-obj": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/stylehacks/node_modules/postcss-selector-parser": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "license": "MIT",
@@ -36022,98 +40554,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/svgo": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "coa": "^2.0.2",
-        "css-select": "^2.0.0",
-        "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.37",
-        "csso": "^4.0.2",
-        "js-yaml": "^3.13.1",
-        "mkdirp": "~0.5.1",
-        "object.values": "^1.1.0",
-        "sax": "~1.2.4",
-        "stable": "^0.1.8",
-        "unquote": "~1.1.1",
-        "util.promisify": "~1.0.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/svgo/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/svgo/node_modules/css-select": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^3.2.1",
-        "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
-      }
-    },
-    "node_modules/svgo/node_modules/css-what": {
-      "version": "3.4.2",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/svgo/node_modules/dom-serializer": {
-      "version": "0.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/svgo/node_modules/domutils": {
-      "version": "1.7.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/svgo/node_modules/domutils/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/svgo/node_modules/nth-check": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "~1.0.0"
-      }
-    },
     "node_modules/symbol-observable": {
       "version": "1.0.1",
       "dev": true,
@@ -36125,7 +40565,9 @@
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/table": {
       "version": "6.7.1",
@@ -36525,14 +40967,28 @@
         "node": ">=8"
       }
     },
-    "node_modules/terser": {
-      "version": "5.7.2",
+    "node_modules/term-size": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.16.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.3.tgz",
+      "integrity": "sha512-v8wWLaS/xt3nE9dgKEWhNUFP6q4kngO5B8eYFUuebsu7Dw/UNAnpUod6UHo04jSSkv8TzKHjZDSd7EXdDQAl8Q==",
+      "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
+        "source-map-support": "~0.5.20"
       },
       "bin": {
         "terser": "bin/terser"
@@ -36827,12 +41283,16 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.7.3",
+    "node_modules/terser/node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
-      "license": "BSD-3-Clause",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
       "engines": {
-        "node": ">= 8"
+        "node": ">=0.4.0"
       }
     },
     "node_modules/text-extensions": {
@@ -36902,11 +41362,6 @@
     },
     "node_modules/timsort": {
       "version": "0.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tiny-inflate": {
-      "version": "1.0.3",
       "dev": true,
       "license": "MIT"
     },
@@ -37338,8 +41793,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -37808,6 +42264,8 @@
       "version": "0.17.3",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^2.20.0",
         "glob": "^7.1.4",
@@ -37830,6 +42288,8 @@
       "version": "3.0.3",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -37838,6 +42298,8 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "indexes-of": "^1.0.1",
@@ -37883,20 +42345,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/unicode-trie": {
-      "version": "0.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pako": "^0.2.5",
-        "tiny-inflate": "^1.0.0"
-      }
-    },
-    "node_modules/unicode-trie/node_modules/pako": {
-      "version": "0.2.9",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "dev": true,
@@ -37914,12 +42362,9 @@
     "node_modules/uniq": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/uniqs": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",
@@ -37981,11 +42426,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/unquote": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/unset-value": {
       "version": "1.0.0",
@@ -38055,6 +42495,38 @@
         "node": ">=4",
         "yarn": "*"
       }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/update-browserslist-db/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -38135,13 +42607,13 @@
         "object.getownpropertydescriptors": "^2.0.3"
       }
     },
-    "node_modules/util.promisify": {
-      "version": "1.0.0",
+    "node_modules/utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/utils-merge": {
@@ -38192,15 +42664,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/vendors": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/verror": {
@@ -38318,11 +42781,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
       }
-    },
-    "node_modules/vlq": {
-      "version": "0.2.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
@@ -38482,6 +42940,8 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }
@@ -38490,6 +42950,8 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "domexception": "^1.0.1",
         "webidl-conversions": "^4.0.2",
@@ -38552,6 +43014,12 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/weak-lru-cache": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
+      "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
+      "dev": true
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.1.1",
@@ -39142,6 +43610,8 @@
       "version": "1.0.5",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "0.4.24"
       }
@@ -39149,12 +43619,15 @@
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -39682,12 +44155,16 @@
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "1.6.3",
@@ -39703,6 +44180,12 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
+      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
+      "dev": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -39871,7 +44354,7 @@
     },
     "packages/arcgis-rest-feature-service": {
       "name": "@esri/arcgis-rest-feature-service",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -39956,7 +44439,7 @@
     },
     "packages/arcgis-rest-portal": {
       "name": "@esri/arcgis-rest-portal",
-      "version": "4.0.6",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -39973,7 +44456,7 @@
     },
     "packages/arcgis-rest-request": {
       "name": "@esri/arcgis-rest-request",
-      "version": "4.0.4",
+      "version": "4.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@esri/arcgis-rest-fetch": "^4.0.0",
@@ -39995,7 +44478,7 @@
     },
     "packages/arcgis-rest-routing": {
       "name": "@esri/arcgis-rest-routing",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@terraformer/arcgis": "^2.0.7",
@@ -40495,25 +44978,11 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
-    "@babel/plugin-syntax-flow": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      }
-    },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      }
-    },
-    "@babel/plugin-syntax-jsx": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -40658,14 +45127,6 @@
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
-    "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/plugin-syntax-flow": "^7.16.0"
-      }
-    },
     "@babel/plugin-transform-for-of": {
       "version": "7.15.4",
       "dev": true,
@@ -40767,17 +45228,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
-      }
-    },
-    "@babel/plugin-transform-react-jsx": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/plugin-syntax-jsx": "^7.16.0",
-        "@babel/types": "^7.16.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -41605,7 +46055,7 @@
       "requires": {
         "@esri/arcgis-rest-portal": "^4.0.0",
         "@esri/arcgis-rest-request": "^4.0.0",
-        "parcel-bundler": "^1.12.5"
+        "parcel": "^2.0.0"
       }
     },
     "@esri/arcgis-rest-demo-snowpack": {
@@ -42487,10 +46937,6 @@
       "version": "1.2.0",
       "dev": true
     },
-    "@iarna/toml": {
-      "version": "2.2.5",
-      "dev": true
-    },
     "@isaacs/string-locale-compare": {
       "version": "1.1.0",
       "dev": true
@@ -42499,11 +46945,38 @@
       "version": "0.1.3",
       "dev": true
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
       "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
@@ -44552,6 +49025,63 @@
         }
       }
     },
+    "@lezer/common": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
+      "dev": true
+    },
+    "@lezer/lr": {
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
+      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^0.15.0"
+      }
+    },
+    "@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "dev": true,
+      "optional": true
+    },
     "@manypkg/find-root": {
       "version": "1.1.0",
       "dev": true,
@@ -44653,13 +49183,67 @@
         }
       }
     },
+    "@mischnic/json-sourcemap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
+      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^0.15.7",
+        "@lezer/lr": "^0.15.4",
+        "json5": "^2.2.1"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "dev": true,
+      "peer": true,
       "requires": {
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
       }
+    },
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.0.tgz",
+      "integrity": "sha512-5qpnNHUyyEj9H3sm/4Um/bnx1lrQGhe8iqry/1d+cQYCRd/gzYA0YLeq0ezlk4hKx4vO+dsEsNyeowqRqslwQA==",
+      "dev": true,
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.0.tgz",
+      "integrity": "sha512-ZphTFFd6SFweNAMKD+QJCrWpgkjf4qBuHltiMkKkD6FFrB3NOTRVmetAGTkJ57pa+s6J0yCH06LujWB9rZe94g==",
+      "dev": true,
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.0.tgz",
+      "integrity": "sha512-ztKVV1dO/sSZyGse0PBCq3Pk1PkYjsA/dsEWE7lfrGoAK3i9HpS2o7XjGQ7V4va6nX+xPPOiuYpQwa4Bi6vlww==",
+      "dev": true,
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.0.tgz",
+      "integrity": "sha512-NEX6hdSvP4BmVyegaIbrGxvHzHvTzzsPaxXCsUt0mbLbPpEftsvNwaEVKOowXnLoeuGeD4MaqSwL3BUK2elsUA==",
+      "dev": true,
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.0.tgz",
+      "integrity": "sha512-9uvdAkZMOPCY7SPRxZLW8XGqBOVNVEhqlgffenN8shA1XR9FWVsSM13nr/oHtNgXg6iVyML7RwWPyqUeThlwxg==",
+      "dev": true,
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.0.tgz",
+      "integrity": "sha512-Wg0+9615kHKlr9iLVcG5I+/CHnf6w3x5UADRv8Ad16yA0Bu5l9eVOROjV7aHPG6uC8ZPFIVVaoSjDChD+Y0pzg==",
+      "dev": true,
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -45118,102 +49702,3960 @@
         "@octokit/openapi-types": "^11.2.0"
       }
     },
-    "@parcel/fs": {
-      "version": "1.11.0",
+    "@parcel/bundler-default": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.8.3.tgz",
+      "integrity": "sha512-yJvRsNWWu5fVydsWk3O2L4yIy3UZiKWO2cPDukGOIWMgp/Vbpp+2Ct5IygVRtE22bnseW/E/oe0PV3d2IkEJGg==",
       "dev": true,
       "requires": {
-        "@parcel/utils": "^1.11.0",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.2"
-      }
-    },
-    "@parcel/logger": {
-      "version": "1.11.1",
-      "dev": true,
-      "requires": {
-        "@parcel/workers": "^1.11.0",
-        "chalk": "^2.1.0",
-        "grapheme-breaker": "^0.3.2",
-        "ora": "^2.1.0",
-        "strip-ansi": "^4.0.0"
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/graph": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "dev": true
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
         },
         "chalk": {
-          "version": "2.4.2",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
-        "cli-spinners": {
-          "version": "1.3.1",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "ora": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.3.1",
-            "cli-cursor": "^2.1.0",
-            "cli-spinners": "^1.1.0",
-            "log-symbols": "^2.2.0",
-            "strip-ansi": "^4.0.0",
-            "wcwidth": "^1.0.1"
-          }
-        },
-        "strip-ansi": {
+        "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
     },
-    "@parcel/utils": {
-      "version": "1.11.0",
-      "dev": true
-    },
-    "@parcel/watcher": {
-      "version": "1.12.1",
+    "@parcel/cache": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.3.tgz",
+      "integrity": "sha512-k7xv5vSQrJLdXuglo+Hv3yF4BCSs1tQ/8Vbd6CHTkOhf7LcGg6CPtLw053R/KdMpd/4GPn0QrAsOLdATm1ELtQ==",
       "dev": true,
       "requires": {
-        "@parcel/utils": "^1.11.0",
-        "chokidar": "^2.1.5"
+        "@parcel/fs": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "lmdb": "2.5.2"
       },
       "dependencies": {
-        "chokidar": {
-          "version": "2.1.8",
+        "@parcel/fs": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+          "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
           "dev": true,
           "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.1",
-            "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.3",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^3.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.2.1",
-            "upath": "^1.1.1"
+            "@parcel/fs-search": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "@parcel/watcher": "^2.0.7",
+            "@parcel/workers": "2.8.3"
+          }
+        },
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/watcher": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.1.0.tgz",
+          "integrity": "sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3",
+            "micromatch": "^4.0.5",
+            "node-addon-api": "^3.2.1",
+            "node-gyp-build": "^4.3.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+          "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "node-addon-api": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
     },
-    "@parcel/workers": {
-      "version": "1.11.0",
+    "@parcel/codeframe": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.3.tgz",
+      "integrity": "sha512-FE7sY53D6n/+2Pgg6M9iuEC6F5fvmyBkRE4d9VdnOoxhTXtkEqpqYgX7RJ12FAQwNlxKq4suBJQMgQHMF2Kjeg==",
       "dev": true,
       "requires": {
-        "@parcel/utils": "^1.11.0",
-        "physical-cpu-count": "^2.0.0"
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/compressor-raw": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.8.3.tgz",
+      "integrity": "sha512-bVDsqleBUxRdKMakWSlWC9ZjOcqDKE60BE+Gh3JSN6WJrycJ02P5wxjTVF4CStNP/G7X17U+nkENxSlMG77ySg==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3"
+      }
+    },
+    "@parcel/config-default": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.8.3.tgz",
+      "integrity": "sha512-o/A/mbrO6X/BfGS65Sib8d6SSG45NYrNooNBkH/o7zbOBSRQxwyTlysleK1/3Wa35YpvFyLOwgfakqCtbGy4fw==",
+      "dev": true,
+      "requires": {
+        "@parcel/bundler-default": "2.8.3",
+        "@parcel/compressor-raw": "2.8.3",
+        "@parcel/namer-default": "2.8.3",
+        "@parcel/optimizer-css": "2.8.3",
+        "@parcel/optimizer-htmlnano": "2.8.3",
+        "@parcel/optimizer-image": "2.8.3",
+        "@parcel/optimizer-svgo": "2.8.3",
+        "@parcel/optimizer-terser": "2.8.3",
+        "@parcel/packager-css": "2.8.3",
+        "@parcel/packager-html": "2.8.3",
+        "@parcel/packager-js": "2.8.3",
+        "@parcel/packager-raw": "2.8.3",
+        "@parcel/packager-svg": "2.8.3",
+        "@parcel/reporter-dev-server": "2.8.3",
+        "@parcel/resolver-default": "2.8.3",
+        "@parcel/runtime-browser-hmr": "2.8.3",
+        "@parcel/runtime-js": "2.8.3",
+        "@parcel/runtime-react-refresh": "2.8.3",
+        "@parcel/runtime-service-worker": "2.8.3",
+        "@parcel/transformer-babel": "2.8.3",
+        "@parcel/transformer-css": "2.8.3",
+        "@parcel/transformer-html": "2.8.3",
+        "@parcel/transformer-image": "2.8.3",
+        "@parcel/transformer-js": "2.8.3",
+        "@parcel/transformer-json": "2.8.3",
+        "@parcel/transformer-postcss": "2.8.3",
+        "@parcel/transformer-posthtml": "2.8.3",
+        "@parcel/transformer-raw": "2.8.3",
+        "@parcel/transformer-react-refresh-wrap": "2.8.3",
+        "@parcel/transformer-svg": "2.8.3"
+      }
+    },
+    "@parcel/core": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.3.tgz",
+      "integrity": "sha512-Euf/un4ZAiClnlUXqPB9phQlKbveU+2CotZv7m7i+qkgvFn5nAGnrV4h1OzQU42j9dpgOxWi7AttUDMrvkbhCQ==",
+      "dev": true,
+      "requires": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/cache": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/graph": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/package-manager": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "abortcontroller-polyfill": "^1.1.9",
+        "base-x": "^3.0.8",
+        "browserslist": "^4.6.6",
+        "clone": "^2.1.1",
+        "dotenv": "^7.0.0",
+        "dotenv-expand": "^5.1.0",
+        "json5": "^2.2.0",
+        "msgpackr": "^1.5.4",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "@parcel/fs": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+          "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+          "dev": true,
+          "requires": {
+            "@parcel/fs-search": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "@parcel/watcher": "^2.0.7",
+            "@parcel/workers": "2.8.3"
+          }
+        },
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/watcher": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.1.0.tgz",
+          "integrity": "sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3",
+            "micromatch": "^4.0.5",
+            "node-addon-api": "^3.2.1",
+            "node-gyp-build": "^4.3.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+          "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "dotenv": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+          "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "node-addon-api": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/diagnostic": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
+      "integrity": "sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==",
+      "dev": true,
+      "requires": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "nullthrows": "^1.1.1"
+      }
+    },
+    "@parcel/events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.3.tgz",
+      "integrity": "sha512-hoIS4tAxWp8FJk3628bsgKxEvR7bq2scCVYHSqZ4fTi/s0+VymEATrRCUqf+12e5H47uw1/ZjoqrGtBI02pz4w==",
+      "dev": true
+    },
+    "@parcel/fs-search": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.3.tgz",
+      "integrity": "sha512-DJBT2N8knfN7Na6PP2mett3spQLTqxFrvl0gv+TJRp61T8Ljc4VuUTb0hqBj+belaASIp3Q+e8+SgaFQu7wLiQ==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3"
+      }
+    },
+    "@parcel/graph": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.8.3.tgz",
+      "integrity": "sha512-26GL8fYZPdsRhSXCZ0ZWliloK6DHlMJPWh6Z+3VVZ5mnDSbYg/rRKWmrkhnr99ZWmL9rJsv4G74ZwvDEXTMPBg==",
+      "dev": true,
+      "requires": {
+        "nullthrows": "^1.1.1"
+      }
+    },
+    "@parcel/hash": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.3.tgz",
+      "integrity": "sha512-FVItqzjWmnyP4ZsVgX+G00+6U2IzOvqDtdwQIWisCcVoXJFCqZJDy6oa2qDDFz96xCCCynjRjPdQx2jYBCpfYw==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "xxhash-wasm": "^0.4.2"
+      }
+    },
+    "@parcel/markdown-ansi": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.3.tgz",
+      "integrity": "sha512-4v+pjyoh9f5zuU/gJlNvNFGEAb6J90sOBwpKJYJhdWXLZMNFCVzSigxrYO+vCsi8G4rl6/B2c0LcwIMjGPHmFQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/namer-default": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.8.3.tgz",
+      "integrity": "sha512-tJ7JehZviS5QwnxbARd8Uh63rkikZdZs1QOyivUhEvhN+DddSAVEdQLHGPzkl3YRk0tjFhbqo+Jci7TpezuAMw==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "nullthrows": "^1.1.1"
+      }
+    },
+    "@parcel/node-resolver-core": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.8.3.tgz",
+      "integrity": "sha512-12YryWcA5Iw2WNoEVr/t2HDjYR1iEzbjEcxfh1vaVDdZ020PiGw67g5hyIE/tsnG7SRJ0xdRx1fQ2hDgED+0Ww==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/optimizer-css": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.8.3.tgz",
+      "integrity": "sha512-JotGAWo8JhuXsQDK0UkzeQB0UR5hDAKvAviXrjqB4KM9wZNLhLleeEAW4Hk8R9smCeQFP6Xg/N/NkLDpqMwT3g==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "browserslist": "^4.6.6",
+        "lightningcss": "^1.16.1",
+        "nullthrows": "^1.1.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/optimizer-htmlnano": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.8.3.tgz",
+      "integrity": "sha512-L8/fHbEy8Id2a2E0fwR5eKGlv9VYDjrH9PwdJE9Za9v1O/vEsfl/0T/79/x129l5O0yB6EFQkFa20MiK3b+vOg==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "htmlnano": "^2.0.0",
+        "nullthrows": "^1.1.1",
+        "posthtml": "^0.16.5",
+        "svgo": "^2.4.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "css-declaration-sorter": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
+          "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {}
+        },
+        "css-tree": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+          "dev": true,
+          "requires": {
+            "mdn-data": "2.0.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "cssnano": {
+          "version": "5.1.14",
+          "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.14.tgz",
+          "integrity": "sha512-Oou7ihiTocbKqi0J1bB+TRJIQX5RMR3JghA8hcWSw9mjBLQ5Y3RWqEDoYG3sRNlAbCIXpqMoZGbq5KDR3vdzgw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "cssnano-preset-default": "^5.2.13",
+            "lilconfig": "^2.0.3",
+            "yaml": "^1.10.2"
+          }
+        },
+        "cssnano-preset-default": {
+          "version": "5.2.13",
+          "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.13.tgz",
+          "integrity": "sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "css-declaration-sorter": "^6.3.1",
+            "cssnano-utils": "^3.1.0",
+            "postcss-calc": "^8.2.3",
+            "postcss-colormin": "^5.3.0",
+            "postcss-convert-values": "^5.1.3",
+            "postcss-discard-comments": "^5.1.2",
+            "postcss-discard-duplicates": "^5.1.0",
+            "postcss-discard-empty": "^5.1.1",
+            "postcss-discard-overridden": "^5.1.0",
+            "postcss-merge-longhand": "^5.1.7",
+            "postcss-merge-rules": "^5.1.3",
+            "postcss-minify-font-values": "^5.1.0",
+            "postcss-minify-gradients": "^5.1.1",
+            "postcss-minify-params": "^5.1.4",
+            "postcss-minify-selectors": "^5.2.1",
+            "postcss-normalize-charset": "^5.1.0",
+            "postcss-normalize-display-values": "^5.1.0",
+            "postcss-normalize-positions": "^5.1.1",
+            "postcss-normalize-repeat-style": "^5.1.1",
+            "postcss-normalize-string": "^5.1.0",
+            "postcss-normalize-timing-functions": "^5.1.0",
+            "postcss-normalize-unicode": "^5.1.1",
+            "postcss-normalize-url": "^5.1.0",
+            "postcss-normalize-whitespace": "^5.1.1",
+            "postcss-ordered-values": "^5.1.3",
+            "postcss-reduce-initial": "^5.1.1",
+            "postcss-reduce-transforms": "^5.1.0",
+            "postcss-svgo": "^5.1.0",
+            "postcss-unique-selectors": "^5.1.1"
+          }
+        },
+        "cssnano-utils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+          "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {}
+        },
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+          "dev": true
+        },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "htmlnano": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.3.tgz",
+          "integrity": "sha512-S4PGGj9RbdgW8LhbILNK7W9JhmYP8zmDY7KDV/8eCiJBQJlbmltp5I0gv8c5ntLljfdxxfmJ+UJVSqyH4mb41A==",
+          "dev": true,
+          "requires": {
+            "cosmiconfig": "^7.0.1",
+            "posthtml": "^0.16.5",
+            "timsort": "^0.3.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "normalize-url": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+          "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "picocolors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "8.4.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+          "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "nanoid": "^3.3.4",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.2"
+          }
+        },
+        "postcss-calc": {
+          "version": "8.2.4",
+          "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
+          "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.9",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-colormin": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
+          "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "browserslist": "^4.16.6",
+            "caniuse-api": "^3.0.0",
+            "colord": "^2.9.1",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-convert-values": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+          "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "browserslist": "^4.21.4",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-discard-comments": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
+          "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {}
+        },
+        "postcss-discard-duplicates": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+          "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {}
+        },
+        "postcss-discard-empty": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
+          "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {}
+        },
+        "postcss-discard-overridden": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+          "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {}
+        },
+        "postcss-merge-longhand": {
+          "version": "5.1.7",
+          "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+          "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0",
+            "stylehacks": "^5.1.1"
+          }
+        },
+        "postcss-merge-rules": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.3.tgz",
+          "integrity": "sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "browserslist": "^4.21.4",
+            "caniuse-api": "^3.0.0",
+            "cssnano-utils": "^3.1.0",
+            "postcss-selector-parser": "^6.0.5"
+          }
+        },
+        "postcss-minify-font-values": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+          "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-minify-gradients": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
+          "integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "colord": "^2.9.1",
+            "cssnano-utils": "^3.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-minify-params": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+          "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "browserslist": "^4.21.4",
+            "cssnano-utils": "^3.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-minify-selectors": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
+          "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.5"
+          }
+        },
+        "postcss-normalize-charset": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+          "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {}
+        },
+        "postcss-normalize-display-values": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+          "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-positions": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
+          "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-repeat-style": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
+          "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-string": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+          "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-timing-functions": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+          "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-unicode": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+          "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "browserslist": "^4.21.4",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-url": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+          "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "normalize-url": "^6.0.1",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-whitespace": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
+          "integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-ordered-values": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
+          "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "cssnano-utils": "^3.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-reduce-initial": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.1.tgz",
+          "integrity": "sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "browserslist": "^4.21.4",
+            "caniuse-api": "^3.0.0"
+          }
+        },
+        "postcss-reduce-transforms": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+          "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-svgo": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+          "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0",
+            "svgo": "^2.7.0"
+          }
+        },
+        "postcss-unique-selectors": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
+          "integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.5"
+          }
+        },
+        "posthtml": {
+          "version": "0.16.6",
+          "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+          "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+          "dev": true,
+          "requires": {
+            "posthtml-parser": "^0.11.0",
+            "posthtml-render": "^3.0.0"
+          }
+        },
+        "posthtml-parser": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+          "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+          "dev": true,
+          "requires": {
+            "htmlparser2": "^7.1.1"
+          }
+        },
+        "posthtml-render": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+          "dev": true,
+          "requires": {
+            "is-json": "^2.0.1"
+          }
+        },
+        "purgecss": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-5.0.0.tgz",
+          "integrity": "sha512-RAnuxrGuVyLLTr8uMbKaxDRGWMgK5CCYDfRyUNNcaz5P3kGgD2b7ymQGYEyo2ST7Tl/ScwFgf5l3slKMxHSbrw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "commander": "^9.0.0",
+            "glob": "^8.0.3",
+            "postcss": "^8.4.4",
+            "postcss-selector-parser": "^6.0.7"
+          }
+        },
+        "source-map-js": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+          "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "srcset": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
+          "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "stylehacks": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+          "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "browserslist": "^4.21.4",
+            "postcss-selector-parser": "^6.0.4"
+          }
+        },
+        "svgo": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+          "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+          "dev": true,
+          "requires": {
+            "@trysound/sax": "0.2.0",
+            "commander": "^7.2.0",
+            "css-select": "^4.1.3",
+            "css-tree": "^1.1.3",
+            "csso": "^4.2.0",
+            "picocolors": "^1.0.0",
+            "stable": "^0.1.8"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+              "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "@parcel/optimizer-image": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.8.3.tgz",
+      "integrity": "sha512-SD71sSH27SkCDNUNx9A3jizqB/WIJr3dsfp+JZGZC42tpD/Siim6Rqy9M4To/BpMMQIIiEXa5ofwS+DgTEiEHQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "detect-libc": "^1.0.3"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+          "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/optimizer-svgo": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.8.3.tgz",
+      "integrity": "sha512-9KQed99NZnQw3/W4qBYVQ7212rzA9EqrQG019TIWJzkA9tjGBMIm2c/nXpK1tc3hQ3e7KkXkFCQ3C+ibVUnHNA==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "svgo": "^2.4.0"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "dev": true
+        },
+        "css-tree": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+          "dev": true,
+          "requires": {
+            "mdn-data": "2.0.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "mdn-data": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+          "dev": true
+        },
+        "picocolors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "svgo": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+          "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+          "dev": true,
+          "requires": {
+            "@trysound/sax": "0.2.0",
+            "commander": "^7.2.0",
+            "css-select": "^4.1.3",
+            "css-tree": "^1.1.3",
+            "csso": "^4.2.0",
+            "picocolors": "^1.0.0",
+            "stable": "^0.1.8"
+          }
+        }
+      }
+    },
+    "@parcel/optimizer-terser": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.8.3.tgz",
+      "integrity": "sha512-9EeQlN6zIeUWwzrzu6Q2pQSaYsYGah8MtiQ/hog9KEPlYTP60hBv/+utDyYEHSQhL7y5ym08tPX5GzBvwAD/dA==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "terser": "^5.2.0"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/package-manager": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.3.tgz",
+      "integrity": "sha512-tIpY5pD2lH53p9hpi++GsODy6V3khSTX4pLEGuMpeSYbHthnOViobqIlFLsjni+QA1pfc8NNNIQwSNdGjYflVA==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "@parcel/fs": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+          "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+          "dev": true,
+          "requires": {
+            "@parcel/fs-search": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "@parcel/watcher": "^2.0.7",
+            "@parcel/workers": "2.8.3"
+          }
+        },
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/watcher": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.1.0.tgz",
+          "integrity": "sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3",
+            "micromatch": "^4.0.5",
+            "node-addon-api": "^3.2.1",
+            "node-gyp-build": "^4.3.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+          "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "node-addon-api": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/packager-css": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.8.3.tgz",
+      "integrity": "sha512-WyvkMmsurlHG8d8oUVm7S+D+cC/T3qGeqogb7sTI52gB6uiywU7lRCizLNqGFyFGIxcVTVHWnSHqItBcLN76lA==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/packager-html": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.8.3.tgz",
+      "integrity": "sha512-OhPu1Hx1RRKJodpiu86ZqL8el2Aa4uhBHF6RAL1Pcrh2EhRRlPf70Sk0tC22zUpYL7es+iNKZ/n0Rl+OWSHWEw==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "posthtml": "^0.16.5"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        },
+        "posthtml": {
+          "version": "0.16.6",
+          "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+          "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+          "dev": true,
+          "requires": {
+            "posthtml-parser": "^0.11.0",
+            "posthtml-render": "^3.0.0"
+          }
+        },
+        "posthtml-parser": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+          "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+          "dev": true,
+          "requires": {
+            "htmlparser2": "^7.1.1"
+          }
+        },
+        "posthtml-render": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+          "dev": true,
+          "requires": {
+            "is-json": "^2.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/packager-js": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.8.3.tgz",
+      "integrity": "sha512-0pGKC3Ax5vFuxuZCRB+nBucRfFRz4ioie19BbDxYnvBxrd4M3FIu45njf6zbBYsI9eXqaDnL1b3DcZJfYqtIzw==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "globals": "^13.2.0",
+        "nullthrows": "^1.1.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/packager-raw": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.8.3.tgz",
+      "integrity": "sha512-BA6enNQo1RCnco9MhkxGrjOk59O71IZ9DPKu3lCtqqYEVd823tXff2clDKHK25i6cChmeHu6oB1Rb73hlPqhUA==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3"
+      }
+    },
+    "@parcel/packager-svg": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.8.3.tgz",
+      "integrity": "sha512-mvIoHpmv5yzl36OjrklTDFShLUfPFTwrmp1eIwiszGdEBuQaX7JVI3Oo2jbVQgcN4W7J6SENzGQ3Q5hPTW3pMw==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "posthtml": "^0.16.4"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        },
+        "posthtml": {
+          "version": "0.16.6",
+          "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+          "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+          "dev": true,
+          "requires": {
+            "posthtml-parser": "^0.11.0",
+            "posthtml-render": "^3.0.0"
+          }
+        },
+        "posthtml-parser": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+          "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+          "dev": true,
+          "requires": {
+            "htmlparser2": "^7.1.1"
+          }
+        },
+        "posthtml-render": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+          "dev": true,
+          "requires": {
+            "is-json": "^2.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/plugin": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.3.tgz",
+      "integrity": "sha512-jZ6mnsS4D9X9GaNnvrixDQwlUQJCohDX2hGyM0U0bY2NWU8Km97SjtoCpWjq+XBCx/gpC4g58+fk9VQeZq2vlw==",
+      "dev": true,
+      "requires": {
+        "@parcel/types": "2.8.3"
+      }
+    },
+    "@parcel/reporter-cli": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.8.3.tgz",
+      "integrity": "sha512-3sJkS6tFFzgIOz3u3IpD/RsmRxvOKKiQHOTkiiqRt1l44mMDGKS7zANRnJYsQzdCsgwc9SOP30XFgJwtoVlMbw==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chalk": "^4.1.0",
+        "term-size": "^2.2.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/reporter-dev-server": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.8.3.tgz",
+      "integrity": "sha512-Y8C8hzgzTd13IoWTj+COYXEyCkXfmVJs3//GDBsH22pbtSFMuzAZd+8J9qsCo0EWpiDow7V9f1LischvEh3FbQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/resolver-default": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.8.3.tgz",
+      "integrity": "sha512-k0B5M/PJ+3rFbNj4xZSBr6d6HVIe6DH/P3dClLcgBYSXAvElNDfXgtIimbjCyItFkW9/BfcgOVKEEIZOeySH/A==",
+      "dev": true,
+      "requires": {
+        "@parcel/node-resolver-core": "2.8.3",
+        "@parcel/plugin": "2.8.3"
+      }
+    },
+    "@parcel/runtime-browser-hmr": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.8.3.tgz",
+      "integrity": "sha512-2O1PYi2j/Q0lTyGNV3JdBYwg4rKo6TEVFlYGdd5wCYU9ZIN9RRuoCnWWH2qCPj3pjIVtBeppYxzfVjPEHINWVg==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/runtime-js": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.8.3.tgz",
+      "integrity": "sha512-IRja0vNKwvMtPgIqkBQh0QtRn0XcxNC8HU1jrgWGRckzu10qJWO+5ULgtOeR4pv9krffmMPqywGXw6l/gvJKYQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/runtime-react-refresh": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.8.3.tgz",
+      "integrity": "sha512-2v/qFKp00MfG0234OdOgQNAo6TLENpFYZMbVbAsPMY9ITiqG73MrEsrGXVoGbYiGTMB/Toer/lSWlJxtacOCuA==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "react-error-overlay": "6.0.9",
+        "react-refresh": "^0.9.0"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/runtime-service-worker": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.8.3.tgz",
+      "integrity": "sha512-/Skkw+EeRiwzOJso5fQtK8c9b452uWLNhQH1ISTodbmlcyB4YalAiSsyHCtMYD0c3/t5Sx4ZS7vxBAtQd0RvOw==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/source-map": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.1.tgz",
+      "integrity": "sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3"
+      }
+    },
+    "@parcel/transformer-babel": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.8.3.tgz",
+      "integrity": "sha512-L6lExfpvvC7T/g3pxf3CIJRouQl+sgrSzuWQ0fD4PemUDHvHchSP4SNUVnd6gOytF3Y1KpnEZIunQGi5xVqQCQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "browserslist": "^4.6.6",
+        "json5": "^2.2.0",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/transformer-css": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.8.3.tgz",
+      "integrity": "sha512-xTqFwlSXtnaYen9ivAgz+xPW7yRl/u4QxtnDyDpz5dr8gSeOpQYRcjkd4RsYzKsWzZcGtB5EofEk8ayUbWKEUg==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "browserslist": "^4.6.6",
+        "lightningcss": "^1.16.1",
+        "nullthrows": "^1.1.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/transformer-html": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.8.3.tgz",
+      "integrity": "sha512-kIZO3qsMYTbSnSpl9cnZog+SwL517ffWH54JeB410OSAYF1ouf4n5v9qBnALZbuCCmPwJRGs4jUtE452hxwN4g==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "posthtml": "^0.16.5",
+        "posthtml-parser": "^0.10.1",
+        "posthtml-render": "^3.0.0",
+        "semver": "^5.7.1",
+        "srcset": "4"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        },
+        "posthtml": {
+          "version": "0.16.6",
+          "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+          "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+          "dev": true,
+          "requires": {
+            "posthtml-parser": "^0.11.0",
+            "posthtml-render": "^3.0.0"
+          },
+          "dependencies": {
+            "posthtml-parser": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+              "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+              "dev": true,
+              "requires": {
+                "htmlparser2": "^7.1.1"
+              }
+            }
+          }
+        },
+        "posthtml-parser": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.2.tgz",
+          "integrity": "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==",
+          "dev": true,
+          "requires": {
+            "htmlparser2": "^7.1.1"
+          }
+        },
+        "posthtml-render": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+          "dev": true,
+          "requires": {
+            "is-json": "^2.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "srcset": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
+          "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
+          "dev": true
+        }
+      }
+    },
+    "@parcel/transformer-image": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.8.3.tgz",
+      "integrity": "sha512-cO4uptcCGTi5H6bvTrAWEFUsTNhA4kCo8BSvRSCHA2sf/4C5tGQPHt3JhdO0GQLPwZRCh/R41EkJs5HZ8A8DAg==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "nullthrows": "^1.1.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+          "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/transformer-js": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.8.3.tgz",
+      "integrity": "sha512-9Qd6bib+sWRcpovvzvxwy/PdFrLUXGfmSW9XcVVG8pvgXsZPFaNjnNT8stzGQj1pQiougCoxMY4aTM5p1lGHEQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "@swc/helpers": "^0.4.12",
+        "browserslist": "^4.6.6",
+        "detect-libc": "^1.0.3",
+        "nullthrows": "^1.1.1",
+        "regenerator-runtime": "^0.13.7",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+          "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.11",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+          "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/transformer-json": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.8.3.tgz",
+      "integrity": "sha512-B7LmVq5Q7bZO4ERb6NHtRuUKWGysEeaj9H4zelnyBv+wLgpo4f5FCxSE1/rTNmP9u1qHvQ3scGdK6EdSSokGPg==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "json5": "^2.2.0"
+      }
+    },
+    "@parcel/transformer-postcss": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.8.3.tgz",
+      "integrity": "sha512-e8luB/poIlz6jBsD1Izms+6ElbyzuoFVa4lFVLZnTAChI3UxPdt9p/uTsIO46HyBps/Bk8ocvt3J4YF84jzmvg==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "clone": "^2.1.1",
+        "nullthrows": "^1.1.1",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/transformer-posthtml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.8.3.tgz",
+      "integrity": "sha512-pkzf9Smyeaw4uaRLsT41RGrPLT5Aip8ZPcntawAfIo+KivBQUV0erY1IvHYjyfFzq1ld/Fo2Ith9He6mxpPifA==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "posthtml": "^0.16.5",
+        "posthtml-parser": "^0.10.1",
+        "posthtml-render": "^3.0.0",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        },
+        "posthtml": {
+          "version": "0.16.6",
+          "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+          "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+          "dev": true,
+          "requires": {
+            "posthtml-parser": "^0.11.0",
+            "posthtml-render": "^3.0.0"
+          },
+          "dependencies": {
+            "posthtml-parser": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+              "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+              "dev": true,
+              "requires": {
+                "htmlparser2": "^7.1.1"
+              }
+            }
+          }
+        },
+        "posthtml-parser": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.2.tgz",
+          "integrity": "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==",
+          "dev": true,
+          "requires": {
+            "htmlparser2": "^7.1.1"
+          }
+        },
+        "posthtml-render": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+          "dev": true,
+          "requires": {
+            "is-json": "^2.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/transformer-raw": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.8.3.tgz",
+      "integrity": "sha512-G+5cXnd2/1O3nV/pgRxVKZY/HcGSseuhAe71gQdSQftb8uJEURyUHoQ9Eh0JUD3MgWh9V+nIKoyFEZdf9T0sUQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3"
+      }
+    },
+    "@parcel/transformer-react-refresh-wrap": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.8.3.tgz",
+      "integrity": "sha512-q8AAoEvBnCf/nPvgOwFwKZfEl/thwq7c2duxXkhl+tTLDRN2vGmyz4355IxCkavSX+pLWSQ5MexklSEeMkgthg==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "react-refresh": "^0.9.0"
+      },
+      "dependencies": {
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/transformer-svg": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.8.3.tgz",
+      "integrity": "sha512-3Zr/gBzxi1ZH1fftH/+KsZU7w5GqkmxlB0ZM8ovS5E/Pl1lq1t0xvGJue9m2VuQqP8Mxfpl5qLFmsKlhaZdMIQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "nullthrows": "^1.1.1",
+        "posthtml": "^0.16.5",
+        "posthtml-parser": "^0.10.1",
+        "posthtml-render": "^3.0.0",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        },
+        "posthtml": {
+          "version": "0.16.6",
+          "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+          "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+          "dev": true,
+          "requires": {
+            "posthtml-parser": "^0.11.0",
+            "posthtml-render": "^3.0.0"
+          },
+          "dependencies": {
+            "posthtml-parser": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+              "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+              "dev": true,
+              "requires": {
+                "htmlparser2": "^7.1.1"
+              }
+            }
+          }
+        },
+        "posthtml-parser": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.2.tgz",
+          "integrity": "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==",
+          "dev": true,
+          "requires": {
+            "htmlparser2": "^7.1.1"
+          }
+        },
+        "posthtml-render": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+          "dev": true,
+          "requires": {
+            "is-json": "^2.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "@parcel/types": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.3.tgz",
+      "integrity": "sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==",
+      "dev": true,
+      "requires": {
+        "@parcel/cache": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/package-manager": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/workers": "2.8.3",
+        "utility-types": "^3.10.0"
+      },
+      "dependencies": {
+        "@parcel/fs": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+          "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+          "dev": true,
+          "requires": {
+            "@parcel/fs-search": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "@parcel/watcher": "^2.0.7",
+            "@parcel/workers": "2.8.3"
+          }
+        },
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/watcher": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.1.0.tgz",
+          "integrity": "sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3",
+            "micromatch": "^4.0.5",
+            "node-addon-api": "^3.2.1",
+            "node-gyp-build": "^4.3.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+          "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "node-addon-api": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@rollup/plugin-commonjs": {
@@ -45989,6 +54431,15 @@
       "version": "1.2.1",
       "dev": true
     },
+    "@swc/helpers": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "@szmarczak/http-timer": {
       "version": "4.0.6",
       "dev": true,
@@ -46007,6 +54458,12 @@
     },
     "@tootallnate/once": {
       "version": "1.1.2",
+      "dev": true
+    },
+    "@trysound/sax": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "dev": true
     },
     "@tsconfig/node10": {
@@ -46061,7 +54518,9 @@
       "dev": true
     },
     "@types/fetch-mock": {
-      "version": "6.0.6",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-7.3.5.tgz",
+      "integrity": "sha512-sLecm9ohBdGIpYUP9rWk5/XIKY2xHMYTBJIcJuBBM8IJWnYoQ1DAj8F4OVjnfD0API1drlkWEV0LPNk+ACuhsg==",
       "dev": true
     },
     "@types/geojson": {
@@ -46118,10 +54577,6 @@
     },
     "@types/parse-json": {
       "version": "4.0.0",
-      "dev": true
-    },
-    "@types/q": {
-      "version": "1.5.5",
       "dev": true
     },
     "@types/resolve": {
@@ -46404,10 +54859,18 @@
     },
     "abab": {
       "version": "2.0.5",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "abbrev": {
       "version": "1.1.1",
+      "dev": true
+    },
+    "abortcontroller-polyfill": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
+      "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==",
       "dev": true
     },
     "accepts": {
@@ -46424,6 +54887,8 @@
     "acorn-globals": {
       "version": "4.3.4",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
@@ -46431,11 +54896,15 @@
       "dependencies": {
         "acorn": {
           "version": "6.4.2",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "acorn-walk": {
           "version": "6.2.0",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -46506,10 +54975,6 @@
       "dev": true,
       "requires": {}
     },
-    "alphanum-sort": {
-      "version": "1.0.2",
-      "dev": true
-    },
     "ansi-align": {
       "version": "3.0.0",
       "dev": true,
@@ -46575,13 +55040,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "ansi-to-html": {
-      "version": "0.6.15",
-      "dev": true,
-      "requires": {
-        "entities": "^2.0.0"
-      }
-    },
     "ansicolors": {
       "version": "0.3.2",
       "dev": true
@@ -46594,6 +55052,7 @@
     "anymatch": {
       "version": "2.0.0",
       "dev": true,
+      "optional": true,
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
@@ -46602,6 +55061,7 @@
         "define-property": {
           "version": "2.0.2",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.2",
             "isobject": "^3.0.1"
@@ -46610,6 +55070,7 @@
         "extend-shallow": {
           "version": "3.0.2",
           "dev": true,
+          "optional": true,
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -46618,6 +55079,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -46625,6 +55087,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -46632,6 +55095,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -46641,17 +55105,20 @@
         "is-extendable": {
           "version": "1.0.1",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
         },
         "kind-of": {
           "version": "6.0.3",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "micromatch": {
           "version": "3.1.10",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -46671,6 +55138,7 @@
         "normalize-path": {
           "version": "2.1.1",
           "dev": true,
+          "optional": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -46761,7 +55229,9 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -46870,7 +55340,8 @@
     },
     "async-each": {
       "version": "1.0.3",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "async-each-series": {
       "version": "0.1.1",
@@ -46880,7 +55351,9 @@
     },
     "async-limiter": {
       "version": "1.0.1",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -47001,31 +55474,6 @@
         "regenerator-runtime": "^0.11.0"
       }
     },
-    "babel-types": {
-      "version": "6.26.0",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      },
-      "dependencies": {
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "dev": true
-        }
-      }
-    },
-    "babylon-walk": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.11.6",
-        "babel-types": "^6.15.0",
-        "lodash.clone": "^4.5.0"
-      }
-    },
     "backo2": {
       "version": "1.0.2",
       "dev": true
@@ -47084,6 +55532,15 @@
           "version": "6.0.3",
           "dev": true
         }
+      }
+    },
+    "base-x": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "base64-arraybuffer": {
@@ -47154,11 +55611,13 @@
     },
     "binary-extensions": {
       "version": "1.13.1",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "bindings": {
       "version": "1.5.0",
       "dev": true,
+      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -47341,58 +55800,6 @@
         "to-regex": "^3.0.1"
       }
     },
-    "brfs": {
-      "version": "1.6.1",
-      "dev": true,
-      "requires": {
-        "quote-stream": "^1.0.1",
-        "resolve": "^1.1.5",
-        "static-module": "^2.2.0",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
-      }
-    },
     "brorand": {
       "version": "1.1.0",
       "dev": true
@@ -47412,7 +55819,9 @@
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "browser-resolve": {
       "version": "2.0.0",
@@ -47696,20 +56105,15 @@
       }
     },
     "browserslist": {
-      "version": "4.17.5",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001271",
-        "electron-to-chromium": "^1.3.878",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
-      },
-      "dependencies": {
-        "picocolors": {
-          "version": "1.0.0",
-          "dev": true
-        }
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       }
     },
     "bs-recipes": {
@@ -47736,10 +56140,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "buffer-equal": {
-      "version": "0.0.1",
-      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -47911,18 +56311,21 @@
     },
     "call-me-maybe": {
       "version": "1.0.1",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "caller-callsite": {
       "version": "2.0.0",
       "dev": true,
+      "peer": true,
       "requires": {
         "callsites": "^2.0.0"
       },
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -47952,6 +56355,8 @@
     "caniuse-api": {
       "version": "3.0.0",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "browserslist": "^4.0.0",
         "caniuse-lite": "^1.0.0",
@@ -47961,12 +56366,16 @@
       "dependencies": {
         "lodash.memoize": {
           "version": "4.1.2",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001274",
+      "version": "1.0.30001451",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz",
+      "integrity": "sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==",
       "dev": true
     },
     "cardinal": {
@@ -48155,6 +56564,7 @@
     "cli-cursor": {
       "version": "2.1.0",
       "dev": true,
+      "peer": true,
       "requires": {
         "restore-cursor": "^2.0.0"
       }
@@ -48319,26 +56729,6 @@
         "mkdirp-infer-owner": "^2.0.0"
       }
     },
-    "coa": {
-      "version": "2.0.2",
-      "dev": true,
-      "requires": {
-        "@types/q": "^1.5.1",
-        "chalk": "^2.4.1",
-        "q": "^1.1.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
-      }
-    },
     "code-point-at": {
       "version": "1.1.0",
       "dev": true
@@ -48351,14 +56741,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "3.2.1",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "requires": {
@@ -48368,13 +56750,13 @@
     "color-name": {
       "version": "1.1.3"
     },
-    "color-string": {
-      "version": "1.6.0",
+    "colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true,
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
+      "optional": true,
+      "peer": true
     },
     "colors": {
       "version": "1.4.0",
@@ -48429,10 +56811,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "command-exists": {
-      "version": "1.2.9",
-      "dev": true
     },
     "commander": {
       "version": "2.20.3",
@@ -49233,63 +57611,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "css-color-names": {
-      "version": "0.0.4",
-      "dev": true
-    },
-    "css-declaration-sorter": {
-      "version": "4.0.1",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.1",
-        "timsort": "^0.3.0"
-      }
-    },
-    "css-modules-loader-core": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.1",
-        "postcss-modules-extract-imports": "1.1.0",
-        "postcss-modules-local-by-default": "1.2.0",
-        "postcss-modules-scope": "1.1.0",
-        "postcss-modules-values": "1.3.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "postcss": {
-          "version": "6.0.1",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
-          }
-        },
-        "postcss-modules-extract-imports": {
-          "version": "1.1.0",
-          "dev": true,
-          "requires": {
-            "postcss": "^6.0.1"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
-      }
-    },
     "css-select": {
       "version": "4.1.3",
       "dev": true,
@@ -49301,136 +57622,12 @@
         "nth-check": "^2.0.0"
       }
     },
-    "css-select-base-adapter": {
-      "version": "0.1.1",
-      "dev": true
-    },
-    "css-selector-tokenizer": {
-      "version": "0.7.3",
-      "dev": true,
-      "requires": {
-        "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2"
-      }
-    },
-    "css-tree": {
-      "version": "1.0.0-alpha.37",
-      "dev": true,
-      "requires": {
-        "mdn-data": "2.0.4",
-        "source-map": "^0.6.1"
-      }
-    },
     "css-what": {
       "version": "5.0.1",
       "dev": true
     },
     "cssesc": {
       "version": "3.0.0",
-      "dev": true
-    },
-    "cssnano": {
-      "version": "4.1.11",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "^5.0.0",
-        "cssnano-preset-default": "^4.0.8",
-        "is-resolvable": "^1.0.0",
-        "postcss": "^7.0.0"
-      },
-      "dependencies": {
-        "caller-path": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "caller-callsite": "^2.0.0"
-          }
-        },
-        "cosmiconfig": {
-          "version": "5.2.1",
-          "dev": true,
-          "requires": {
-            "import-fresh": "^2.0.0",
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.13.1",
-            "parse-json": "^4.0.0"
-          }
-        },
-        "import-fresh": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "caller-path": "^2.0.0",
-            "resolve-from": "^3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "resolve-from": {
-          "version": "3.0.0",
-          "dev": true
-        }
-      }
-    },
-    "cssnano-preset-default": {
-      "version": "4.0.8",
-      "dev": true,
-      "requires": {
-        "css-declaration-sorter": "^4.0.1",
-        "cssnano-util-raw-cache": "^4.0.1",
-        "postcss": "^7.0.0",
-        "postcss-calc": "^7.0.1",
-        "postcss-colormin": "^4.0.3",
-        "postcss-convert-values": "^4.0.1",
-        "postcss-discard-comments": "^4.0.2",
-        "postcss-discard-duplicates": "^4.0.2",
-        "postcss-discard-empty": "^4.0.1",
-        "postcss-discard-overridden": "^4.0.1",
-        "postcss-merge-longhand": "^4.0.11",
-        "postcss-merge-rules": "^4.0.3",
-        "postcss-minify-font-values": "^4.0.2",
-        "postcss-minify-gradients": "^4.0.2",
-        "postcss-minify-params": "^4.0.2",
-        "postcss-minify-selectors": "^4.0.2",
-        "postcss-normalize-charset": "^4.0.1",
-        "postcss-normalize-display-values": "^4.0.2",
-        "postcss-normalize-positions": "^4.0.2",
-        "postcss-normalize-repeat-style": "^4.0.2",
-        "postcss-normalize-string": "^4.0.2",
-        "postcss-normalize-timing-functions": "^4.0.2",
-        "postcss-normalize-unicode": "^4.0.1",
-        "postcss-normalize-url": "^4.0.1",
-        "postcss-normalize-whitespace": "^4.0.2",
-        "postcss-ordered-values": "^4.1.2",
-        "postcss-reduce-initial": "^4.0.3",
-        "postcss-reduce-transforms": "^4.0.2",
-        "postcss-svgo": "^4.0.3",
-        "postcss-unique-selectors": "^4.0.1"
-      }
-    },
-    "cssnano-util-get-arguments": {
-      "version": "4.0.0",
-      "dev": true
-    },
-    "cssnano-util-get-match": {
-      "version": "4.0.0",
-      "dev": true
-    },
-    "cssnano-util-raw-cache": {
-      "version": "4.0.1",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0"
-      }
-    },
-    "cssnano-util-same-parent": {
-      "version": "4.0.1",
       "dev": true
     },
     "csso": {
@@ -49456,11 +57653,15 @@
     },
     "cssom": {
       "version": "0.3.8",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "cssstyle": {
       "version": "1.4.0",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "cssom": "0.3.x"
       }
@@ -49498,6 +57699,8 @@
     "data-urls": {
       "version": "1.1.0",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "abab": "^2.0.0",
         "whatwg-mimetype": "^2.2.0",
@@ -49515,14 +57718,6 @@
     "dateformat": {
       "version": "3.0.3",
       "dev": true
-    },
-    "deasync": {
-      "version": "0.1.23",
-      "dev": true,
-      "requires": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      }
     },
     "debug": {
       "version": "4.3.2",
@@ -49658,6 +57853,12 @@
       "version": "6.1.0",
       "dev": true
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true
+    },
     "detect-newline": {
       "version": "3.1.0",
       "dev": true
@@ -49770,6 +57971,8 @@
     "domexception": {
       "version": "1.0.1",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
@@ -49851,7 +58054,9 @@
       "version": "1.1.1"
     },
     "electron-to-chromium": {
-      "version": "1.3.885",
+      "version": "1.4.295",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.295.tgz",
+      "integrity": "sha512-lEO94zqf1bDA3aepxwnWoHUjA8sZ+2owgcSZjYQy0+uOSEclJX0VieZC+r+wLpSxUHRd6gG32znTWmr+5iGzFw==",
       "dev": true
     },
     "elegant-spinner": {
@@ -50104,7 +58309,8 @@
     },
     "envinfo": {
       "version": "7.8.1",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "err-code": {
       "version": "2.0.3",
@@ -50198,54 +58404,6 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5"
-    },
-    "escodegen": {
-      "version": "1.9.1",
-      "dev": true,
-      "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "dev": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "dev": true,
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "dev": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
-        }
-      }
     },
     "esinstall": {
       "version": "1.1.7",
@@ -51007,22 +59165,6 @@
       "version": "1.3.0",
       "dev": true
     },
-    "falafel": {
-      "version": "2.2.4",
-      "dev": true,
-      "requires": {
-        "acorn": "^7.1.1",
-        "foreach": "^2.0.5",
-        "isarray": "^2.0.1",
-        "object-keys": "^1.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "dev": true
-        }
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "dev": true
@@ -51055,10 +59197,6 @@
       "version": "2.0.6",
       "dev": true
     },
-    "fastparse": {
-      "version": "1.1.2",
-      "dev": true
-    },
     "fastq": {
       "version": "1.13.0",
       "dev": true,
@@ -51085,20 +59223,44 @@
       }
     },
     "fetch-mock": {
-      "version": "5.13.1",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
       "dev": true,
       "requires": {
-        "glob-to-regexp": "^0.3.0",
-        "node-fetch": "^1.3.3",
-        "path-to-regexp": "^1.7.0"
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
       },
       "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
+        "core-js": {
+          "version": "3.28.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+          "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw==",
+          "dev": true
+        },
+        "glob-to-regexp": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
           "dev": true,
           "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
           }
         }
       }
@@ -51123,7 +59285,8 @@
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "filename-reserved-regex": {
       "version": "1.0.0",
@@ -51783,10 +59946,6 @@
         }
       }
     },
-    "get-port": {
-      "version": "3.2.0",
-      "dev": true
-    },
     "get-stdin": {
       "version": "6.0.0",
       "dev": true
@@ -52122,7 +60281,8 @@
     },
     "glob-to-regexp": {
       "version": "0.3.0",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "global-dirs": {
       "version": "0.1.1",
@@ -52188,14 +60348,6 @@
     },
     "graceful-fs": {
       "version": "4.2.8"
-    },
-    "grapheme-breaker": {
-      "version": "0.3.2",
-      "dev": true,
-      "requires": {
-        "brfs": "^1.2.0",
-        "unicode-trie": "^0.3.1"
-      }
     },
     "gzip-size": {
       "version": "6.0.0",
@@ -52338,10 +60490,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hex-color-regex": {
-      "version": "1.1.0",
-      "dev": true
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "dev": true,
@@ -52366,17 +60514,11 @@
       "version": "2.8.9",
       "dev": true
     },
-    "hsl-regex": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "hsla-regex": {
-      "version": "1.0.0",
-      "dev": true
-    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
@@ -52384,38 +60526,6 @@
     "html-escaper": {
       "version": "2.0.2",
       "dev": true
-    },
-    "htmlnano": {
-      "version": "0.2.9",
-      "dev": true,
-      "requires": {
-        "cssnano": "^4.1.11",
-        "posthtml": "^0.15.1",
-        "purgecss": "^2.3.0",
-        "relateurl": "^0.2.7",
-        "srcset": "^3.0.0",
-        "svgo": "^1.3.2",
-        "terser": "^5.6.1",
-        "timsort": "^0.3.0",
-        "uncss": "^0.17.3"
-      },
-      "dependencies": {
-        "posthtml": {
-          "version": "0.15.2",
-          "dev": true,
-          "requires": {
-            "posthtml-parser": "^0.7.2",
-            "posthtml-render": "^1.3.1"
-          }
-        },
-        "posthtml-parser": {
-          "version": "0.7.2",
-          "dev": true,
-          "requires": {
-            "htmlparser2": "^6.0.0"
-          }
-        }
-      }
     },
     "htmlparser2": {
       "version": "6.1.0",
@@ -52729,7 +60839,9 @@
     },
     "indexes-of": {
       "version": "1.0.1",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "indexof": {
       "version": "0.0.1",
@@ -52915,10 +61027,6 @@
     "ipaddr.js": {
       "version": "1.9.1"
     },
-    "is-absolute-url": {
-      "version": "2.1.0",
-      "dev": true
-    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "dev": true,
@@ -52948,6 +61056,7 @@
     "is-binary-path": {
       "version": "1.0.1",
       "dev": true,
+      "optional": true,
       "requires": {
         "binary-extensions": "^1.0.0"
       }
@@ -52967,18 +61076,6 @@
     "is-callable": {
       "version": "1.2.4",
       "dev": true
-    },
-    "is-color-stop": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "css-color-names": "^0.0.4",
-        "hex-color-regex": "^1.1.0",
-        "hsl-regex": "^1.0.0",
-        "hsla-regex": "^1.0.0",
-        "rgb-regex": "^1.0.1",
-        "rgba-regex": "^1.0.0"
-      }
     },
     "is-core-module": {
       "version": "2.6.0",
@@ -53018,7 +61115,8 @@
     },
     "is-directory": {
       "version": "0.3.1",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "is-docker": {
       "version": "2.2.1",
@@ -53051,7 +61149,9 @@
       }
     },
     "is-glob": {
-      "version": "4.0.1",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -53060,15 +61160,25 @@
     "is-html": {
       "version": "1.1.0",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "html-tags": "^1.0.0"
       },
       "dependencies": {
         "html-tags": {
           "version": "1.2.0",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
+    },
+    "is-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
+      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
+      "dev": true
     },
     "is-lambda": {
       "version": "1.0.1",
@@ -53155,10 +61265,6 @@
       "version": "1.0.0",
       "dev": true
     },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "dev": true
-    },
     "is-shared-array-buffer": {
       "version": "1.0.1",
       "dev": true
@@ -53181,6 +61287,12 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.4",
@@ -53209,10 +61321,6 @@
     },
     "is-typedarray": {
       "version": "1.0.0"
-    },
-    "is-url": {
-      "version": "1.2.4",
-      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -53264,10 +61372,6 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "dev": true
     },
     "isbinaryfile": {
       "version": "4.0.8",
@@ -53449,6 +61553,8 @@
     "jsdom": {
       "version": "14.1.0",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "abab": "^2.0.0",
         "acorn": "^6.0.4",
@@ -53480,11 +61586,15 @@
       "dependencies": {
         "acorn": {
           "version": "6.4.2",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "escodegen": {
           "version": "1.14.3",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "esprima": "^4.0.1",
             "estraverse": "^4.2.0",
@@ -53496,6 +61606,8 @@
         "levn": {
           "version": "0.3.0",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "prelude-ls": "~1.1.2",
             "type-check": "~0.3.2"
@@ -53504,6 +61616,8 @@
         "optionator": {
           "version": "0.8.3",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "deep-is": "~0.1.3",
             "fast-levenshtein": "~2.0.6",
@@ -53515,15 +61629,21 @@
         },
         "parse5": {
           "version": "5.1.0",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "prelude-ls": {
           "version": "1.1.2",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "type-check": {
           "version": "0.3.2",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "prelude-ls": "~1.1.2"
           }
@@ -53531,6 +61651,8 @@
         "ws": {
           "version": "6.2.2",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -53574,11 +61696,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -54098,6 +62219,87 @@
         "type-check": "~0.4.0"
       }
     },
+    "lightningcss": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.19.0.tgz",
+      "integrity": "sha512-yV5UR7og+Og7lQC+70DA7a8ta1uiOPnWPJfxa0wnxylev5qfo4P+4iMpzWAdYWOca4jdNQZii+bDL/l+4hUXIA==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "lightningcss-darwin-arm64": "1.19.0",
+        "lightningcss-darwin-x64": "1.19.0",
+        "lightningcss-linux-arm-gnueabihf": "1.19.0",
+        "lightningcss-linux-arm64-gnu": "1.19.0",
+        "lightningcss-linux-arm64-musl": "1.19.0",
+        "lightningcss-linux-x64-gnu": "1.19.0",
+        "lightningcss-linux-x64-musl": "1.19.0",
+        "lightningcss-win32-x64-msvc": "1.19.0"
+      }
+    },
+    "lightningcss-darwin-arm64": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.19.0.tgz",
+      "integrity": "sha512-wIJmFtYX0rXHsXHSr4+sC5clwblEMji7HHQ4Ub1/CznVRxtCFha6JIt5JZaNf8vQrfdZnBxLLC6R8pC818jXqg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-darwin-x64": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.19.0.tgz",
+      "integrity": "sha512-Lif1wD6P4poaw9c/4Uh2z+gmrWhw/HtXFoeZ3bEsv6Ia4tt8rOJBdkfVaUJ6VXmpKHALve+iTyP2+50xY1wKPw==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm-gnueabihf": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.19.0.tgz",
+      "integrity": "sha512-P15VXY5682mTXaiDtbnLYQflc8BYb774j2R84FgDLJTN6Qp0ZjWEFyN1SPqyfTj2B2TFjRHRUvQSSZ7qN4Weig==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-gnu": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.19.0.tgz",
+      "integrity": "sha512-zwXRjWqpev8wqO0sv0M1aM1PpjHz6RVIsBcxKszIG83Befuh4yNysjgHVplF9RTU7eozGe3Ts7r6we1+Qkqsww==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-musl": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.19.0.tgz",
+      "integrity": "sha512-vSCKO7SDnZaFN9zEloKSZM5/kC5gbzUjoJQ43BvUpyTFUX7ACs/mDfl2Eq6fdz2+uWhUh7vf92c4EaaP4udEtA==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-gnu": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.19.0.tgz",
+      "integrity": "sha512-0AFQKvVzXf9byrXUq9z0anMGLdZJS+XSDqidyijI5njIwj6MdbvX2UZK/c4FfNmeRa2N/8ngTffoIuOUit5eIQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-musl": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.19.0.tgz",
+      "integrity": "sha512-SJoM8CLPt6ECCgSuWe+g0qo8dqQYVcPiW2s19dxkmSI5+Uu1GIRzyKA0b7QqmEXolA+oSJhQqCmJpzjY4CuZAg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-win32-x64-msvc": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.19.0.tgz",
+      "integrity": "sha512-C+VuUTeSUOAaBZZOPT7Etn/agx/MatzJzGRkeV+zEABmPuntv1zihncsi+AyGmjkkzq3wVedEy7h0/4S84mUtg==",
+      "dev": true,
+      "optional": true
+    },
+    "lilconfig": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -54278,6 +62480,33 @@
         }
       }
     },
+    "lmdb": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "dev": true,
+      "requires": {
+        "@lmdb/lmdb-darwin-arm64": "2.5.2",
+        "@lmdb/lmdb-darwin-x64": "2.5.2",
+        "@lmdb/lmdb-linux-arm": "2.5.2",
+        "@lmdb/lmdb-linux-arm64": "2.5.2",
+        "@lmdb/lmdb-linux-x64": "2.5.2",
+        "@lmdb/lmdb-win32-x64": "2.5.2",
+        "msgpackr": "^1.5.4",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "5.0.3",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+          "dev": true
+        }
+      }
+    },
     "load-json-file": {
       "version": "4.0.0",
       "dev": true,
@@ -54417,10 +62646,6 @@
       "version": "4.2.1",
       "dev": true
     },
-    "lodash.clone": {
-      "version": "4.5.0",
-      "dev": true
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "dev": true
@@ -54437,6 +62662,12 @@
       "version": "4.4.2",
       "dev": true,
       "peer": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
     },
     "lodash.isfinite": {
       "version": "3.3.2",
@@ -54496,7 +62727,8 @@
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "lodash.uniqby": {
       "version": "4.7.0",
@@ -54716,10 +62948,6 @@
         "safe-buffer": "^5.1.2"
       }
     },
-    "mdn-data": {
-      "version": "2.0.4",
-      "dev": true
-    },
     "media-typer": {
       "version": "0.3.0"
     },
@@ -54899,11 +63127,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "dependencies": {
         "braces": {
@@ -54961,7 +63191,8 @@
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -55181,6 +63412,40 @@
     "ms": {
       "version": "2.1.2",
       "dev": true
+    },
+    "msgpackr": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.3.tgz",
+      "integrity": "sha512-m2JefwcKNzoHYXkH/5jzHRxAw7XLWsAdvu0FOJ+OLwwozwOV/J6UA62iLkfIMbg7G8+dIuRwgg6oz+QoQ4YkoA==",
+      "dev": true,
+      "requires": {
+        "msgpackr-extract": "^3.0.0"
+      }
+    },
+    "msgpackr-extract": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.0.tgz",
+      "integrity": "sha512-oy6KCk1+X4Bn5m6Ycq5N1EWl9npqG/cLrE8ga8NX7ZqfqYUUBS08beCQaGq80fjbKBySur0E6x//yZjzNJDt3A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.0",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.0",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.0",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.0",
+        "node-gyp-build-optional-packages": "5.0.7"
+      },
+      "dependencies": {
+        "node-gyp-build-optional-packages": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+          "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "multi-semantic-release": {
       "version": "2.11.1",
@@ -55800,7 +64065,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.1.30",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true
     },
     "nanomatch": {
@@ -55891,10 +64158,6 @@
       "version": "1.0.5",
       "dev": true
     },
-    "node-addon-api": {
-      "version": "1.7.2",
-      "dev": true
-    },
     "node-cli": {
       "version": "file:demos/ago-node-cli",
       "requires": {
@@ -55962,10 +64225,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node-forge": {
-      "version": "0.10.0",
-      "dev": true
-    },
     "node-gyp": {
       "version": "5.1.1",
       "dev": true,
@@ -55993,6 +64252,12 @@
     },
     "node-gyp-build": {
       "version": "4.3.0",
+      "dev": true
+    },
+    "node-gyp-build-optional-packages": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
       "dev": true
     },
     "node-libs-browser": {
@@ -56139,7 +64404,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.1",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
     },
     "nopt": {
@@ -58442,13 +66709,21 @@
         "boolbase": "^1.0.0"
       }
     },
+    "nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -58502,6 +66777,7 @@
     "object.getownpropertydescriptors": {
       "version": "2.1.3",
       "dev": true,
+      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -58548,6 +66824,7 @@
     "onetime": {
       "version": "2.0.1",
       "dev": true,
+      "peer": true,
       "requires": {
         "mimic-fn": "^1.0.0"
       }
@@ -58649,6 +66926,12 @@
           }
         }
       }
+    },
+    "ordered-binary": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.4.0.tgz",
+      "integrity": "sha512-EHQ/jk4/a9hLupIKxTfUsQRej1Yd/0QLQs3vGvIqg5ZtCYSzNhkzHoZc7Zf4e4kUlDaC3Uw8Q/1opOLNN2OKRQ==",
+      "dev": true
     },
     "os-browserify": {
       "version": "0.3.0",
@@ -58897,217 +67180,157 @@
         }
       }
     },
-    "parcel-bundler": {
-      "version": "1.12.5",
+    "parcel": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.8.3.tgz",
+      "integrity": "sha512-5rMBpbNE72g6jZvkdR5gS2nyhwIXaJy8i65osOqs/+5b7zgf3eMKgjSsDrv6bhz3gzifsba6MBJiZdBckl+vnA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/core": "^7.4.4",
-        "@babel/generator": "^7.4.4",
-        "@babel/parser": "^7.4.4",
-        "@babel/plugin-transform-flow-strip-types": "^7.4.4",
-        "@babel/plugin-transform-modules-commonjs": "^7.4.4",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/preset-env": "^7.4.4",
-        "@babel/runtime": "^7.4.4",
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "@iarna/toml": "^2.2.0",
-        "@parcel/fs": "^1.11.0",
-        "@parcel/logger": "^1.11.1",
-        "@parcel/utils": "^1.11.0",
-        "@parcel/watcher": "^1.12.1",
-        "@parcel/workers": "^1.11.0",
-        "ansi-to-html": "^0.6.4",
-        "babylon-walk": "^1.0.2",
-        "browserslist": "^4.1.0",
-        "chalk": "^2.1.0",
-        "clone": "^2.1.1",
-        "command-exists": "^1.2.6",
-        "commander": "^2.11.0",
-        "core-js": "^2.6.5",
-        "cross-spawn": "^6.0.4",
-        "css-modules-loader-core": "^1.1.0",
-        "cssnano": "^4.0.0",
-        "deasync": "^0.1.14",
-        "dotenv": "^5.0.0",
-        "dotenv-expand": "^5.1.0",
-        "envinfo": "^7.3.1",
-        "fast-glob": "^2.2.2",
-        "filesize": "^3.6.0",
-        "get-port": "^3.2.0",
-        "htmlnano": "^0.2.2",
-        "is-glob": "^4.0.0",
-        "is-url": "^1.2.2",
-        "js-yaml": "^3.10.0",
-        "json5": "^1.0.1",
-        "micromatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "node-forge": "^0.10.0",
-        "node-libs-browser": "^2.0.0",
-        "opn": "^5.1.0",
-        "postcss": "^7.0.11",
-        "postcss-value-parser": "^3.3.1",
-        "posthtml": "^0.11.2",
-        "posthtml-parser": "^0.4.0",
-        "posthtml-render": "^1.1.3",
-        "resolve": "^1.4.0",
-        "semver": "^5.4.1",
-        "serialize-to-js": "^3.0.0",
-        "serve-static": "^1.12.4",
-        "source-map": "0.6.1",
-        "terser": "^3.7.3",
-        "v8-compile-cache": "^2.0.0",
-        "ws": "^5.1.1"
+        "@parcel/config-default": "2.8.3",
+        "@parcel/core": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/package-manager": "2.8.3",
+        "@parcel/reporter-cli": "2.8.3",
+        "@parcel/reporter-dev-server": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chalk": "^4.1.0",
+        "commander": "^7.0.0",
+        "get-port": "^4.2.0",
+        "v8-compile-cache": "^2.0.0"
       },
       "dependencies": {
-        "@nodelib/fs.stat": {
-          "version": "1.1.3",
-          "dev": true
+        "@parcel/fs": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+          "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+          "dev": true,
+          "requires": {
+            "@parcel/fs-search": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "@parcel/watcher": "^2.0.7",
+            "@parcel/workers": "2.8.3"
+          }
+        },
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/watcher": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.1.0.tgz",
+          "integrity": "sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3",
+            "micromatch": "^4.0.5",
+            "node-addon-api": "^3.2.1",
+            "node-gyp-build": "^4.3.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+          "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
         },
         "chalk": {
-          "version": "2.4.2",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
-        "clone": {
-          "version": "2.1.2",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "define-property": {
-          "version": "2.0.2",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
-          }
-        },
-        "dotenv": {
-          "version": "5.0.1",
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
-        },
-        "fast-glob": {
-          "version": "2.2.7",
-          "dev": true,
-          "requires": {
-            "@mrmlnc/readdir-enhanced": "^2.2.1",
-            "@nodelib/fs.stat": "^1.1.2",
-            "glob-parent": "^3.1.0",
-            "is-glob": "^4.0.0",
-            "merge2": "^1.2.3",
-            "micromatch": "^3.1.10"
-          }
-        },
-        "filesize": {
-          "version": "3.6.1",
+        "get-port": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
+          "integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
           "dev": true
         },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        },
-        "json5": {
-          "version": "1.0.1",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "kind-of": {
-          "version": "6.0.3",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "micromatch": {
-          "version": "3.1.10",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "postcss-value-parser": {
-          "version": "3.3.1",
+        "node-addon-api": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
           "dev": true
         },
-        "semver": {
-          "version": "5.7.1",
-          "dev": true
-        },
-        "terser": {
-          "version": "3.17.0",
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "commander": "^2.19.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.10"
-          }
-        },
-        "ws": {
-          "version": "5.2.3",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -59271,11 +67494,10 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.8.0",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      }
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -59310,16 +67532,16 @@
         }
       }
     },
-    "physical-cpu-count": {
-      "version": "2.0.0",
-      "dev": true
-    },
     "picocolors": {
       "version": "0.2.1",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "picomatch": {
-      "version": "2.3.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pid-cwd": {
@@ -59376,7 +67598,9 @@
     },
     "pn": {
       "version": "1.1.0",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "portscanner": {
       "version": "2.1.1",
@@ -59403,584 +67627,27 @@
     "postcss": {
       "version": "7.0.39",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "picocolors": "^0.2.1",
         "source-map": "^0.6.1"
       }
     },
-    "postcss-calc": {
-      "version": "7.0.5",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.27",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.0.2"
-      }
-    },
-    "postcss-colormin": {
-      "version": "4.0.3",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.0.0",
-        "color": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-convert-values": {
-      "version": "4.0.1",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-discard-comments": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0"
-      }
-    },
-    "postcss-discard-duplicates": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0"
-      }
-    },
-    "postcss-discard-empty": {
-      "version": "4.0.1",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0"
-      }
-    },
-    "postcss-discard-overridden": {
-      "version": "4.0.1",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0"
-      }
-    },
-    "postcss-merge-longhand": {
-      "version": "4.0.11",
-      "dev": true,
-      "requires": {
-        "css-color-names": "0.0.4",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "stylehacks": "^4.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-merge-rules": {
-      "version": "4.0.3",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "cssnano-util-same-parent": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0",
-        "vendors": "^1.0.0"
-      },
-      "dependencies": {
-        "dot-prop": {
-          "version": "5.3.0",
-          "dev": true,
-          "requires": {
-            "is-obj": "^2.0.0"
-          }
-        },
-        "is-obj": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "postcss-selector-parser": {
-          "version": "3.1.2",
-          "dev": true,
-          "requires": {
-            "dot-prop": "^5.2.0",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
-        }
-      }
-    },
-    "postcss-minify-font-values": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-minify-gradients": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "is-color-stop": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-minify-params": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "^1.0.0",
-        "browserslist": "^4.0.0",
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "uniqs": "^2.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-minify-selectors": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "^1.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "dot-prop": {
-          "version": "5.3.0",
-          "dev": true,
-          "requires": {
-            "is-obj": "^2.0.0"
-          }
-        },
-        "is-obj": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "postcss-selector-parser": {
-          "version": "3.1.2",
-          "dev": true,
-          "requires": {
-            "dot-prop": "^5.2.0",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
-        }
-      }
-    },
-    "postcss-modules-local-by-default": {
-      "version": "1.2.0",
-      "dev": true,
-      "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "postcss": {
-          "version": "6.0.23",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
-      }
-    },
-    "postcss-modules-scope": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "postcss": {
-          "version": "6.0.23",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
-      }
-    },
-    "postcss-modules-values": {
-      "version": "1.3.0",
-      "dev": true,
-      "requires": {
-        "icss-replace-symbols": "^1.1.0",
-        "postcss": "^6.0.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "postcss": {
-          "version": "6.0.23",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
-      }
-    },
-    "postcss-normalize-charset": {
-      "version": "4.0.1",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0"
-      }
-    },
-    "postcss-normalize-display-values": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-normalize-positions": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-normalize-repeat-style": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-normalize-string": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-normalize-timing-functions": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-normalize-unicode": {
-      "version": "4.0.1",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-normalize-url": {
-      "version": "4.0.1",
-      "dev": true,
-      "requires": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "normalize-url": {
-          "version": "3.3.0",
-          "dev": true
-        },
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-normalize-whitespace": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-ordered-values": {
-      "version": "4.1.2",
-      "dev": true,
-      "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-reduce-initial": {
-      "version": "4.0.3",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0"
-      }
-    },
-    "postcss-reduce-transforms": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
     "postcss-selector-parser": {
-      "version": "6.0.6",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       }
     },
-    "postcss-svgo": {
-      "version": "4.0.3",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "svgo": "^1.0.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "dev": true
-        }
-      }
-    },
-    "postcss-unique-selectors": {
-      "version": "4.0.1",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "^1.0.0",
-        "postcss": "^7.0.0",
-        "uniqs": "^2.0.0"
-      }
-    },
     "postcss-value-parser": {
-      "version": "4.1.0",
-      "dev": true
-    },
-    "posthtml": {
-      "version": "0.11.6",
-      "dev": true,
-      "requires": {
-        "posthtml-parser": "^0.4.1",
-        "posthtml-render": "^1.1.5"
-      }
-    },
-    "posthtml-parser": {
-      "version": "0.4.2",
-      "dev": true,
-      "requires": {
-        "htmlparser2": "^3.9.2"
-      },
-      "dependencies": {
-        "dom-serializer": {
-          "version": "0.2.2",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "entities": "^2.0.0"
-          },
-          "dependencies": {
-            "domelementtype": {
-              "version": "2.2.0",
-              "dev": true
-            },
-            "entities": {
-              "version": "2.2.0",
-              "dev": true
-            }
-          }
-        },
-        "domelementtype": {
-          "version": "1.3.1",
-          "dev": true
-        },
-        "domhandler": {
-          "version": "2.4.2",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1"
-          }
-        },
-        "domutils": {
-          "version": "1.7.0",
-          "dev": true,
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "entities": {
-          "version": "1.1.2",
-          "dev": true
-        },
-        "htmlparser2": {
-          "version": "3.10.1",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^1.3.1",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^3.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "posthtml-render": {
-      "version": "1.4.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
     "prelude-ls": {
@@ -60195,49 +67862,6 @@
       "version": "2.1.1",
       "dev": true
     },
-    "purgecss": {
-      "version": "2.3.0",
-      "dev": true,
-      "requires": {
-        "commander": "^5.0.0",
-        "glob": "^7.0.0",
-        "postcss": "7.0.32",
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "commander": {
-          "version": "5.1.0",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.32",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "6.1.0",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        }
-      }
-    },
     "q": {
       "version": "1.5.1",
       "dev": true
@@ -60275,57 +67899,6 @@
     "quick-lru": {
       "version": "4.0.1",
       "dev": true
-    },
-    "quote-stream": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "buffer-equal": "0.0.1",
-        "minimist": "^1.1.3",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
-      }
     },
     "random-bytes": {
       "version": "1.0.0"
@@ -60420,6 +67993,18 @@
           "dev": true
         }
       }
+    },
+    "react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
+      "dev": true
+    },
+    "react-refresh": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "dev": true
     },
     "read": {
       "version": "1.0.7",
@@ -60539,6 +68124,7 @@
     "readdirp": {
       "version": "2.2.1",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
@@ -60548,6 +68134,7 @@
         "define-property": {
           "version": "2.0.2",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.2",
             "isobject": "^3.0.1"
@@ -60556,6 +68143,7 @@
         "extend-shallow": {
           "version": "3.0.2",
           "dev": true,
+          "optional": true,
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -60564,6 +68152,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -60571,6 +68160,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -60578,6 +68168,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -60587,17 +68178,20 @@
         "is-extendable": {
           "version": "1.0.1",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
         },
         "kind-of": {
           "version": "6.0.3",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "micromatch": {
           "version": "3.1.10",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -60741,7 +68335,9 @@
     },
     "relateurl": {
       "version": "0.2.7",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -60806,6 +68402,8 @@
     "request-promise-core": {
       "version": "1.1.4",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "lodash": "^4.17.19"
       }
@@ -60813,6 +68411,8 @@
     "request-promise-native": {
       "version": "1.0.9",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
@@ -60957,6 +68557,7 @@
     "restore-cursor": {
       "version": "2.0.0",
       "dev": true,
+      "peer": true,
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -60975,14 +68576,6 @@
     },
     "rfdc": {
       "version": "1.3.0",
-      "dev": true
-    },
-    "rgb-regex": {
-      "version": "1.0.1",
-      "dev": true
-    },
-    "rgba-regex": {
-      "version": "1.0.0",
       "dev": true
     },
     "rimraf": {
@@ -61181,13 +68774,11 @@
         "chokidar": ">=3.0.0 <4.0.0"
       }
     },
-    "sax": {
-      "version": "1.2.4",
-      "dev": true
-    },
     "saxes": {
       "version": "3.1.11",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "xmlchars": "^2.1.1"
       }
@@ -63627,10 +71218,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "serialize-to-js": {
-      "version": "3.1.1",
-      "dev": true
-    },
     "serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -63774,10 +71361,6 @@
         }
       }
     },
-    "shallow-copy": {
-      "version": "0.0.1",
-      "dev": true
-    },
     "shebang-command": {
       "version": "1.2.0",
       "dev": true,
@@ -63835,19 +71418,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        }
-      }
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "dev": true
         }
       }
     },
@@ -64601,10 +72171,6 @@
       "version": "1.0.3",
       "dev": true
     },
-    "srcset": {
-      "version": "3.0.1",
-      "dev": true
-    },
     "sri-toolbox": {
       "version": "0.2.0",
       "dev": true
@@ -64639,154 +72205,12 @@
       "version": "0.0.4",
       "dev": true
     },
-    "static-eval": {
-      "version": "2.1.0",
-      "dev": true,
-      "requires": {
-        "escodegen": "^1.11.1"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "1.14.3",
-          "dev": true,
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "levn": {
-          "version": "0.3.0",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "dev": true,
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "dev": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
-        }
-      }
-    },
     "static-extend": {
       "version": "0.1.2",
       "dev": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
-      }
-    },
-    "static-module": {
-      "version": "2.2.5",
-      "dev": true,
-      "requires": {
-        "concat-stream": "~1.6.0",
-        "convert-source-map": "^1.5.1",
-        "duplexer2": "~0.1.4",
-        "escodegen": "~1.9.0",
-        "falafel": "^2.1.0",
-        "has": "^1.0.1",
-        "magic-string": "^0.22.4",
-        "merge-source-map": "1.0.4",
-        "object-inspect": "~1.4.0",
-        "quote-stream": "~1.0.2",
-        "readable-stream": "~2.3.3",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "^2.0.0",
-        "through2": "~2.0.3"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "magic-string": {
-          "version": "0.22.5",
-          "dev": true,
-          "requires": {
-            "vlq": "^0.2.2"
-          }
-        },
-        "merge-source-map": {
-          "version": "1.0.4",
-          "dev": true,
-          "requires": {
-            "source-map": "^0.5.6"
-          }
-        },
-        "object-inspect": {
-          "version": "1.4.1",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "statuses": {
@@ -64797,7 +72221,9 @@
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "stream-browserify": {
       "version": "3.0.0",
@@ -65028,37 +72454,6 @@
         "through": "^2.3.4"
       }
     },
-    "stylehacks": {
-      "version": "4.0.3",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "dot-prop": {
-          "version": "5.3.0",
-          "dev": true,
-          "requires": {
-            "is-obj": "^2.0.0"
-          }
-        },
-        "is-obj": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "postcss-selector-parser": {
-          "version": "3.1.2",
-          "dev": true,
-          "requires": {
-            "dot-prop": "^5.2.0",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
-        }
-      }
-    },
     "supports-color": {
       "version": "5.5.0",
       "requires": {
@@ -65086,86 +72481,15 @@
         }
       }
     },
-    "svgo": {
-      "version": "1.3.2",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.1",
-        "coa": "^2.0.2",
-        "css-select": "^2.0.0",
-        "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.37",
-        "csso": "^4.0.2",
-        "js-yaml": "^3.13.1",
-        "mkdirp": "~0.5.1",
-        "object.values": "^1.1.0",
-        "sax": "~1.2.4",
-        "stable": "^0.1.8",
-        "unquote": "~1.1.1",
-        "util.promisify": "~1.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "css-select": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "boolbase": "^1.0.0",
-            "css-what": "^3.2.1",
-            "domutils": "^1.7.0",
-            "nth-check": "^1.0.2"
-          }
-        },
-        "css-what": {
-          "version": "3.4.2",
-          "dev": true
-        },
-        "dom-serializer": {
-          "version": "0.2.2",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "entities": "^2.0.0"
-          }
-        },
-        "domutils": {
-          "version": "1.7.0",
-          "dev": true,
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          },
-          "dependencies": {
-            "domelementtype": {
-              "version": "1.3.1",
-              "dev": true
-            }
-          }
-        },
-        "nth-check": {
-          "version": "1.0.2",
-          "dev": true,
-          "requires": {
-            "boolbase": "~1.0.0"
-          }
-        }
-      }
-    },
     "symbol-observable": {
       "version": "1.0.1",
       "dev": true
     },
     "symbol-tree": {
       "version": "3.2.4",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "table": {
       "version": "6.7.1",
@@ -65425,17 +72749,28 @@
         }
       }
     },
+    "term-size": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
+      "dev": true
+    },
     "terser": {
-      "version": "5.7.2",
+      "version": "5.16.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.3.tgz",
+      "integrity": "sha512-v8wWLaS/xt3nE9dgKEWhNUFP6q4kngO5B8eYFUuebsu7Dw/UNAnpUod6UHo04jSSkv8TzKHjZDSd7EXdDQAl8Q==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
+        "source-map-support": "~0.5.20"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
+        "acorn": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+          "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
           "dev": true
         }
       }
@@ -65698,10 +73033,6 @@
     },
     "timsort": {
       "version": "0.3.0",
-      "dev": true
-    },
-    "tiny-inflate": {
-      "version": "1.0.3",
       "dev": true
     },
     "tmp": {
@@ -65988,7 +73319,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -66277,6 +73610,8 @@
     "uncss": {
       "version": "0.17.3",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "commander": "^2.20.0",
         "glob": "^7.1.4",
@@ -66291,11 +73626,15 @@
       "dependencies": {
         "is-absolute-url": {
           "version": "3.0.3",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "postcss-selector-parser": {
           "version": "6.0.2",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "indexes-of": "^1.0.1",
@@ -66324,20 +73663,6 @@
       "version": "1.1.0",
       "dev": true
     },
-    "unicode-trie": {
-      "version": "0.3.1",
-      "dev": true,
-      "requires": {
-        "pako": "^0.2.5",
-        "tiny-inflate": "^1.0.0"
-      },
-      "dependencies": {
-        "pako": {
-          "version": "0.2.9",
-          "dev": true
-        }
-      }
-    },
     "union-value": {
       "version": "1.0.1",
       "dev": true,
@@ -66350,11 +73675,9 @@
     },
     "uniq": {
       "version": "1.0.1",
-      "dev": true
-    },
-    "uniqs": {
-      "version": "2.0.0",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "unique-filename": {
       "version": "1.1.1",
@@ -66399,10 +73722,6 @@
     },
     "unpipe": {
       "version": "1.0.0"
-    },
-    "unquote": {
-      "version": "1.1.1",
-      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -66450,6 +73769,24 @@
     "upath": {
       "version": "1.2.0",
       "dev": true
+    },
+    "update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+          "dev": true
+        }
+      }
     },
     "uri-js": {
       "version": "4.4.1",
@@ -66515,13 +73852,11 @@
         "object.getownpropertydescriptors": "^2.0.3"
       }
     },
-    "util.promisify": {
-      "version": "1.0.0",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
-      }
+    "utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1"
@@ -66557,10 +73892,6 @@
     },
     "vary": {
       "version": "1.1.2"
-    },
-    "vendors": {
-      "version": "1.0.4",
-      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -66630,10 +73961,6 @@
           }
         }
       }
-    },
-    "vlq": {
-      "version": "0.2.3",
-      "dev": true
     },
     "vm-browserify": {
       "version": "1.1.2",
@@ -66750,6 +74077,8 @@
     "w3c-hr-time": {
       "version": "1.0.2",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "browser-process-hrtime": "^1.0.0"
       }
@@ -66757,6 +74086,8 @@
     "w3c-xmlserializer": {
       "version": "1.1.2",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "domexception": "^1.0.1",
         "webidl-conversions": "^4.0.2",
@@ -66812,6 +74143,12 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "weak-lru-cache": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
+      "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
+      "dev": true
     },
     "web-streams-polyfill": {
       "version": "3.1.1"
@@ -67201,17 +74538,22 @@
     "whatwg-encoding": {
       "version": "1.0.5",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "iconv-lite": "0.4.24"
       }
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "whatwg-url": {
       "version": "7.1.0",
       "dev": true,
+      "peer": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -67572,11 +74914,15 @@
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "xmlchars": {
       "version": "2.2.0",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.6.3",
@@ -67584,6 +74930,12 @@
     },
     "xtend": {
       "version": "4.0.2",
+      "dev": true
+    },
+    "xxhash-wasm": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
+      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@types/node": "^12.20.4",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.31.0",
+    "babel-preset-env": "^1.7.0",
     "browser-sync": "^2.27.9",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^6.12.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^8.0.0",
     "@skypack/package-check": "^0.2.2",
-    "@types/fetch-mock": "^6.0.6",
+    "@types/fetch-mock": "^7.3.5",
     "@types/jasmine": "^2.8.2",
     "@types/node": "^12.20.4",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
@@ -82,7 +82,7 @@
     "eslint-config-prettier": "^6.12.0",
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.24.2",
-    "fetch-mock": "^5.13.1",
+    "fetch-mock": "^9.0.0",
     "gh-pages": "^1.1.0",
     "globby": "^12.0.2",
     "husky": "^4.3.0",
@@ -156,8 +156,7 @@
     "./demos/*"
   ],
   "volta": {
-    "node": "16.13.0",
-    "npm": "8.1.2"
+    "node": "18.14.0"
   },
   "release": {
     "branches": [

--- a/packages/arcgis-rest-demographics/test/getAvailableCountries.test.ts
+++ b/packages/arcgis-rest-demographics/test/getAvailableCountries.test.ts
@@ -5,21 +5,23 @@ import fetchMock from "fetch-mock";
 import { getAvailableCountries } from "../src/getAvailableCountries.js";
 
 describe("getAvailableCountries", () => {
-  afterEach(fetchMock.restore);
+  beforeEach(() => {
+    fetchMock.reset();
+  });
 
   it("should make a simple, single getAvailableCountries request", (done) => {
-    fetchMock.once("*", {});
+    fetchMock.once("*", { prop: "val" });
 
     getAvailableCountries()
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const { request } = fetchMock.lastCall("*");
-        const { url } = request;
+        const [url, options] = fetchMock.lastCall("*");
+
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/countries"
         );
-        expect(request.method).toBe("POST");
-        expect(request.body).toContain("f=json");
+        expect(options.method).toBe("POST");
+        expect(options.body).toContain("f=json");
         done();
       })
       .catch((e) => {
@@ -35,12 +37,11 @@ describe("getAvailableCountries", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const { request } = fetchMock.lastCall("*");
-        const { url } = request;
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/countries/us"
         );
-        expect(request.body).not.toContain("countryCode=us");
+        expect(options.body).not.toContain("countryCode=us");
         done();
       })
       .catch((e) => {
@@ -58,14 +59,13 @@ describe("getAvailableCountries", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const { request } = fetchMock.lastCall("*");
-        const { url } = request;
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/countries"
         );
-        expect(request.method).toBe("POST");
-        expect(request.body).toContain("f=json");
-        expect(request.body).toContain("foo=bar");
+        expect(options.method).toBe("POST");
+        expect(options.body).toContain("f=json");
+        expect(options.body).toContain("foo=bar");
         done();
       })
       .catch((e) => {
@@ -80,8 +80,7 @@ describe("getAvailableCountries", () => {
       endpoint: "https://esri.com/test"
     })
       .then((response) => {
-        const { request } = fetchMock.lastCall("*");
-        const { url } = request;
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://esri.com/test/countries");
         done();
       })

--- a/packages/arcgis-rest-demographics/test/getAvailableCountries.test.ts
+++ b/packages/arcgis-rest-demographics/test/getAvailableCountries.test.ts
@@ -13,12 +13,13 @@ describe("getAvailableCountries", () => {
     getAvailableCountries()
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const { request } = fetchMock.lastCall("*");
+        const { url } = request;
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/countries"
         );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
+        expect(request.method).toBe("POST");
+        expect(request.body).toContain("f=json");
         done();
       })
       .catch((e) => {
@@ -34,11 +35,12 @@ describe("getAvailableCountries", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const { request } = fetchMock.lastCall("*");
+        const { url } = request;
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/countries/us"
         );
-        expect(options.body).not.toContain("countryCode=us");
+        expect(request.body).not.toContain("countryCode=us");
         done();
       })
       .catch((e) => {
@@ -56,13 +58,14 @@ describe("getAvailableCountries", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const { request } = fetchMock.lastCall("*");
+        const { url } = request;
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/countries"
         );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain("foo=bar");
+        expect(request.method).toBe("POST");
+        expect(request.body).toContain("f=json");
+        expect(request.body).toContain("foo=bar");
         done();
       })
       .catch((e) => {
@@ -77,8 +80,8 @@ describe("getAvailableCountries", () => {
       endpoint: "https://esri.com/test"
     })
       .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const { request } = fetchMock.lastCall("*");
+        const { url } = request;
         expect(url).toEqual("https://esri.com/test/countries");
         done();
       })

--- a/packages/arcgis-rest-demographics/test/getAvailableDataCollections.test.ts
+++ b/packages/arcgis-rest-demographics/test/getAvailableDataCollections.test.ts
@@ -6,15 +6,16 @@ import { getAvailableDataCollections } from "../src/getAvailableDataCollections.
 import { dataCollectionsResponse } from "./mocks/responses.js";
 
 describe("getAvailableDataCollections", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should make a simple, single dataCollections request", (done) => {
     fetchMock.once("*", dataCollectionsResponse);
 
     getAvailableDataCollections()
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/dataCollections"
         );
@@ -35,7 +36,7 @@ describe("getAvailableDataCollections", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/dataCollections/us"
         );
@@ -56,7 +57,7 @@ describe("getAvailableDataCollections", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/dataCollections/us/EducationalAttainment"
         );
@@ -80,7 +81,7 @@ describe("getAvailableDataCollections", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/dataCollections"
         );
@@ -103,7 +104,7 @@ describe("getAvailableDataCollections", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://esri.com/test/dataCollections");
         done();
       })

--- a/packages/arcgis-rest-demographics/test/getAvailableGeographyLevels.test.ts
+++ b/packages/arcgis-rest-demographics/test/getAvailableGeographyLevels.test.ts
@@ -4,10 +4,9 @@
 import fetchMock from "fetch-mock";
 import { getAvailableGeographyLevels } from "../src/getAvailableGeographyLevels.js";
 
-fdescribe("getAvailableGeographyLevels", () => {
+describe("getAvailableGeographyLevels", () => {
   beforeEach(() => {
     fetchMock.restore();
-    fetchMock.reset();
   });
 
   it("should make a simple, single dataCollections request", (done) => {
@@ -16,7 +15,7 @@ fdescribe("getAvailableGeographyLevels", () => {
     getAvailableGeographyLevels()
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/StandardGeographyLevels"
         );
@@ -37,7 +36,7 @@ fdescribe("getAvailableGeographyLevels", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url] = fetchMock.lastCall("*");
         expect(url).toEqual("https://esri.com/test/StandardGeographyLevels");
         done();
       })
@@ -56,7 +55,7 @@ fdescribe("getAvailableGeographyLevels", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/StandardGeographyLevels"
         );

--- a/packages/arcgis-rest-demographics/test/getAvailableGeographyLevels.test.ts
+++ b/packages/arcgis-rest-demographics/test/getAvailableGeographyLevels.test.ts
@@ -4,11 +4,14 @@
 import fetchMock from "fetch-mock";
 import { getAvailableGeographyLevels } from "../src/getAvailableGeographyLevels.js";
 
-describe("getAvailableGeographyLevels", () => {
-  afterEach(fetchMock.restore);
+fdescribe("getAvailableGeographyLevels", () => {
+  beforeEach(() => {
+    fetchMock.restore();
+    fetchMock.reset();
+  });
 
   it("should make a simple, single dataCollections request", (done) => {
-    fetchMock.once("*", {});
+    fetchMock.once("*", {}, { overwriteRoutes: true });
 
     getAvailableGeographyLevels()
       .then((response) => {
@@ -27,7 +30,7 @@ describe("getAvailableGeographyLevels", () => {
   });
 
   it("should make a dataCollections request with a custom endpoint", (done) => {
-    fetchMock.once("*", {});
+    fetchMock.once("*", {}, { overwriteRoutes: true });
 
     getAvailableGeographyLevels({
       endpoint: "https://esri.com/test"
@@ -44,7 +47,7 @@ describe("getAvailableGeographyLevels", () => {
   });
 
   it("should make a dataCollections request with a param", (done) => {
-    fetchMock.once("*", {});
+    fetchMock.once("*", {}, { overwriteRoutes: true });
 
     getAvailableGeographyLevels({
       params: {

--- a/packages/arcgis-rest-demographics/test/getGeography.test.ts
+++ b/packages/arcgis-rest-demographics/test/getGeography.test.ts
@@ -12,8 +12,9 @@ const MOCK_AUTH = {
 };
 
 describe("getGeography", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should throw an error when a getGeography request is made without a token", (done) => {
     fetchMock.once("*", {});
 
@@ -39,7 +40,7 @@ describe("getGeography", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/StandardGeographyQuery/execute"
         );
@@ -67,7 +68,7 @@ describe("getGeography", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://esri.com/test/execute");
         expect(options.method).toBe("POST");
         expect(options.body).toContain("f=json");
@@ -111,7 +112,7 @@ describe("getGeography", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/StandardGeographyQuery/execute"
         );

--- a/packages/arcgis-rest-demographics/test/queryDemographicData.test.ts
+++ b/packages/arcgis-rest-demographics/test/queryDemographicData.test.ts
@@ -12,8 +12,9 @@ const MOCK_AUTH = {
 };
 
 describe("queryDemographicData", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should throw an error when a queryDemographicData request is made without a token", (done) => {
     fetchMock.once("*", {});
 
@@ -38,7 +39,7 @@ describe("queryDemographicData", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/enrich"
         );
@@ -61,7 +62,7 @@ describe("queryDemographicData", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://esri.com/test/enrich");
         expect(options.method).toBe("POST");
         expect(options.body).toContain("f=json");
@@ -97,7 +98,7 @@ describe("queryDemographicData", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geoenrich.arcgis.com/arcgis/rest/services/World/geoenrichmentserver/Geoenrichment/enrich"
         );

--- a/packages/arcgis-rest-feature-service/test/addToServiceDefinition.test.ts
+++ b/packages/arcgis-rest-feature-service/test/addToServiceDefinition.test.ts
@@ -19,8 +19,9 @@ import {
 import { layerDefinitionSid } from "./mocks/layerDefinition.js";
 
 describe("add to feature service", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     // setup a ArcGISIdentityManager to use in all these tests
     const MOCK_USER_SESSION = new ArcGISIdentityManager({
@@ -97,8 +98,7 @@ describe("add to feature service", () => {
           (response) => {
             // Check service call
             expect(fetchMock.called()).toEqual(true);
-            const [url, options]: [string, RequestInit] =
-              fetchMock.lastCall("*");
+            const [url, options] = fetchMock.lastCall("*");
 
             expect(url).toEqual(
               "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
@@ -145,8 +145,7 @@ describe("add to feature service", () => {
           (response) => {
             // Check service call
             expect(fetchMock.called()).toEqual(true);
-            const [url, options]: [string, RequestInit] =
-              fetchMock.lastCall("*");
+            const [url, options] = fetchMock.lastCall("*");
 
             expect(url).toEqual(
               "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
@@ -193,7 +192,7 @@ describe("add to feature service", () => {
         .then((response) => {
           // Check service call
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
 
           expect(url).toEqual(
             "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
@@ -235,7 +234,7 @@ describe("add to feature service", () => {
         .then((response) => {
           // Check service call
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
 
           expect(url).toEqual(
             "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"

--- a/packages/arcgis-rest-feature-service/test/attachments.test.ts
+++ b/packages/arcgis-rest-feature-service/test/attachments.test.ts
@@ -26,8 +26,9 @@ const serviceUrl =
   "https://services.arcgis.com/f8b/arcgis/rest/services/Custom/FeatureServer/0";
 
 describe("attachment methods", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should return an array of attachmentInfos for a feature by id", (done) => {
     const requestOptions = {
       url: serviceUrl,
@@ -40,7 +41,7 @@ describe("attachment methods", () => {
     getAttachments(requestOptions)
       .then(() => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           `${requestOptions.url}/${requestOptions.featureId}/attachments?f=json&gdbVersion=SDE.DEFAULT`
         );
@@ -67,7 +68,7 @@ describe("attachment methods", () => {
     addAttachment(requestOptions)
       .then(() => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           `${requestOptions.url}/${requestOptions.featureId}/addAttachment`
         );
@@ -108,7 +109,7 @@ describe("attachment methods", () => {
       })
       .catch((error) => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           `${requestOptions.url}/${requestOptions.featureId}/addAttachment`
         );
@@ -135,7 +136,7 @@ describe("attachment methods", () => {
     updateAttachment(requestOptions)
       .then(() => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           `${requestOptions.url}/${requestOptions.featureId}/updateAttachment`
         );
@@ -166,7 +167,7 @@ describe("attachment methods", () => {
     deleteAttachments(requestOptions)
       .then(() => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           `${requestOptions.url}/${requestOptions.featureId}/deleteAttachments`
         );

--- a/packages/arcgis-rest-feature-service/test/createFeatureService.test.ts
+++ b/packages/arcgis-rest-feature-service/test/createFeatureService.test.ts
@@ -8,8 +8,9 @@ import { TOMORROW } from "../../../scripts/test-helpers.js";
 import { encodeParam, ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 
 describe("create feature service", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     // setup a ArcGISIdentityManager to use in all these tests
     const MOCK_USER_SESSION = new ArcGISIdentityManager({
@@ -71,7 +72,7 @@ describe("create feature service", () => {
             expect(fetchMock.called("end:createService")).toEqual(true);
 
             // Check create service call
-            const [urlCreate, optionsCreate]: [string, RequestInit] =
+            const [urlCreate, optionsCreate] =
               fetchMock.lastCall("end:createService");
             expect(urlCreate).toEqual(
               "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
@@ -117,7 +118,7 @@ describe("create feature service", () => {
             expect(fetchMock.called("end:createService")).toEqual(true);
 
             // Check create service call
-            const [urlCreate, optionsCreate]: [string, RequestInit] =
+            const [urlCreate, optionsCreate] =
               fetchMock.lastCall("end:createService");
             expect(urlCreate).toEqual(
               "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
@@ -163,7 +164,7 @@ describe("create feature service", () => {
             expect(fetchMock.called("end:createService")).toEqual(true);
 
             // Check create service call
-            const [urlCreate, optionsCreate]: [string, RequestInit] =
+            const [urlCreate, optionsCreate] =
               fetchMock.lastCall("end:createService");
             expect(urlCreate).toEqual(
               "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
@@ -209,7 +210,7 @@ describe("create feature service", () => {
             expect(fetchMock.called("end:createService")).toEqual(true);
 
             // Check create service call
-            const [urlCreate, optionsCreate]: [string, RequestInit] =
+            const [urlCreate, optionsCreate] =
               fetchMock.lastCall("end:createService");
             expect(urlCreate).toEqual(
               "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/83216cba44bf4357bf06687ec88a847b/createService"
@@ -255,7 +256,7 @@ describe("create feature service", () => {
           expect(fetchMock.called("end:createService")).toEqual(true);
 
           // Check create service call
-          const [urlCreate, optionsCreate]: [string, RequestInit] =
+          const [urlCreate, optionsCreate] =
             fetchMock.lastCall("end:createService");
           expect(urlCreate).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/83216cba44bf4357bf06687ec88a847b/createService"

--- a/packages/arcgis-rest-feature-service/test/crud.test.ts
+++ b/packages/arcgis-rest-feature-service/test/crud.test.ts
@@ -22,8 +22,9 @@ const serviceUrl =
   "https://services.arcgis.com/f8b/arcgis/rest/services/Custom/FeatureServer/0";
 
 describe("feature", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should return objectId of the added feature and a truthy success", (done) => {
     const requestOptions = {
       url: serviceUrl,
@@ -49,7 +50,7 @@ describe("feature", () => {
     addFeatures(requestOptions)
       .then((response) => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(`${requestOptions.url}/addFeatures`);
         expect(options.body).toContain(
           "features=" +
@@ -86,7 +87,7 @@ describe("feature", () => {
     updateFeatures(requestOptions)
       .then((response) => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(`${requestOptions.url}/updateFeatures`);
         expect(options.method).toBe("POST");
         expect(options.body).toContain(
@@ -115,7 +116,7 @@ describe("feature", () => {
     deleteFeatures(requestOptions)
       .then((response) => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(`${requestOptions.url}/deleteFeatures`);
         expect(options.body).toContain("objectIds=1001");
         expect(options.body).toContain("where=1%3D1");
@@ -165,7 +166,7 @@ describe("feature", () => {
     applyEdits(requestOptions)
       .then((response) => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(`${requestOptions.url}/applyEdits`);
         expect(options.method).toBe("POST");
         expect(options.body).toContain(

--- a/packages/arcgis-rest-feature-service/test/decodeValues.test.ts
+++ b/packages/arcgis-rest-feature-service/test/decodeValues.test.ts
@@ -16,8 +16,9 @@ const serviceUrl =
   "https://services.arcgis.com/f8b/arcgis/rest/services/Custom/FeatureServer/0";
 
 describe("formatCodedValues()", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should format the cvd codes in a raw response", (done) => {
     decodeValues({
       url: serviceUrl,

--- a/packages/arcgis-rest-feature-service/test/getAllLayersAndTables.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getAllLayersAndTables.test.ts
@@ -7,14 +7,15 @@ const layerUrlBase =
   "https://services.arcgis.com/f8b/arcgis/rest/services/Custom/FeatureServer";
 
 describe("getAllLayersAndTables()", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should fetch all layers and table associated with the service", (done) => {
     fetchMock.once("*", allLayersAndTablesResponse);
     getAllLayersAndTables({ url: layerUrlBase + "/0" })
       .then((response) => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(layerUrlBase + "/layers");
         expect(options.method).toBe("POST");
         expect(response).toEqual(allLayersAndTablesResponse);

--- a/packages/arcgis-rest-feature-service/test/getLayer.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getLayer.test.ts
@@ -10,14 +10,15 @@ const layerUrl =
   "https://services.arcgis.com/f8b/arcgis/rest/services/Custom/FeatureServer/0";
 
 describe("feature", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should fetch service metadata", (done) => {
     fetchMock.once("*", getFeatureServiceResponse);
     getLayer({ url: layerUrl })
       .then((response) => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(layerUrl);
         expect(options.method).toBe("POST");
         expect(response).toEqual(getFeatureServiceResponse);

--- a/packages/arcgis-rest-feature-service/test/getService.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getService.test.ts
@@ -10,14 +10,15 @@ const layerUrl =
   "https://services.arcgis.com/f8b/arcgis/rest/services/Custom/FeatureServer";
 
 describe("getServer()", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should fetch feature service metadata", (done) => {
     fetchMock.once("*", getFeatureServerResponse);
     getService({ url: layerUrl })
       .then((response) => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(layerUrl);
         expect(options.method).toBe("POST");
         expect(response).toEqual(getFeatureServerResponse);

--- a/packages/arcgis-rest-feature-service/test/getServiceAdminInfo.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getServiceAdminInfo.test.ts
@@ -7,8 +7,9 @@ import { TOMORROW } from "../../../scripts/test-helpers.js";
 import { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 
 describe("getServiceAdminInfo: ", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   const MOCK_USER_SESSION = new ArcGISIdentityManager({
     clientId: "clientId",
     redirectUri: "https://example-app.com/redirect-uri",
@@ -28,7 +29,7 @@ describe("getServiceAdminInfo: ", () => {
       "https://servicesqa.arcgis.com/orgid/arcgis/rest/services/mysevice/FeatureServer",
       MOCK_USER_SESSION
     ).then((result) => {
-      const [url]: [string, RequestInit] = fetchMock.lastCall("*");
+      const [url] = fetchMock.lastCall("*");
 
       expect(result.foo).toBe("bar", "should return the api response");
 

--- a/packages/arcgis-rest-feature-service/test/getViewSources.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getViewSources.test.ts
@@ -18,8 +18,9 @@ describe("get-view-sources: ", () => {
     password: "123456",
     portal: "https://myorg.maps.arcgis.com/sharing/rest"
   });
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("makes request to the admin url", () => {
     fetchMock.once("*", { currentVersion: 1234 }, { method: "POST" });
 
@@ -32,7 +33,7 @@ describe("get-view-sources: ", () => {
         "should return the api response"
       );
 
-      const [url]: [string, RequestInit] = fetchMock.lastCall("*");
+      const [url] = fetchMock.lastCall("*");
 
       expect(fetchMock.called()).toEqual(true);
 

--- a/packages/arcgis-rest-feature-service/test/query.test.ts
+++ b/packages/arcgis-rest-feature-service/test/query.test.ts
@@ -20,8 +20,9 @@ const serviceUrl =
   "https://services.arcgis.com/f8b/arcgis/rest/services/Custom/FeatureServer/0";
 
 describe("getFeature() and queryFeatures()", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should return a feature by id", (done) => {
     const requestOptions = {
       url: serviceUrl,
@@ -31,7 +32,7 @@ describe("getFeature() and queryFeatures()", () => {
     getFeature(requestOptions)
       .then((response) => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(`${requestOptions.url}/42?f=json`);
         expect(options.method).toBe("GET");
         expect(response.attributes.FID).toEqual(42);
@@ -52,7 +53,7 @@ describe("getFeature() and queryFeatures()", () => {
     getFeature(requestOptions)
       .then((response: any) => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(`${requestOptions.url}/42?f=json`);
         expect(options.method).toBe("GET");
         expect(response.status).toBe(200);
@@ -78,7 +79,7 @@ describe("getFeature() and queryFeatures()", () => {
     queryFeatures(requestOptions)
       .then(() => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           `${requestOptions.url}/query?f=json&where=1%3D1&outFields=*`
         );
@@ -103,9 +104,9 @@ describe("getFeature() and queryFeatures()", () => {
     queryFeatures(requestOptions)
       .then(() => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
-          `${requestOptions.url}/query?f=json&where=Condition%3D'Poor'&outFields=FID%2CTree_ID%2CCmn_Name%2CCondition&geometry=%7B%7D&geometryType=esriGeometryPolygon&orderByFields=test`
+          `${requestOptions.url}/query?f=json&where=Condition%3D%27Poor%27&outFields=FID%2CTree_ID%2CCmn_Name%2CCondition&geometry=%7B%7D&geometryType=esriGeometryPolygon&orderByFields=test`
         );
         expect(options.method).toBe("GET");
         // expect(response.attributes.FID).toEqual(42);
@@ -124,7 +125,7 @@ describe("getFeature() and queryFeatures()", () => {
     queryRelated(requestOptions)
       .then(() => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           `${requestOptions.url}/queryRelatedRecords?f=json&definitionExpression=1%3D1&outFields=*&relationshipId=0`
         );
@@ -148,7 +149,7 @@ describe("getFeature() and queryFeatures()", () => {
     queryRelated(requestOptions)
       .then(() => {
         expect(fetchMock.called()).toBeTruthy();
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(`${requestOptions.url}/queryRelatedRecords`);
         expect(options.method).toBe("POST");
         expect(options.body).toContain("f=json");

--- a/packages/arcgis-rest-feature-service/test/updateServiceDefinition.test.ts
+++ b/packages/arcgis-rest-feature-service/test/updateServiceDefinition.test.ts
@@ -8,8 +8,9 @@ import { updateServiceDefinition } from "../src/updateServiceDefinition.js";
 import { UpdateServiceDefinitionSuccess } from "./mocks/service.js";
 
 describe("update service definition", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     // setup a ArcGISIdentityManager to use in all these tests
     const MOCK_USER_SESSION = new ArcGISIdentityManager({
@@ -45,7 +46,7 @@ describe("update service definition", () => {
         .then((response) => {
           // Check service call
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
 
           expect(url).toEqual(
             "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/updateDefinition"
@@ -78,7 +79,7 @@ describe("update service definition", () => {
         .then((response) => {
           // Check service call
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
 
           expect(url).toEqual(
             "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/updateDefinition"

--- a/packages/arcgis-rest-geocoding/test/bulk.test.ts
+++ b/packages/arcgis-rest-geocoding/test/bulk.test.ts
@@ -21,8 +21,9 @@ const addresses = [
 ];
 
 describe("geocode", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should make a bulk geocoding request, even with an unmatchable record", (done) => {
     fetchMock.once("*", GeocodeAddresses);
 
@@ -36,7 +37,7 @@ describe("geocode", () => {
     bulkGeocode({ addresses, authentication: MOCK_AUTH })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/geocodeAddresses"
         );
@@ -89,7 +90,7 @@ describe("geocode", () => {
       // tslint:disable-next-line
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://customer.gov/arcgis/rest/services/CompositeGeocoder/GeocodeServer/geocodeAddresses"
         );
@@ -130,7 +131,7 @@ describe("geocode", () => {
       // tslint:disable-next-line
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://customer.gov/arcgis/rest/services/CompositeGeocoder/GeocodeServer/geocodeAddresses"
         );
@@ -171,7 +172,7 @@ describe("geocode", () => {
     bulkGeocode({ addresses, authentication: MOCK_AUTH, rawResponse: true })
       .then((response: any) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/geocodeAddresses"
         );

--- a/packages/arcgis-rest-geocoding/test/geocode.test.ts
+++ b/packages/arcgis-rest-geocoding/test/geocode.test.ts
@@ -13,7 +13,9 @@ const customGeocoderUrl =
   "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/";
 
 describe("geocode", () => {
-  afterEach(fetchMock.restore);
+  afterEach(() => {
+    fetchMock.restore();
+  });
 
   it("should make a simple, single geocoding request", (done) => {
     fetchMock.once("*", FindAddressCandidates);
@@ -21,7 +23,7 @@ describe("geocode", () => {
     geocode("LAX")
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
         );
@@ -47,7 +49,7 @@ describe("geocode", () => {
     geocode({ address: "1600 Pennsylvania Avenue", city: "Washington D.C." })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
         );
@@ -77,7 +79,7 @@ describe("geocode", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
         );
@@ -107,7 +109,7 @@ describe("geocode", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
         );
@@ -141,7 +143,7 @@ describe("geocode", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/findAddressCandidates"
         );
@@ -176,7 +178,7 @@ describe("geocode", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/findAddressCandidates?f=json&outSr=3857&address=380%20New%20York%20St&postal=92373"
         );
@@ -196,7 +198,7 @@ describe("geocode", () => {
     geocode("LAX")
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
         );
@@ -224,7 +226,7 @@ describe("geocode", () => {
     })
       .then((response: any) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
         );

--- a/packages/arcgis-rest-geocoding/test/helpers.test.ts
+++ b/packages/arcgis-rest-geocoding/test/helpers.test.ts
@@ -9,15 +9,16 @@ const customGeocoderUrl =
   "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/";
 
 describe("geocode", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should retrieve metadata from the World Geocoding Service", (done) => {
     fetchMock.once("*", SharingInfo);
 
     getGeocodeService()
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/?f=json"
         );
@@ -40,7 +41,7 @@ describe("geocode", () => {
     getGeocodeService({ httpMethod: "POST" })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/"
         );
@@ -65,7 +66,7 @@ describe("geocode", () => {
     getGeocodeService({ endpoint: customGeocoderUrl })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/?f=json"
         );

--- a/packages/arcgis-rest-geocoding/test/reverse.test.ts
+++ b/packages/arcgis-rest-geocoding/test/reverse.test.ts
@@ -6,15 +6,16 @@ import { reverseGeocode } from "../src/reverse.js";
 import { ReverseGeocode } from "./mocks/responses.js";
 
 describe("geocode", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should make a reverse geocoding request", (done) => {
     fetchMock.once("*", ReverseGeocode);
 
     reverseGeocode({ x: -118.409, y: 33.9425 })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
         );
@@ -40,7 +41,7 @@ describe("geocode", () => {
     )
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?f=json&location=%7B%22x%22%3A-118.409%2C%22y%22%3A33.9425%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D"
         );
@@ -59,7 +60,7 @@ describe("geocode", () => {
     reverseGeocode({ longitude: -118.409, latitude: 33.9425 })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
         );
@@ -82,7 +83,7 @@ describe("geocode", () => {
     reverseGeocode({ lat: 33.9425, long: -118.409 })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
         );
@@ -105,7 +106,7 @@ describe("geocode", () => {
     reverseGeocode([-118, 34])
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
         );

--- a/packages/arcgis-rest-geocoding/test/suggest.test.ts
+++ b/packages/arcgis-rest-geocoding/test/suggest.test.ts
@@ -6,15 +6,16 @@ import { suggest } from "../src/suggest.js";
 import { Suggest } from "./mocks/responses.js";
 
 describe("geocode", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should make a request for suggestions", (done) => {
     fetchMock.once("*", Suggest);
 
     suggest("LAX")
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest"
         );
@@ -35,7 +36,7 @@ describe("geocode", () => {
     suggest("LAX", { params: { category: "Address,Postal" } })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest"
         );

--- a/packages/arcgis-rest-portal/test/groups/add-user.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/add-user.test.ts
@@ -32,8 +32,9 @@ describe("add-users", () => {
     portal: "https://myorg.maps.arcgis.com/sharing/rest"
   });
 
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should send multiple requests for a long user array", (done) => {
     const requests = [createUsernames(0, 25), createUsernames(25, 35)];
 

--- a/packages/arcgis-rest-portal/test/groups/crud.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/crud.test.ts
@@ -18,8 +18,9 @@ import {
 import { TOMORROW } from "../../../../scripts/test-helpers.js";
 
 describe("groups", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("authenticted methods", () => {
     const MOCK_AUTH = new ArcGISIdentityManager({
       clientId: "clientId",
@@ -49,7 +50,7 @@ describe("groups", () => {
       createGroup({ group: fakeGroup, ...MOCK_REQOPTS })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/createGroup"
           );
@@ -76,7 +77,7 @@ describe("groups", () => {
       createGroup({ group: fakeGroup, ...MOCK_REQOPTS })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/createGroup"
           );
@@ -106,7 +107,7 @@ describe("groups", () => {
       updateGroup({ group: fakeGroup, ...MOCK_REQOPTS })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/update"
           );
@@ -141,7 +142,7 @@ describe("groups", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/update"
           );
@@ -165,7 +166,7 @@ describe("groups", () => {
       removeGroup({ id: "5bc", ...MOCK_REQOPTS })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/delete"
           );

--- a/packages/arcgis-rest-portal/test/groups/get.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/get.test.ts
@@ -20,15 +20,16 @@ import {
 } from "../mocks/groups/responses.js";
 
 describe("groups", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("getGroup", () => {
     it("should return a group", (done) => {
       fetchMock.once("*", GroupResponse);
       getGroup("3ef")
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/community/groups/3ef?f=json"
           );
@@ -47,7 +48,7 @@ describe("groups", () => {
       getGroupCategorySchema("3ef")
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/community/groups/3ef/categorySchema?f=json"
           );
@@ -66,7 +67,7 @@ describe("groups", () => {
       getGroupContent("3ef")
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/content/groups/3ef?f=json&start=1&num=100"
           );
@@ -83,7 +84,7 @@ describe("groups", () => {
       getGroupContent("3ef", { paging: { start: 4, num: 7 } })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/content/groups/3ef?f=json&start=4&num=7"
           );
@@ -113,7 +114,7 @@ describe("groups", () => {
       getGroupUsers("5bc", MOCK_REQOPTS)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/users?f=json&token=fake-token"
           );
@@ -141,8 +142,7 @@ describe("groups", () => {
         })
           .then((response) => {
             expect(fetchMock.called()).toEqual(true);
-            const [url, options]: [string, RequestInit] =
-              fetchMock.lastCall("*");
+            const [url, options] = fetchMock.lastCall("*");
             expect(url).toEqual(
               "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/userlist?f=json&name=jupe&num=2&start=2&sortField=fullname&sortOrder=asc&joined=%2C123456&memberType=member&token=fake-token"
             );
@@ -160,8 +160,7 @@ describe("groups", () => {
         searchGroupUsers("5bc")
           .then((_) => {
             expect(fetchMock.called()).toEqual(true);
-            const [__, options]: [string, RequestInit] =
-              fetchMock.lastCall("*");
+            const [__, options] = fetchMock.lastCall("*");
             expect(options.method).toBe("GET");
             done();
           })

--- a/packages/arcgis-rest-portal/test/groups/invite-users.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/invite-users.test.ts
@@ -34,8 +34,9 @@ describe("invite-users", () => {
     portal: "https://myorg.maps.arcgis.com/sharing/rest"
   });
 
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should send multiple requests for a long user array", (done) => {
     const requests = [createUsernames(0, 25), createUsernames(25, 35)];
 

--- a/packages/arcgis-rest-portal/test/groups/join.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/join.test.ts
@@ -11,8 +11,9 @@ import { encodeParam, ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 import { TOMORROW } from "../../../../scripts/test-helpers.js";
 
 describe("groups", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("authenticted methods", () => {
     const MOCK_REQOPTS = {
       authentication: new ArcGISIdentityManager({
@@ -34,7 +35,7 @@ describe("groups", () => {
       joinGroup({ id: "5bc", ...MOCK_REQOPTS })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/join"
           );
@@ -53,7 +54,7 @@ describe("groups", () => {
       leaveGroup({ id: "5bc", ...MOCK_REQOPTS })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/leave"
           );

--- a/packages/arcgis-rest-portal/test/groups/notification.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/notification.test.ts
@@ -8,8 +8,9 @@ import { createGroupNotification } from "../../src/groups/notification.js";
 import { GroupNotificationResponse } from "../mocks/groups/responses.js";
 
 describe("groups", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("createGroupNotification", () => {
     const MOCK_AUTH = new ArcGISIdentityManager({
       clientId: "clientId",
@@ -40,7 +41,7 @@ describe("groups", () => {
       createGroupNotification(opts)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/3ef/createNotification"
           );
@@ -79,7 +80,7 @@ describe("groups", () => {
       createGroupNotification(opts)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/3ef/createNotification"
           );

--- a/packages/arcgis-rest-portal/test/groups/protect.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/protect.test.ts
@@ -11,8 +11,9 @@ import { encodeParam, ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 import { TOMORROW } from "../../../../scripts/test-helpers.js";
 
 describe("groups", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("authenticted methods", () => {
     const MOCK_REQOPTS = {
       authentication: new ArcGISIdentityManager({
@@ -34,7 +35,7 @@ describe("groups", () => {
       protectGroup({ id: "5bc", ...MOCK_REQOPTS })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/protect"
           );
@@ -53,7 +54,7 @@ describe("groups", () => {
       unprotectGroup({ id: "5bc", ...MOCK_REQOPTS })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/5bc/unprotect"
           );

--- a/packages/arcgis-rest-portal/test/groups/remove-users.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/remove-users.test.ts
@@ -33,8 +33,9 @@ describe("remove-users", () => {
     portal: "https://myorg.maps.arcgis.com/sharing/rest"
   });
 
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should send multiple requests for a long user array", (done) => {
     const requests = [createUsernames(0, 25), createUsernames(25, 35)];
 

--- a/packages/arcgis-rest-portal/test/groups/search.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/search.test.ts
@@ -9,8 +9,9 @@ import { SearchQueryBuilder } from "../../src/util/SearchQueryBuilder.js";
 import { genericSearch } from "../../src/util/generic-search.js";
 
 describe("groups", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("searchGroups", () => {
     it("should make a simple, unauthenticated group search request", (done) => {
       fetchMock.once("*", GroupSearchResponse);
@@ -18,7 +19,7 @@ describe("groups", () => {
       searchGroups("water")
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/community/groups?f=json&q=water"
           );
@@ -41,7 +42,7 @@ describe("groups", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/community/groups?f=json&q=water&num=7&start=4&sortField=owner&sortOrder=desc"
           );
@@ -62,7 +63,7 @@ describe("groups", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/content/groups/grp1234567890/search?f=json&q=water"
           );
@@ -105,7 +106,7 @@ describe("groups", () => {
     searchGroups(q)
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           `https://www.arcgis.com/sharing/rest/community/groups?f=json&q=${encodeURIComponent(
             expectedParam
@@ -136,7 +137,7 @@ describe("groups", () => {
       searchGroups({ q: "water", authentication: MOCK_AUTH })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups?f=json&q=water&token=fake-token"
           );

--- a/packages/arcgis-rest-portal/test/groups/update-user-membership.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/update-user-membership.test.ts
@@ -21,8 +21,9 @@ describe("udpate-user-membership", () => {
       .catch();
   });
 
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("converts member to admin", (done) => {
     fetchMock.post(
       "https://myorg.maps.arcgis.com/sharing/rest/community/groups/3ef/updateUsers",
@@ -35,7 +36,7 @@ describe("udpate-user-membership", () => {
       users: ["larry", "curly", "moe"],
       newMemberType: "admin"
     } as any).then(() => {
-      const opts: RequestInit = fetchMock.lastOptions(
+      const opts = fetchMock.lastOptions(
         "https://myorg.maps.arcgis.com/sharing/rest/community/groups/3ef/updateUsers"
       );
       expect(opts.body).toContain("admins=larry%2Ccurly%2Cmoe");
@@ -54,7 +55,7 @@ describe("udpate-user-membership", () => {
       users: ["larry", "curly", "moe"],
       newMemberType: "member"
     } as any).then(() => {
-      const opts: RequestInit = fetchMock.lastOptions(
+      const opts = fetchMock.lastOptions(
         "https://myorg.maps.arcgis.com/sharing/rest/community/groups/3ef/updateUsers"
       );
       expect(opts.body).toContain("users=larry%2Ccurly%2Cmoe");

--- a/packages/arcgis-rest-portal/test/items/add.test.ts
+++ b/packages/arcgis-rest-portal/test/items/add.test.ts
@@ -16,8 +16,9 @@ import { encodeParam, ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 import { FormData } from "@esri/arcgis-rest-form-data";
 
 describe("search", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     // setup a ArcGISIdentityManager to use in all these tests
     const MOCK_USER_SESSION = new ArcGISIdentityManager({
@@ -52,7 +53,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/update"
           );
@@ -86,7 +87,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/update"
           );
@@ -123,7 +124,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/update"
           );
@@ -157,7 +158,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/update"
           );
@@ -189,7 +190,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/addRelationship"
           );
@@ -224,7 +225,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/addResources"
           );
@@ -264,7 +265,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/addResources"
           );
@@ -299,7 +300,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/addResources"
           );

--- a/packages/arcgis-rest-portal/test/items/content.test.ts
+++ b/packages/arcgis-rest-portal/test/items/content.test.ts
@@ -9,8 +9,9 @@ import { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 import { TOMORROW } from "../../../../scripts/test-helpers.js";
 
 describe("getContent", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     const authentication = new ArcGISIdentityManager({
       clientId: "clientId",
@@ -75,7 +76,7 @@ describe("getContent", () => {
       getUserContent(requestOptions)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             `https://myorg.maps.arcgis.com/sharing/rest/content/users/${requestOptions.owner}?f=json&start=1&num=10&token=fake-token`
           );
@@ -99,7 +100,7 @@ describe("getContent", () => {
       getUserContent(requestOptions)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             `https://myorg.maps.arcgis.com/sharing/rest/content/users/${requestOptions.owner}?f=json&start=2&num=1&token=fake-token`
           );
@@ -122,7 +123,7 @@ describe("getContent", () => {
       getUserContent(requestOptions)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             `https://myorg.maps.arcgis.com/sharing/rest/content/users/${authentication.username}?f=json&start=2&num=1&token=fake-token`
           );
@@ -146,7 +147,7 @@ describe("getContent", () => {
       getUserContent(requestOptions)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             `https://myorg.maps.arcgis.com/sharing/rest/content/users/${authentication.username}/${requestOptions.folderId}?f=json&start=2&num=1&token=fake-token`
           );

--- a/packages/arcgis-rest-portal/test/items/create.test.ts
+++ b/packages/arcgis-rest-portal/test/items/create.test.ts
@@ -18,8 +18,9 @@ import {
 } from "@esri/arcgis-rest-request";
 
 describe("search", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     // setup a ArcGISIdentityManager to use in all these tests
     const MOCK_USER_SESSION = new ArcGISIdentityManager({
@@ -68,7 +69,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/addItem"
           );
@@ -115,7 +116,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/addItem"
           );
@@ -161,7 +162,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/addItem"
           );
@@ -204,7 +205,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/addItem"
           );
@@ -245,7 +246,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/fe8/addItem"
           );
@@ -289,7 +290,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/fe8/addItem"
           );
@@ -329,7 +330,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/addItem"
           );
@@ -360,7 +361,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createFolder"
           );

--- a/packages/arcgis-rest-portal/test/items/export.test.ts
+++ b/packages/arcgis-rest-portal/test/items/export.test.ts
@@ -9,8 +9,9 @@ import { TOMORROW } from "../../../../scripts/test-helpers.js";
 import { ArcGISIdentityManager, encodeParam } from "@esri/arcgis-rest-request";
 
 describe("exportItem", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     const authentication = new ArcGISIdentityManager({
       clientId: "clientId",
@@ -52,7 +53,7 @@ describe("exportItem", () => {
       exportItem(exportOptions)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             `https://myorg.maps.arcgis.com/sharing/rest/content/users/${exportOptions.owner}/export`
           );
@@ -97,7 +98,7 @@ describe("exportItem", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             `https://myorg.maps.arcgis.com/sharing/rest/content/users/${authentication.username}/export`
           );

--- a/packages/arcgis-rest-portal/test/items/get.test.ts
+++ b/packages/arcgis-rest-portal/test/items/get.test.ts
@@ -393,7 +393,6 @@ describe("get", () => {
               "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/resources/resource.json"
             );
             expect(options.method).toBe("POST");
-            expect(blob).toEqual(jasmine.any(Blob));
             blob
               .text()
               .then((text: string) => expect(text).toEqual(resourceResponse))

--- a/packages/arcgis-rest-portal/test/items/get.test.ts
+++ b/packages/arcgis-rest-portal/test/items/get.test.ts
@@ -42,15 +42,16 @@ describe("get base url", () => {
 });
 
 describe("get", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should return an item by id", (done) => {
     fetchMock.once("*", ItemResponse);
 
     getItem("3ef")
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/3ef?f=json"
         );
@@ -68,7 +69,7 @@ describe("get", () => {
     getItemData("3ef")
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/3ef/data?f=json"
         );
@@ -92,7 +93,7 @@ describe("get", () => {
       getItemData("3ef", { file: true })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/content/items/3ef/data"
           );
@@ -109,16 +110,21 @@ describe("get", () => {
   });
 
   it("should return a valid response even when no data is retrieved", (done) => {
-    fetchMock.once("*", {
-      sendAsJson: false,
-      headers: { "Content-Type": "text/plain;charset=utf-8" },
-      body: ""
-    });
+    fetchMock.once(
+      "*",
+      {
+        headers: { "Content-Type": "text/plain;charset=utf-8" },
+        body: ""
+      },
+      {
+        sendAsJson: false
+      }
+    );
 
     getItemData("3ef")
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/3ef/data?f=json"
         );
@@ -140,7 +146,7 @@ describe("get", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/3ef/relatedItems?f=json&relationshipType=Service2Layer"
         );
@@ -161,7 +167,7 @@ describe("get", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/3ef/relatedItems?f=json&relationshipTypes=Service2Layer%2CArea2CustomPackage"
         );
@@ -180,7 +186,7 @@ describe("get", () => {
       .then((response) => {
         expect(response).toBe(ItemInfoResponse);
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/3ef/info/iteminfo.xml"
         );
@@ -203,7 +209,7 @@ describe("get", () => {
       .then((formJson) => {
         expect(formJson).toEqual(ItemFormJsonResponse);
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/3ef/info/form.json"
         );
@@ -225,7 +231,7 @@ describe("get", () => {
       .then((formJson) => {
         expect(formJson).toEqual(ItemFormJsonResponse);
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/3ef/info/form.json"
         );
@@ -244,7 +250,7 @@ describe("get", () => {
       .then((response) => {
         expect(response).toBe(ItemMetadataResponse);
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/3ef/info/metadata/metadata.xml"
         );
@@ -280,7 +286,7 @@ describe("get", () => {
       getItem("3ef", MOCK_USER_REQOPTS)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef?f=json&token=fake-token"
           );
@@ -298,7 +304,7 @@ describe("get", () => {
       getItemData("3ef", MOCK_USER_REQOPTS)
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/data?f=json&token=fake-token"
           );
@@ -318,7 +324,7 @@ describe("get", () => {
         ...MOCK_USER_REQOPTS
       })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/relatedItems?f=json&relationshipType=Service2Layer&token=fake-token"
           );
@@ -336,7 +342,7 @@ describe("get", () => {
         ...MOCK_USER_REQOPTS
       })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/resources"
           );
@@ -358,7 +364,7 @@ describe("get", () => {
         }
       })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/resources"
           );
@@ -387,8 +393,7 @@ describe("get", () => {
           ...MOCK_USER_REQOPTS
         })
           .then((blob) => {
-            const [url, options]: [string, RequestInit] =
-              fetchMock.lastCall("*");
+            const [url, options] = fetchMock.lastCall("*");
             expect(url).toEqual(
               "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/resources/resource.json"
             );
@@ -415,8 +420,7 @@ describe("get", () => {
           ...MOCK_USER_REQOPTS
         })
           .then(() => {
-            const [url, options]: [string, RequestInit] =
-              fetchMock.lastCall("*");
+            const [url, options] = fetchMock.lastCall("*");
             expect(url).toEqual(
               "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/resources/resource.json"
             );
@@ -438,8 +442,7 @@ describe("get", () => {
           ...MOCK_USER_REQOPTS
         })
           .then((resource) => {
-            const [url, options]: [string, RequestInit] =
-              fetchMock.lastCall("*");
+            const [url, options] = fetchMock.lastCall("*");
             expect(url).toEqual(
               "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/resources/resource.json"
             );
@@ -462,8 +465,7 @@ describe("get", () => {
           ...MOCK_USER_REQOPTS
         })
           .then((response) => {
-            const [url, options]: [string, RequestInit] =
-              fetchMock.lastCall("*");
+            const [url, options] = fetchMock.lastCall("*");
             expect(url).toEqual(
               "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/resources/resource.json"
             );
@@ -491,7 +493,7 @@ describe("get", () => {
       fetchMock.once("*", ItemGroupResponse);
       getItemGroups("3ef")
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/content/items/3ef/groups"
           );
@@ -508,7 +510,7 @@ describe("get", () => {
       fetchMock.once("*", ItemGroupResponse);
       getItemGroups("3ef", { authentication: MOCK_USER_SESSION })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/items/3ef/groups"
           );
@@ -525,7 +527,7 @@ describe("get", () => {
       fetchMock.once("*", ItemGroupResponse);
       getItemStatus({ id: "3ef", authentication: MOCK_USER_SESSION })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/status"
           );
@@ -548,7 +550,7 @@ describe("get", () => {
         authentication: MOCK_USER_SESSION
       })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/joe/items/3ef/status"
           );
@@ -567,7 +569,7 @@ describe("get", () => {
       fetchMock.once("*", ItemGroupResponse);
       getItemParts({ id: "3ef", authentication: MOCK_USER_SESSION })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/parts"
           );
@@ -588,7 +590,7 @@ describe("get", () => {
         authentication: MOCK_USER_SESSION
       })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/joe/items/3ef/parts"
           );

--- a/packages/arcgis-rest-portal/test/items/protect.test.ts
+++ b/packages/arcgis-rest-portal/test/items/protect.test.ts
@@ -10,8 +10,9 @@ import { TOMORROW } from "../../../../scripts/test-helpers.js";
 import { ArcGISIdentityManager, encodeParam } from "@esri/arcgis-rest-request";
 
 describe("search", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     // setup a ArcGISIdentityManager to use in all these tests
     const MOCK_USER_SESSION = new ArcGISIdentityManager({
@@ -38,7 +39,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/protect"
           );
@@ -59,7 +60,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/protect"
           );
@@ -81,7 +82,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/unprotect"
           );
@@ -102,7 +103,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/unprotect"
           );

--- a/packages/arcgis-rest-portal/test/items/reassign.test.ts
+++ b/packages/arcgis-rest-portal/test/items/reassign.test.ts
@@ -12,8 +12,9 @@ import {
 } from "../mocks/users/user.js";
 
 describe("reassignItem", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("shoulds throw if not authd as org_admin", (done) => {
     const MOCK_USER_SESSION = new ArcGISIdentityManager({
       token: "fake-token",
@@ -68,7 +69,7 @@ describe("reassignItem", () => {
         //   "All fetchMocks should have been called"
         // );
         expect(resp.success).toBe(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+        const [url, options] = fetchMock.lastCall(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/alex/items/3ef/reassign"
         );
         expect(url).toBe(
@@ -112,7 +113,7 @@ describe("reassignItem", () => {
         //   "All fetchMocks should have been called"
         // );
         expect(resp.success).toBe(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+        const [url, options] = fetchMock.lastCall(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/alex/items/3ef/reassign"
         );
         expect(url).toBe(

--- a/packages/arcgis-rest-portal/test/items/remove.test.ts
+++ b/packages/arcgis-rest-portal/test/items/remove.test.ts
@@ -17,8 +17,9 @@ import { TOMORROW } from "../../../../scripts/test-helpers.js";
 import { ArcGISIdentityManager, encodeParam } from "@esri/arcgis-rest-request";
 
 describe("search", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     // setup a ArcGISIdentityManager to use in all these tests
     const MOCK_USER_SESSION = new ArcGISIdentityManager({
@@ -45,7 +46,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/delete"
           );
@@ -66,7 +67,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/delete"
           );
@@ -91,7 +92,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/deleteRelationship"
           );
@@ -118,7 +119,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/removeResources"
           );
@@ -143,7 +144,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/removeResources"
           );
@@ -170,7 +171,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/removeResources"
           );
@@ -194,7 +195,7 @@ describe("search", () => {
         }
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/removeResources"
           );
@@ -220,7 +221,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/3ef/delete"
           );
@@ -241,7 +242,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/3ef/delete"
           );

--- a/packages/arcgis-rest-portal/test/items/search.test.ts
+++ b/packages/arcgis-rest-portal/test/items/search.test.ts
@@ -10,15 +10,16 @@ import { TOMORROW } from "../../../../scripts/test-helpers.js";
 import { SearchQueryBuilder } from "../../src/util/SearchQueryBuilder.js";
 
 describe("search", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should make a simple, single search request", (done) => {
     fetchMock.once("*", SearchResponse);
 
     searchItems("DC AND typekeywords:hubSiteApplication")
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication"
         );
@@ -41,7 +42,7 @@ describe("search", () => {
     searchItems(q)
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           `https://www.arcgis.com/sharing/rest/search?f=json&q=${encodeURIComponent(
             expectedParam
@@ -70,7 +71,7 @@ describe("search", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication&num=12&start=22&sortField=title&sortOrder=desc&searchUserAccess=groupMember&searchUserName=casey"
         );
@@ -95,7 +96,7 @@ describe("search", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/search?f=json&q=DC&sortOrder=desc&filter=title%3A%22Some%20Exact%20Title%22&countFields=tags%2C%20type&countSize=15"
         );
@@ -118,7 +119,7 @@ describe("search", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/search?f=json&q=DC&categories=%2FRegion%2FUS%2C%2FForest&categoryFilters=ocean"
         );
@@ -139,7 +140,7 @@ describe("search", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/search?f=json&q=Washington&categories=%2FCategories%2FWater%2C%2FCategories%2FForest"
         );
@@ -166,7 +167,7 @@ describe("search", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication&num=0&start=22&sortField=title&sortOrder=desc&searchUserAccess=groupMember&searchUserName=casey"
         );
@@ -191,7 +192,7 @@ describe("search", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/search");
         expect(options.body).toContain(
           "q=DC%20AND%20typekeywords%3AhubSiteApplication&num=12&start=22&sortField=title&sortOrder=desc"
@@ -223,7 +224,7 @@ describe("search", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/search");
         expect(options.body).toContain(encodeURIComponent(expectedParam));
         expect(options.method).toBe("POST");
@@ -249,7 +250,7 @@ describe("search", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/search?f=json&foo=bar&q=DC%20AND%20typekeywords%3AhubSiteApplication&num=12&start=22&sortField=title&sortOrder=desc"
         );
@@ -267,7 +268,7 @@ describe("search", () => {
     searchItems("DC AND typekeywords:hubSiteApplication")
       .then((r) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication"
         );
@@ -276,7 +277,7 @@ describe("search", () => {
 
           r.nextPage()
             .then(() => {
-              const [nextUrl]: [string, RequestInit] = fetchMock.lastCall("*");
+              const [nextUrl] = fetchMock.lastCall("*");
 
               expect(nextUrl).toEqual(
                 "https://www.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication&start=2"
@@ -302,7 +303,7 @@ describe("search", () => {
     searchItems({ q: "DC AND typekeywords:hubSiteApplication" })
       .then((r) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication"
         );
@@ -311,7 +312,7 @@ describe("search", () => {
 
           r.nextPage()
             .then(() => {
-              const [nextUrl]: [string, RequestInit] = fetchMock.lastCall("*");
+              const [nextUrl] = fetchMock.lastCall("*");
 
               expect(nextUrl).toEqual(
                 "https://www.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication&start=2"
@@ -354,7 +355,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication&token=fake-token"
           );

--- a/packages/arcgis-rest-portal/test/items/search.test.ts
+++ b/packages/arcgis-rest-portal/test/items/search.test.ts
@@ -272,7 +272,7 @@ describe("search", () => {
           "https://www.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication"
         );
         if (r.nextPage) {
-          fetchMock.once("*", BigSearchResponse);
+          fetchMock.once("*", BigSearchResponse, { overwriteRoutes: true });
 
           r.nextPage()
             .then(() => {
@@ -307,7 +307,7 @@ describe("search", () => {
           "https://www.arcgis.com/sharing/rest/search?f=json&q=DC%20AND%20typekeywords%3AhubSiteApplication"
         );
         if (r.nextPage) {
-          fetchMock.once("*", BigSearchResponse);
+          fetchMock.once("*", BigSearchResponse, { overwriteRoutes: true });
 
           r.nextPage()
             .then(() => {

--- a/packages/arcgis-rest-portal/test/items/update.test.ts
+++ b/packages/arcgis-rest-portal/test/items/update.test.ts
@@ -22,8 +22,9 @@ import { encodeParam, ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 import { FormData } from "@esri/arcgis-rest-form-data";
 
 describe("search", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     // setup a ArcGISIdentityManager to use in all these tests
     const MOCK_USER_SESSION = new ArcGISIdentityManager({
@@ -69,7 +70,7 @@ describe("search", () => {
       updateItem({ item: fakeItem, ...MOCK_USER_REQOPTS })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/5bc/update"
           );
@@ -122,7 +123,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/5bc/update"
           );
@@ -182,7 +183,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/aFolder/items/5bc/update"
           );
@@ -226,7 +227,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/updateinfo"
           );
@@ -256,7 +257,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/updateResources"
           );
@@ -291,7 +292,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/updateResources"
           );
@@ -321,7 +322,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/updateResources"
           );
@@ -354,7 +355,7 @@ describe("search", () => {
         }
       })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/updateResources"
           );
@@ -385,7 +386,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/updateResources"
           );
@@ -415,7 +416,7 @@ describe("search", () => {
         ...MOCK_USER_REQOPTS
       })
         .then(() => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/updateResources"
           );
@@ -447,7 +448,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/" +
               itemId +
@@ -474,7 +475,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/" +
               itemId +
@@ -503,7 +504,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/" +
               itemId +
@@ -532,7 +533,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/" +
               itemId +

--- a/packages/arcgis-rest-portal/test/items/upload.test.ts
+++ b/packages/arcgis-rest-portal/test/items/upload.test.ts
@@ -13,8 +13,9 @@ import { TOMORROW, attachmentFile } from "../../../../scripts/test-helpers.js";
 import { FormData } from "@esri/arcgis-rest-form-data";
 
 describe("search", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("Authenticated methods", () => {
     // setup a ArcGISIdentityManager to use in all these tests
     const MOCK_USER_SESSION = new ArcGISIdentityManager({
@@ -46,7 +47,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/commit"
           );
@@ -76,7 +77,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/fanny/items/3ef/commit"
           );
@@ -101,7 +102,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/cancel"
           );
@@ -127,7 +128,7 @@ describe("search", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/fanny/items/3ef/cancel"
           );
@@ -159,7 +160,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/addPart?partNum=1"
           );
@@ -197,7 +198,7 @@ describe("search", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/joe/items/3ef/addPart?partNum=1"
           );

--- a/packages/arcgis-rest-portal/test/orgs/notification.test.ts
+++ b/packages/arcgis-rest-portal/test/orgs/notification.test.ts
@@ -30,8 +30,9 @@ describe("create-org-notification", () => {
     portal: "https://myorg.maps.arcgis.com/sharing/rest"
   });
 
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should send multiple requests for a long user array", (done) => {
     const requests = [createUsernames(0, 25), createUsernames(25, 35)];
 

--- a/packages/arcgis-rest-portal/test/services/get-unique-service-name.test.ts
+++ b/packages/arcgis-rest-portal/test/services/get-unique-service-name.test.ts
@@ -8,8 +8,9 @@ import { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
 import { TOMORROW } from "../../../../scripts/test-helpers.js";
 
 describe("get-unique-service-name:", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   const MOCK_USER_SESSION = new ArcGISIdentityManager({
     clientId: "clientId",
     redirectUri: "https://example-app.com/redirect-uri",

--- a/packages/arcgis-rest-portal/test/services/is-service-name-available.test.ts
+++ b/packages/arcgis-rest-portal/test/services/is-service-name-available.test.ts
@@ -27,7 +27,7 @@ describe("is-service-name-available", () => {
       "Feature Service",
       MOCK_USER_SESSION
     ).then((result) => {
-      const [url]: [string, RequestInit] = fetchMock.lastCall("*");
+      const [url] = fetchMock.lastCall("*");
 
       expect(result.available).toBe(true, "should return the api response");
       expect(url).toContain(

--- a/packages/arcgis-rest-portal/test/sharing/access.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/access.test.ts
@@ -28,8 +28,9 @@ describe("setItemAccess()", () => {
       .catch();
   });
 
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should share an item with everyone", (done) => {
     fetchMock.once("*", SharingResponse, { overwriteRoutes: true });
 
@@ -39,7 +40,7 @@ describe("setItemAccess()", () => {
       access: "public"
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/jsmith/items/abc123/share"
         );
@@ -64,7 +65,7 @@ describe("setItemAccess()", () => {
       access: "org"
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/jsmith/items/abc123/share"
         );
@@ -89,7 +90,7 @@ describe("setItemAccess()", () => {
       access: "private"
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/jsmith/items/abc123/share"
         );
@@ -124,7 +125,7 @@ describe("setItemAccess()", () => {
       owner: "casey"
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall();
+        const [url, options] = fetchMock.lastCall();
         expect(url).toEqual(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/abc123/share"
         );

--- a/packages/arcgis-rest-portal/test/sharing/access.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/access.test.ts
@@ -31,7 +31,7 @@ describe("setItemAccess()", () => {
   afterEach(fetchMock.restore);
 
   it("should share an item with everyone", (done) => {
-    fetchMock.once("*", SharingResponse);
+    fetchMock.once("*", SharingResponse, { overwriteRoutes: true });
 
     setItemAccess({
       authentication: MOCK_USER_SESSION,

--- a/packages/arcgis-rest-portal/test/sharing/helpers.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/helpers.test.ts
@@ -10,7 +10,9 @@ import {
 } from "./share-item-with-group.test.js";
 
 describe("sharing helpers ::", () => {
-  afterEach(fetchMock.restore);
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("getUserMembership ::", () => {
     it("should return nonmember if group could not be fetched", (done) => {
       fetchMock.once(

--- a/packages/arcgis-rest-portal/test/sharing/share-item-with-group.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/share-item-with-group.test.ts
@@ -102,8 +102,9 @@ describe("shareItemWithGroup() ::", () => {
       .catch();
   });
 
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("share item as owner::", () => {
     it("should share an item with a group by owner", (done) => {
       // this is called when we try to determine if the item is already in the group
@@ -127,7 +128,7 @@ describe("shareItemWithGroup() ::", () => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          const [url, options] = fetchMock.lastCall(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/jsmith/items/n3v/share"
           );
           expect(url).toBe(
@@ -187,7 +188,7 @@ describe("shareItemWithGroup() ::", () => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          const [url, options] = fetchMock.lastCall(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(url).toBe(
@@ -245,7 +246,7 @@ describe("shareItemWithGroup() ::", () => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          const [url, options] = fetchMock.lastCall(
             "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
           );
           expect(url).toBe(
@@ -335,7 +336,7 @@ describe("shareItemWithGroup() ::", () => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          const [url, options] = fetchMock.lastCall(
             "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
           );
           expect(url).toBe(
@@ -464,12 +465,12 @@ describe("shareItemWithGroup() ::", () => {
             "All fetchMocks should have been called"
           );
           // verify we added casey to t6b
-          const addUsersOptions: RequestInit = fetchMock.lastOptions(
+          const addUsersOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/addUsers"
           );
           expect(addUsersOptions.body).toContain("admins=casey");
           // verify we shared the item
-          const shareOptions: RequestInit = fetchMock.lastOptions(
+          const shareOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
@@ -524,12 +525,12 @@ describe("shareItemWithGroup() ::", () => {
             "All fetchMocks should have been called"
           );
           // verify we added casey to t6b
-          const addUsersOptions: RequestInit = fetchMock.lastOptions(
+          const addUsersOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/addUsers"
           );
           expect(addUsersOptions.body).toContain("admins=casey");
           // verify we shared the item
-          const shareOptions: RequestInit = fetchMock.lastOptions(
+          const shareOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
@@ -591,12 +592,12 @@ describe("shareItemWithGroup() ::", () => {
             "All fetchMocks should have been called"
           );
           // verify we added casey to t6b
-          const addUsersOptions: RequestInit = fetchMock.lastOptions(
+          const addUsersOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/updateUsers"
           );
           expect(addUsersOptions.body).toContain("admins=casey");
           // verify we shared the item
-          const shareOptions: RequestInit = fetchMock.lastOptions(
+          const shareOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
@@ -654,7 +655,7 @@ describe("shareItemWithGroup() ::", () => {
             "All fetchMocks should have been called"
           );
           // verify we shared the item
-          const shareOptions: RequestInit = fetchMock.lastOptions(
+          const shareOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
@@ -715,7 +716,7 @@ describe("shareItemWithGroup() ::", () => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
-          const addUsersOptions: RequestInit = fetchMock.lastOptions(
+          const addUsersOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/updateUsers"
           );
           expect(addUsersOptions.body).toContain("admins=casey");
@@ -976,7 +977,7 @@ describe("shareItemWithGroup() ::", () => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
-          const addUsersOptions: RequestInit = fetchMock.lastOptions(
+          const addUsersOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/updateUsers"
           );
           expect(addUsersOptions.body).toContain("admins=casey");
@@ -1043,7 +1044,7 @@ describe("shareItemWithGroup() ::", () => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
-          const shareOptions: RequestInit = fetchMock.lastOptions(
+          const shareOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
@@ -1111,7 +1112,7 @@ describe("shareItemWithGroup() ::", () => {
           expect(fetchMock.done()).toBeTruthy(
             "All fetchMocks should have been called"
           );
-          const shareOptions: RequestInit = fetchMock.lastOptions(
+          const shareOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
@@ -1184,12 +1185,12 @@ describe("shareItemWithGroup() ::", () => {
             "All fetchMocks should have been called"
           );
           // verify we added casey to t6b
-          const addUsersOptions: RequestInit = fetchMock.lastOptions(
+          const addUsersOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/community/groups/t6b/updateUsers"
           );
           expect(addUsersOptions.body).toContain("admins=casey");
           // verify we shared the item
-          const shareOptions: RequestInit = fetchMock.lastOptions(
+          const shareOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
@@ -1318,7 +1319,7 @@ describe("shareItemWithGroup() ::", () => {
             "All fetchMocks should have been called"
           );
           // verify we shared the item
-          const shareOptions: RequestInit = fetchMock.lastOptions(
+          const shareOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");
@@ -1372,7 +1373,7 @@ describe("shareItemWithGroup() ::", () => {
             "All fetchMocks should have been called"
           );
           // verify we shared the item
-          const shareOptions: RequestInit = fetchMock.lastOptions(
+          const shareOptions = fetchMock.lastOptions(
             "https://myorg.maps.arcgis.com/sharing/rest/content/items/n3v/share"
           );
           expect(shareOptions.body).toContain("groups=t6b");

--- a/packages/arcgis-rest-portal/test/sharing/unshare-item-with-group.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/unshare-item-with-group.test.ts
@@ -58,8 +58,9 @@ describe("unshareItemWithGroup() ::", () => {
       .catch();
   });
 
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should unshare an item with a group by owner", (done) => {
     fetchMock.once(
       "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token",
@@ -87,7 +88,7 @@ describe("unshareItemWithGroup() ::", () => {
       groupId: "t6b"
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+        const [url, options] = fetchMock.lastCall(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/jsmith/items/a5b/unshare"
         );
         expect(url).toBe(
@@ -135,7 +136,7 @@ describe("unshareItemWithGroup() ::", () => {
       owner: "casey"
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+        const [url, options] = fetchMock.lastCall(
           "https://myorg.maps.arcgis.com/sharing/rest/content/items/a5b/unshare"
         );
         expect(url).toBe(
@@ -180,7 +181,7 @@ describe("unshareItemWithGroup() ::", () => {
       owner: "otherguy"
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+        const [url, options] = fetchMock.lastCall(
           "https://myorg.maps.arcgis.com/sharing/rest/content/items/a5b/unshare"
         );
         expect(url).toBe(

--- a/packages/arcgis-rest-portal/test/users/get-user-properties.test.ts
+++ b/packages/arcgis-rest-portal/test/users/get-user-properties.test.ts
@@ -13,8 +13,9 @@ const TOMORROW = (function () {
 })();
 
 describe("users", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   const session = new ArcGISIdentityManager({
     username: "c@sey",
     password: "123456",
@@ -33,7 +34,7 @@ describe("users", () => {
       getUserProperties(session.username, { authentication: session })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall();
+          const [url, options] = fetchMock.lastCall();
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/properties?f=json&token=fake-token"
           );
@@ -54,7 +55,7 @@ describe("users", () => {
       getUserProperties(session.username, { authentication: session })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall();
+          const [url, options] = fetchMock.lastCall();
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/properties?f=json&token=fake-token"
           );

--- a/packages/arcgis-rest-portal/test/users/get-user-tags.test.ts
+++ b/packages/arcgis-rest-portal/test/users/get-user-tags.test.ts
@@ -14,8 +14,9 @@ const TOMORROW = (function () {
 })();
 
 describe("users", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("getUserTags", () => {
     const session = new ArcGISIdentityManager({
       username: "c@sey",
@@ -31,7 +32,7 @@ describe("users", () => {
       getUserTags({ authentication: session })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/tags"
           );
@@ -54,7 +55,7 @@ describe("users", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith/tags"
           );

--- a/packages/arcgis-rest-portal/test/users/get-user.test.ts
+++ b/packages/arcgis-rest-portal/test/users/get-user.test.ts
@@ -19,8 +19,9 @@ const TOMORROW = (function () {
 })();
 
 describe("users", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("getUser", () => {
     const session = new ArcGISIdentityManager({
       username: "c@sey",
@@ -36,7 +37,7 @@ describe("users", () => {
       getUser("jsmith")
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/community/users/jsmith?f=json"
           );
@@ -54,7 +55,7 @@ describe("users", () => {
       getUser({ authentication: session })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey?f=json&token=fake-token"
           );
@@ -75,7 +76,7 @@ describe("users", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith?f=json&token=fake-token"
           );

--- a/packages/arcgis-rest-portal/test/users/invitation.test.ts
+++ b/packages/arcgis-rest-portal/test/users/invitation.test.ts
@@ -23,8 +23,9 @@ const TOMORROW = (function () {
 })();
 
 describe("invitations", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   const session = new ArcGISIdentityManager({
     username: "c@sey",
     password: "123456",
@@ -40,7 +41,7 @@ describe("invitations", () => {
       getUserInvitations({ authentication: session })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/invitations?f=json&token=fake-token"
           );
@@ -61,7 +62,7 @@ describe("invitations", () => {
       getUserInvitation({ invitationId: "3ef", authentication: session })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/invitations/3ef?f=json&token=fake-token"
           );
@@ -83,7 +84,7 @@ describe("invitations", () => {
       acceptInvitation({ invitationId: "3ef", authentication: session })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/invitations/3ef/accept"
           );
@@ -107,7 +108,7 @@ describe("invitations", () => {
       declineInvitation({ invitationId: "3ef", authentication: session })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/invitations/3ef/decline"
           );

--- a/packages/arcgis-rest-portal/test/users/notification.test.ts
+++ b/packages/arcgis-rest-portal/test/users/notification.test.ts
@@ -21,8 +21,9 @@ const TOMORROW = (function () {
 })();
 
 describe("users", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("getUserNotifications", () => {
     const session = new ArcGISIdentityManager({
       username: "c@sey",
@@ -38,7 +39,7 @@ describe("users", () => {
       getUserNotifications({ authentication: session })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/notifications?f=json&token=fake-token"
           );
@@ -57,7 +58,7 @@ describe("users", () => {
       removeNotification({ id: "3ef", ...{ authentication: session } })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/notifications/3ef/delete"
           );

--- a/packages/arcgis-rest-portal/test/users/search.test.ts
+++ b/packages/arcgis-rest-portal/test/users/search.test.ts
@@ -6,8 +6,9 @@ import { searchUsers } from "../../src/users/search-users.js";
 import { UserSearchResponse } from "../mocks/users/user-search.js";
 
 describe("users", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("searchUsers", () => {
     const MOCK_AUTH = {
       getToken() {
@@ -26,7 +27,7 @@ describe("users", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/portals/self/users/search?f=json&q=role%3Aorg_user%20OR%20role%3Aorg_publisher&num=100&token=fake-token"
           );

--- a/packages/arcgis-rest-portal/test/users/set-user-properties.test.ts
+++ b/packages/arcgis-rest-portal/test/users/set-user-properties.test.ts
@@ -17,8 +17,9 @@ const TOMORROW = (function () {
 })();
 
 describe("users", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   const session = new ArcGISIdentityManager({
     username: "c@sey",
     password: "123456",
@@ -45,7 +46,7 @@ describe("users", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall();
+          const [url, options] = fetchMock.lastCall();
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/setProperties"
           );
@@ -77,7 +78,7 @@ describe("users", () => {
         })
         .catch(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall();
+          const [url, options] = fetchMock.lastCall();
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/setProperties"
           );

--- a/packages/arcgis-rest-portal/test/users/update.test.ts
+++ b/packages/arcgis-rest-portal/test/users/update.test.ts
@@ -12,8 +12,9 @@ const TOMORROW = (function () {
 })();
 
 describe("updateUser", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   const session = new ArcGISIdentityManager({
     username: "c@sey",
     password: "123456",
@@ -34,7 +35,7 @@ describe("updateUser", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/update"
         );
@@ -64,7 +65,7 @@ describe("updateUser", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/c%40sey/update"
         );
@@ -94,7 +95,7 @@ describe("updateUser", () => {
     })
       .then(() => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/jsmith/update"
         );
@@ -131,7 +132,7 @@ describe("updateUser", () => {
       })
       .catch((e) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://myorg.maps.arcgis.com/sharing/rest/community/users/fake/update"
         );

--- a/packages/arcgis-rest-portal/test/util/get-portal-settings.test.ts
+++ b/packages/arcgis-rest-portal/test/util/get-portal-settings.test.ts
@@ -7,8 +7,9 @@ import { getPortalSettings } from "../../src/util/get-portal-settings.js";
 import { PortalResponse } from "./../mocks/portal/response.js";
 
 describe("portal", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("getPortalSettings", () => {
     // setup an authmgr to use in all these tests
     const MOCK_AUTH = {
@@ -26,7 +27,7 @@ describe("portal", () => {
       getPortalSettings("5BZFaKe", MOCK_REQOPTS)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/portals/5BZFaKe/settings?f=json&token=fake-token"
           );
@@ -42,7 +43,7 @@ describe("portal", () => {
       getPortalSettings(null, MOCK_REQOPTS)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/portals/self/settings?f=json&token=fake-token"
           );

--- a/packages/arcgis-rest-portal/test/util/portal.test.ts
+++ b/packages/arcgis-rest-portal/test/util/portal.test.ts
@@ -11,8 +11,9 @@ import {
 } from "./../mocks/portal/response.js";
 
 describe("portal", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe("getPortal", () => {
     // setup an authmgr to use in all these tests
     const MOCK_AUTH = {
@@ -30,7 +31,7 @@ describe("portal", () => {
       getPortal("5BZFaKe", MOCK_REQOPTS)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/portals/5BZFaKe?f=json&token=fake-token"
           );
@@ -46,7 +47,7 @@ describe("portal", () => {
       getPortal(null, MOCK_REQOPTS)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/portals/self?f=json&token=fake-token"
           );
@@ -75,7 +76,7 @@ describe("portal", () => {
       getSelf(MOCK_REQOPTS)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/portals/self?f=json&token=fake-token"
           );
@@ -105,7 +106,7 @@ describe("portal", () => {
       getSubscriptionInfo("5BZFaKe", MOCK_REQOPTS)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/portals/5BZFaKe/subscriptionInfo?f=json&token=fake-token"
           );
@@ -122,7 +123,7 @@ describe("portal", () => {
       getSubscriptionInfo(null, MOCK_REQOPTS)
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/portals/self/subscriptionInfo?f=json&token=fake-token"
           );

--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -36,7 +36,7 @@ export interface IRequestOptions {
   /**
    * The implementation of `fetch` to use. Defaults to a global `fetch`.
    */
-  // fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  // fetch?: (input: RequestInfo, init?) => Promise<Response>;
   /**
    * A string indicating whether credentials (cookies) will be sent with the request. Used internally for authentication workflows.
    */

--- a/packages/arcgis-rest-request/test/ApiKey.test.ts
+++ b/packages/arcgis-rest-request/test/ApiKey.test.ts
@@ -5,8 +5,9 @@ import { ApiKeyManager } from "../src/index.js";
 import fetchMock from "fetch-mock";
 
 describe("ApiKeyManager", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe(".getToken()", () => {
     it("should return the Api Key", (done) => {
       const session = new ApiKeyManager({

--- a/packages/arcgis-rest-request/test/ApplicationCredentialsManager.test.ts
+++ b/packages/arcgis-rest-request/test/ApplicationCredentialsManager.test.ts
@@ -7,8 +7,9 @@ import { YESTERDAY, TOMORROW } from "../../../scripts/test-helpers.js";
 import { ArcGISTokenRequestError } from "../src/utils/ArcGISTokenRequestError.js";
 
 describe("ApplicationCredentialsManager", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe(".fromCredentials", () => {
     it("should construct a new ApplicationCredentialsManager", (done) => {
       fetchMock.post("https://www.arcgis.com/sharing/rest/oauth2/token/", {

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -3322,7 +3322,7 @@ describe("ArcGISIdentityManager", () => {
       });
     });
 
-    it("should initialize a session from a username and password and pass a referer", (done) => {
+    it("should initialize a session from a username and password and pass a referer", () => {
       // we intentionally only mock one response
       fetchMock.once(
         "https://www.arcgis.com/sharing/rest/community/self?f=json&token=token",
@@ -3355,8 +3355,6 @@ describe("ArcGISIdentityManager", () => {
         if (isBrowser) {
           expect(options.body).toContain(`referer=testreferer`);
         }
-
-        done();
       });
     });
   });

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -26,8 +26,9 @@ import {
 } from "../../../scripts/test-helpers.js";
 
 describe("ArcGISIdentityManager", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   describe(".serialize() and ArcGISIdentityManager.deserialize", () => {
     it("should serialize to and from JSON", () => {
       const session = new ArcGISIdentityManager({
@@ -2116,8 +2117,7 @@ describe("ArcGISIdentityManager", () => {
       return session
         .validateAppAccess("abc123")
         .then((response) => {
-          const [url, options]: [string, RequestInit] =
-            fetchMock.lastCall(VERIFYAPPACCESS_URL);
+          const [url, options] = fetchMock.lastCall(VERIFYAPPACCESS_URL);
           expect(url).toEqual(VERIFYAPPACCESS_URL);
           expect(options.body).toContain("f=json");
           expect(options.body).toContain("token=FAKE-TOKEN");
@@ -2317,8 +2317,9 @@ describe("ArcGISIdentityManager", () => {
   });
 
   describe(".getUser()", () => {
-    afterEach(fetchMock.restore);
-
+    afterEach(() => {
+      fetchMock.restore();
+    });
     it("should cache metadata about the user", (done) => {
       // we intentionally only mock one response
       fetchMock.once(
@@ -2393,8 +2394,9 @@ describe("ArcGISIdentityManager", () => {
   });
 
   describe(".getUsername()", () => {
-    afterEach(fetchMock.restore);
-
+    afterEach(() => {
+      fetchMock.restore();
+    });
     it("should fetch the username via getUser()", (done) => {
       // we intentionally only mock one response
       fetchMock.once(
@@ -2691,7 +2693,7 @@ describe("ArcGISIdentityManager", () => {
       )
         .then((token) => {
           expect(token).toBe("fresh-token");
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          const [url, options] = fetchMock.lastCall(
             "https://fakeserver.com/arcgis/tokens/generateToken"
           );
           expect(url).toBe(
@@ -2750,7 +2752,7 @@ describe("ArcGISIdentityManager", () => {
       )
         .then((token) => {
           expect(token).toBe("fresh-token");
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+          const [url, options] = fetchMock.lastCall(
             "https://fakeserver.com/arcgis/tokens/generateToken"
           );
           expect(url).toBe(
@@ -2885,8 +2887,9 @@ describe("ArcGISIdentityManager", () => {
   });
 
   describe(".getPortal()", () => {
-    afterEach(fetchMock.restore);
-
+    afterEach(() => {
+      fetchMock.restore();
+    });
     it("should cache metadata about the portal", (done) => {
       // we intentionally only mock one response
       fetchMock.once(
@@ -3016,7 +3019,7 @@ describe("ArcGISIdentityManager", () => {
         .then((response) => {
           const { credentials } = fetchMock.lastOptions(
             "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query"
-          );
+          ) as RequestInit;
           expect(credentials).toEqual("same-origin");
 
           done();
@@ -3081,7 +3084,7 @@ describe("ArcGISIdentityManager", () => {
         .then((response) => {
           const { credentials } = fetchMock.lastOptions(
             "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query"
-          );
+          ) as RequestInit;
           expect(credentials).toEqual("include");
 
           done();
@@ -3147,7 +3150,7 @@ describe("ArcGISIdentityManager", () => {
       .then((response) => {
         const { credentials } = fetchMock.lastOptions(
           "https://gisservices.city.gov/public/rest/services/trees/FeatureServer/0/query"
-        );
+        ) as RequestInit;
         expect(credentials).toEqual("same-origin");
 
         done();
@@ -3219,7 +3222,7 @@ describe("ArcGISIdentityManager", () => {
         refreshTokenExpires: TOMORROW
       });
       return ArcGISIdentityManager.destroy(session).then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(response).toEqual({ success: true });
         expect(url).toBe(
           "https://www.arcgis.com/sharing/rest/oauth2/revokeToken/"
@@ -3237,7 +3240,7 @@ describe("ArcGISIdentityManager", () => {
         token: "token"
       });
       return ArcGISIdentityManager.destroy(session).then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(response).toEqual({ success: true });
         expect(url).toBe(
           "https://www.arcgis.com/sharing/rest/oauth2/revokeToken/"
@@ -3256,7 +3259,7 @@ describe("ArcGISIdentityManager", () => {
       });
 
       return session.signOut().then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(response).toEqual({ success: true });
         expect(url).toBe(
           "https://www.arcgis.com/sharing/rest/oauth2/revokeToken/"
@@ -3268,8 +3271,9 @@ describe("ArcGISIdentityManager", () => {
   });
 
   describe(".fromToken", () => {
-    afterEach(fetchMock.restore);
-
+    afterEach(() => {
+      fetchMock.restore();
+    });
     it("should initialize a session from a token", () => {
       // we intentionally only mock one response
       fetchMock.once(
@@ -3293,8 +3297,9 @@ describe("ArcGISIdentityManager", () => {
   });
 
   describe(".signIn", () => {
-    afterEach(fetchMock.restore);
-
+    afterEach(() => {
+      fetchMock.restore();
+    });
     it("should initialize a session from a username and password", () => {
       // we intentionally only mock one response
       fetchMock.once(
@@ -3344,7 +3349,7 @@ describe("ArcGISIdentityManager", () => {
         password: "123456",
         referer: "testreferer"
       }).then(() => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall(
+        const [url, options] = fetchMock.lastCall(
           "https://www.arcgis.com/sharing/rest/generateToken"
         );
 

--- a/packages/arcgis-rest-request/test/app-tokens.test.ts
+++ b/packages/arcgis-rest-request/test/app-tokens.test.ts
@@ -14,8 +14,7 @@ describe("app-token functions: ", () => {
       });
       return exchangeToken("FAKE-TOKEN", "CLIENT-ID-ABC123")
         .then((response) => {
-          const [url, options]: [string, RequestInit] =
-            fetchMock.lastCall(EXCHANGE_TOKEN_URL);
+          const [url, options] = fetchMock.lastCall(EXCHANGE_TOKEN_URL);
           expect(url).toEqual(EXCHANGE_TOKEN_URL);
           expect(options.body).toContain("f=json");
           expect(options.body).toContain("token=FAKE-TOKEN");
@@ -33,8 +32,7 @@ describe("app-token functions: ", () => {
       });
       return exchangeToken("FAKE-TOKEN", "CLIENT-ID-ABC123", PORTAL_BASE_URL)
         .then((response) => {
-          const [url, options]: [string, RequestInit] =
-            fetchMock.lastCall(PORTAL_EXCHANGE_URL);
+          const [url, options] = fetchMock.lastCall(PORTAL_EXCHANGE_URL);
           expect(url).toEqual(PORTAL_EXCHANGE_URL);
         })
         .catch((e) => fail(e));
@@ -54,8 +52,7 @@ describe("app-token functions: ", () => {
         "https://hub.arcgis.com/torii-provider-arcgis/redirect.html"
       )
         .then((response) => {
-          const [url, options]: [string, RequestInit] =
-            fetchMock.lastCall(PLATFORM_SELF_URL);
+          const [url, options] = fetchMock.lastCall(PLATFORM_SELF_URL);
           expect(url).toEqual(PLATFORM_SELF_URL);
           const headers = options.headers || ({} as any);
           expect(headers["X-Esri-Auth-Redirect-Uri"]).toBe(
@@ -80,9 +77,7 @@ describe("app-token functions: ", () => {
       });
       return platformSelf("FAKE-TOKEN", "CLIENT-ID-ABC123", PORTAL_BASE_URL)
         .then((response) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall(
-            PORTAL_PLATFORM_SELF_URL
-          );
+          const [url, options] = fetchMock.lastCall(PORTAL_PLATFORM_SELF_URL);
           expect(url).toEqual(PORTAL_PLATFORM_SELF_URL);
         })
         .catch((e) => fail(e));

--- a/packages/arcgis-rest-request/test/fetchToken.test.ts
+++ b/packages/arcgis-rest-request/test/fetchToken.test.ts
@@ -7,8 +7,9 @@ import { fetchToken } from "../src/index.js";
 const TOKEN_URL = "https://www.arcgis.com/sharing/rest/oauth2/token";
 
 describe("fetchToken()", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should request a token with `client_credentials`, `client_id` and `client_secret`", (done) => {
     fetchMock.postOnce(TOKEN_URL, {
       access_token: "token",
@@ -24,8 +25,7 @@ describe("fetchToken()", () => {
       }
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] =
-          fetchMock.lastCall(TOKEN_URL);
+        const [url, options] = fetchMock.lastCall(TOKEN_URL);
         expect(url).toEqual(TOKEN_URL);
         expect(options.body).toContain("f=json");
         expect(options.body).toContain("client_id=clientId");
@@ -59,8 +59,7 @@ describe("fetchToken()", () => {
       }
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] =
-          fetchMock.lastCall(TOKEN_URL);
+        const [url, options] = fetchMock.lastCall(TOKEN_URL);
         expect(url).toEqual(TOKEN_URL);
         expect(options.body).toContain("f=json");
         expect(options.body).toContain("client_id=clientId");

--- a/packages/arcgis-rest-request/test/job.test.ts
+++ b/packages/arcgis-rest-request/test/job.test.ts
@@ -1,4 +1,4 @@
-import fetchMock, { done } from "fetch-mock";
+import fetchMock from "fetch-mock";
 import { Job, JOB_STATUSES, ArcGISRequestError } from "../src/index.js";
 import { processJobParams } from "../src/utils/process-job-params.js";
 import {
@@ -13,13 +13,12 @@ import {
 } from "./mocks/job-mock-fetches.js";
 
 describe("Job", () => {
-  afterEach(() => {
+  beforeEach(() => {
     fetchMock.restore();
   });
 
   it("should return a jobId", () => {
     fetchMock.mock("*", GPJobIdResponse);
-    fetchMock.once("*", GPEndpointCall);
     return Job.submitJob(GPEndpointCall).then((job) => {
       expect(job.id).toEqual(GPJobIdResponse.jobId);
     });
@@ -52,7 +51,8 @@ describe("Job", () => {
           {
             jobStatus: "esriJobSucceeded",
             jobId: "j4fa1db2338f042a19eb68856afabc27e"
-          }
+          },
+          { overwriteRoutes: true }
         );
 
         // 9. fake another polling request
@@ -276,7 +276,8 @@ describe("Job", () => {
 
         fetchMock.once(
           "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/jobs/j4fa1db2338f042a19eb68856afabc27e",
-          { jobStatus: "esriJobWaiting" }
+          { jobStatus: "esriJobWaiting" },
+          { overwriteRoutes: true }
         );
 
         (job as any).executePoll();
@@ -287,7 +288,8 @@ describe("Job", () => {
 
         fetchMock.once(
           "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/jobs/j4fa1db2338f042a19eb68856afabc27e",
-          { jobStatus: "esriJobSubmitted" }
+          { jobStatus: "esriJobSubmitted" },
+          { overwriteRoutes: true }
         );
 
         (job as any).executePoll();
@@ -298,7 +300,8 @@ describe("Job", () => {
 
         fetchMock.once(
           "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/jobs/j4fa1db2338f042a19eb68856afabc27e",
-          { jobStatus: "esriJobTimedOut" }
+          { jobStatus: "esriJobTimedOut" },
+          { overwriteRoutes: true }
         );
 
         (job as any).executePoll();
@@ -308,7 +311,8 @@ describe("Job", () => {
 
         fetchMock.once(
           "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/jobs/j4fa1db2338f042a19eb68856afabc27e",
-          { jobStatus: "expectedFailure" }
+          { jobStatus: "expectedFailure" },
+          { overwriteRoutes: true }
         );
 
         (job as any).executePoll();
@@ -319,7 +323,8 @@ describe("Job", () => {
 
         fetchMock.once(
           "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/jobs/j4fa1db2338f042a19eb68856afabc27e",
-          { jobStatus: "esriJobFailed" }
+          { jobStatus: "esriJobFailed" },
+          { overwriteRoutes: true }
         );
 
         (job as any).executePoll();
@@ -395,7 +400,8 @@ describe("Job", () => {
 
         fetchMock.once(
           "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/jobs/j4fa1db2338f042a19eb68856afabc27e",
-          { jobStatus: "esriJobCancelling" }
+          { jobStatus: "esriJobCancelling" },
+          { overwriteRoutes: true }
         );
 
         (job as any).executePoll();
@@ -406,7 +412,8 @@ describe("Job", () => {
 
         fetchMock.once(
           "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/jobs/j4fa1db2338f042a19eb68856afabc27e",
-          { jobStatus: "esriJobCancelled" }
+          { jobStatus: "esriJobCancelled" },
+          { overwriteRoutes: true }
         );
 
         (job as any).executePoll();
@@ -680,7 +687,6 @@ describe("Job", () => {
     Job.submitJob(GPEndpointCall).then((job) => {
       expect(job.isMonitoring).toEqual(true);
       done();
-
     });
   });
 
@@ -688,46 +694,54 @@ describe("Job", () => {
     processJobParams({
       url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot/submitJob",
       params: {
-        summarizeType: "['CentralFeature', 'MeanCenter', 'MedianCenter', 'Ellipse']",
-        weightField: 'NUM_TREES',
-        ellipseSize: '1 standard deviation',
+        summarizeType:
+          "['CentralFeature', 'MeanCenter', 'MedianCenter', 'Ellipse']",
+        weightField: "NUM_TREES",
+        ellipseSize: "1 standard deviation",
         context: {
           extent: {
             xmin: -15034729.266472297,
             ymin: 5716733.479048933,
             xmax: -12070195.56146081,
             ymax: 7808050.572930799,
-            spatialReference: { wkid: 102100, latestWkid: 3857 },
-          },
-        },
+            spatialReference: { wkid: 102100, latestWkid: 3857 }
+          }
+        }
       }
     });
 
-    expect(processJobParams({
-      summarizeType: ['CentralFeature', 'MeanCenter', 'MedianCenter', 'Ellipse'],
-      weightField: 'NUM_TREES',
-      ellipseSize: '1 standard deviation',
+    expect(
+      processJobParams({
+        summarizeType: [
+          "CentralFeature",
+          "MeanCenter",
+          "MedianCenter",
+          "Ellipse"
+        ],
+        weightField: "NUM_TREES",
+        ellipseSize: "1 standard deviation",
+        context: {
+          extent: {
+            xmin: -15034729.266472297,
+            ymin: 5716733.479048933,
+            xmax: -12070195.56146081,
+            ymax: 7808050.572930799,
+            spatialReference: { wkid: 102100, latestWkid: 3857 }
+          }
+        }
+      })
+    ).toEqual({
+      summarizeType: '["CentralFeature","MeanCenter","MedianCenter","Ellipse"]',
+      weightField: "NUM_TREES",
+      ellipseSize: "1 standard deviation",
       context: {
         extent: {
           xmin: -15034729.266472297,
           ymin: 5716733.479048933,
           xmax: -12070195.56146081,
           ymax: 7808050.572930799,
-          spatialReference: { wkid: 102100, latestWkid: 3857 },
-        },
-      }
-    })).toEqual({
-      summarizeType:'["CentralFeature","MeanCenter","MedianCenter","Ellipse"]',
-      weightField: 'NUM_TREES',
-      ellipseSize: '1 standard deviation',
-      context: {
-        extent: {
-          xmin: -15034729.266472297,
-          ymin: 5716733.479048933,
-          xmax: -12070195.56146081,
-          ymax: 7808050.572930799,
-          spatialReference: { wkid: 102100, latestWkid: 3857 },
-        },
+          spatialReference: { wkid: 102100, latestWkid: 3857 }
+        }
       }
     });
   });

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -34,7 +34,7 @@ describe("request()", () => {
 
     request("https://www.arcgis.com/sharing/rest/info")
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/info");
         expect(options.method).toBe("POST");
         expect(response).toEqual(SharingRestInfo);
@@ -53,7 +53,7 @@ describe("request()", () => {
       httpMethod: "GET"
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/info?f=json");
         expect(options.method).toBe("GET");
         expect(response).toEqual(SharingRestInfo);
@@ -75,7 +75,7 @@ describe("request()", () => {
       }
     )
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/43a8e51789044d9480a20089a84129ad/data?f=text"
         );
@@ -96,7 +96,7 @@ describe("request()", () => {
       params: { f: "html" }
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/info?f=html");
         expect(options.method).toBe("GET");
         expect(response).toEqual(SharingRestInfoHTML);
@@ -118,7 +118,7 @@ describe("request()", () => {
       }
     )
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer/0/query?f=geojson&where=1%3D1"
         );
@@ -143,7 +143,7 @@ describe("request()", () => {
       maxUrlLength: restInfoUrl.length
     })
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/info");
         expect(options.method).toBe("POST");
         expect(options.body).toContain("f=json");
@@ -172,7 +172,7 @@ describe("request()", () => {
       }
     )
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://www.arcgis.com/sharing/rest/content/items/43a8e51789044d9480a20089a84129ad/data"
         );
@@ -253,8 +253,7 @@ describe("request()", () => {
     } as IRequestOptions;
 
     return request(PLATFORM_SELF_URL, ro).then((response) => {
-      const [url, options]: [string, RequestInit] =
-        fetchMock.lastCall(PLATFORM_SELF_URL);
+      const [url, options] = fetchMock.lastCall(PLATFORM_SELF_URL);
       expect(url).toEqual(PLATFORM_SELF_URL);
       const headers = options.headers || ({} as any);
       expect(headers["X-Esri-Auth-Redirect-Uri"]).toBe(
@@ -382,7 +381,7 @@ describe("request()", () => {
 
     request("https://www.arcgis.com/sharing/rest/info")
       .then((response) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/info");
         expect(options.method).toBe("POST");
         expect(response).toEqual(SharingRestInfo);
@@ -455,7 +454,7 @@ describe("request()", () => {
         }
       )
         .then((response) => {
-          const options: RequestInit = fetchMock.lastCall("*")[1];
+          const options = fetchMock.lastCall("*")[1];
           expect(options.body).toContain(`where=${encodeURIComponent("1=1")}`);
           expect(response).toEqual(GeoJSONFeatureCollection);
           done();
@@ -473,7 +472,7 @@ describe("request()", () => {
       request("https://www.arcgis.com/sharing/rest/content/items/43a/data")
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/content/items/43a/data"
           );
@@ -497,7 +496,7 @@ describe("request()", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/content/items/43a/data"
           );
@@ -521,7 +520,7 @@ describe("request()", () => {
       })
         .then(() => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://www.arcgis.com/sharing/rest/content/items/43a/data"
           );
@@ -554,7 +553,7 @@ describe("request()", () => {
       authentication: "token"
     })
       .then(() => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/portals/self");
         expect(console.warn).toHaveBeenCalledTimes(1);
         expect(options.body).toContain("f=json");

--- a/packages/arcgis-rest-request/test/revoke-token.test.ts
+++ b/packages/arcgis-rest-request/test/revoke-token.test.ts
@@ -12,7 +12,7 @@ describe("revokeToken", () => {
       clientId: "clientId",
       token: "token"
     }).then((response) => {
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+      const [url, options] = fetchMock.lastCall("*");
 
       expect(response).toEqual({ success: true });
       expect(url).toBe(
@@ -31,7 +31,7 @@ describe("revokeToken", () => {
       token: "token",
       portal: "https://myportal.com/sharing/rest/"
     }).then((response) => {
-      const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+      const [url, options] = fetchMock.lastCall("*");
 
       expect(response).toEqual({ success: true });
       expect(url).toBe("https://myportal.com/sharing/rest/oauth2/revokeToken/");

--- a/packages/arcgis-rest-request/test/utils/ArcGISAuthError.test.ts
+++ b/packages/arcgis-rest-request/test/utils/ArcGISAuthError.test.ts
@@ -87,7 +87,7 @@ describe("ArcGISRequestError", () => {
       error
         .retry(MockAuth.retryHandler, 3)
         .then((response: any) => {
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "http://www.arcgis.com/sharing/rest/content/users/caseyjones/addItem"
           );
@@ -128,7 +128,7 @@ describe("ArcGISRequestError", () => {
       const retryHandlerSpy = spyOn(MockAuth, "retryHandler").and.callThrough();
 
       error.retry(MockAuth.retryHandler, 3).catch((e: any) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "http://www.arcgis.com/sharing/rest/content/users/caseyjones/addItem"
         );
@@ -165,7 +165,7 @@ describe("ArcGISRequestError", () => {
       const retryHandlerSpy = spyOn(MockAuth, "retryHandler").and.callThrough();
 
       error.retry(MockAuth.retryHandler).catch((e: any) => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(requestUrl);
         expect(options.method).toEqual("POST");
         expect(retryHandlerSpy).toHaveBeenCalledTimes(1);

--- a/packages/arcgis-rest-request/test/utils/with-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/with-options.test.ts
@@ -33,7 +33,7 @@ describe("withOptions()", () => {
 
     requestWithOptions("https://www.arcgis.com/sharing/rest/info")
       .then(() => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/info");
         expect((options.headers as any)["Test-Header"]).toBe("Test");
         done();
@@ -78,7 +78,7 @@ describe("withOptions()", () => {
       id: "foo"
     })
       .then(() => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/info");
         expect(options.body).toContain("id=foo");
         expect((options.headers as any)["Test-Header"]).toBe("Test");
@@ -122,7 +122,7 @@ describe("withOptions()", () => {
 
     requestWithOptions("foo")
       .then(() => {
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://www.arcgis.com/sharing/rest/info");
         expect(options.body).toContain("id=foo");
         expect((options.headers as any)["Test-Header"]).toBe("Test");

--- a/packages/arcgis-rest-request/test/validate-app-access.test.ts
+++ b/packages/arcgis-rest-request/test/validate-app-access.test.ts
@@ -15,8 +15,7 @@ describe("validateAppAccess: ", () => {
     });
     return validateAppAccess("FAKE-TOKEN", "abc123")
       .then((response) => {
-        const [url, options]: [string, RequestInit] =
-          fetchMock.lastCall(VERIFYAPPACCESS_URL);
+        const [url, options] = fetchMock.lastCall(VERIFYAPPACCESS_URL);
         expect(url).toEqual(VERIFYAPPACCESS_URL);
         expect(options.body).toContain("f=json");
         expect(options.body).toContain("token=FAKE-TOKEN");
@@ -35,8 +34,7 @@ describe("validateAppAccess: ", () => {
     });
     return validateAppAccess("FAKE-TOKEN", "abc123", PORTAL_BASE_URL)
       .then((response) => {
-        const [url, options]: [string, RequestInit] =
-          fetchMock.lastCall(PORTAL_VERIFY_URL);
+        const [url, options] = fetchMock.lastCall(PORTAL_VERIFY_URL);
         expect(url).toEqual(PORTAL_VERIFY_URL);
       })
       .catch((e) => fail(e));

--- a/packages/arcgis-rest-routing/test/closestFacility.test.ts
+++ b/packages/arcgis-rest-routing/test/closestFacility.test.ts
@@ -169,8 +169,9 @@ const facilitiesUrl = {
 //   "https://foo.com/ArcGIS/rest/services/Network/USA/NAServer/";
 
 describe("closestFacility", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should throw an error when a closestFacility request is made without a token", (done) => {
     fetchMock.once("*", ClosestFacility);
 
@@ -206,7 +207,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/ClosestFacility/NAServer/ClosestFacility_World/solveClosestFacility"
         );
@@ -254,7 +255,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain("returnDirections=true");
         expect(options.body).toContain("returnFacilities=true");
         expect(options.body).toContain("returnIncidents=true");
@@ -295,7 +296,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain("returnDirections=false");
         expect(options.body).toContain("returnFacilities=false");
         expect(options.body).toContain("returnIncidents=false");
@@ -328,7 +329,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `incidents=${encodeURIComponent("-118.257363,34.076763")}`
         );
@@ -362,7 +363,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `incidents=${encodeURIComponent("-118.257363,34.076763")}`
         );
@@ -396,7 +397,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `incidents=${encodeURIComponent("-118.257363,34.076763")}`
         );
@@ -430,7 +431,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `incidents=${encodeURIComponent(JSON.stringify(incidentsFeatureSet))}`
         );
@@ -464,7 +465,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `incidents=${encodeURIComponent(JSON.stringify(incidentsUrl))}`
         );
@@ -497,7 +498,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `travelDirection=esriNATravelDirectionToFacility`
         );
@@ -527,7 +528,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `travelDirection=esriNATravelDirectionFromFacility`
         );
@@ -557,7 +558,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `barriers=${encodeURIComponent("-117.1957,34.0564;-117.184,34.0546")}`
         );
@@ -587,7 +588,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `barriers=${encodeURIComponent(JSON.stringify(barriersFeatureSet))}`
         );
@@ -617,7 +618,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `polylineBarriers=${encodeURIComponent(
             JSON.stringify(polylineBarriers)
@@ -649,7 +650,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `polygonBarriers=${encodeURIComponent(
             JSON.stringify(polygonBarriers)
@@ -680,7 +681,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(Object.keys(response.routes)).toContain("geoJson");
         expect(Object.keys(response.routes.geoJson)).toContain("type");
         expect(response.routes.geoJson.type).toEqual("FeatureCollection");
@@ -715,7 +716,7 @@ describe("closestFacility", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(Object.keys(response.routes)).not.toContain("geoJson");
         done();
       })

--- a/packages/arcgis-rest-routing/test/originDestinationMatrix.test.ts
+++ b/packages/arcgis-rest-routing/test/originDestinationMatrix.test.ts
@@ -153,8 +153,9 @@ const destinationsFeatureSet: IFeatureSet = {
 };
 
 describe("originDestinationMatrix", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should throw an error when a originDestinationMatrix request is made without a token", (done) => {
     fetchMock.once("*", {});
 
@@ -188,7 +189,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/OriginDestinationCostMatrix/NAServer/OriginDestinationCostMatrix_World/solveODCostMatrix"
         );
@@ -239,7 +240,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain("outputType=esriNAODOutputSparseMatrix");
         expect(options.body).toContain("returnOrigins=true");
         expect(options.body).toContain("returnDestinations=true");
@@ -276,7 +277,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           "outputType=esriNAODOutputStraightLines"
         );
@@ -313,7 +314,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual("https://esri.com/test/solveODCostMatrix");
         done();
       })
@@ -339,7 +340,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `origins=${encodeURIComponent("-118.257363,34.076763")}`
         );
@@ -372,7 +373,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `origins=${encodeURIComponent("-118.257363,34.076763")}`
         );
@@ -405,7 +406,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `origins=${encodeURIComponent("-118.257363,34.076763")}`
         );
@@ -438,7 +439,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `origins=${encodeURIComponent(JSON.stringify(originsFeatureSet))}`
         );
@@ -472,7 +473,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(`outputType=esriNAODOutputSparseMatrix`);
         expect(Object.keys(response)).toContain("odCostMatrix");
         done();
@@ -500,7 +501,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `outputType=esriNAODOutputStraightLines`
         );
@@ -530,7 +531,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(`outputType=esriNAODOutputNoLines`);
         expect(Object.keys(response)).toContain("odLines");
         done();
@@ -558,7 +559,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `barriers=${encodeURIComponent("-117.1957,34.0564;-117.184,34.0546")}`
         );
@@ -587,7 +588,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `barriers=${encodeURIComponent(JSON.stringify(barriersFeatureSet))}`
         );
@@ -616,7 +617,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `polylineBarriers=${encodeURIComponent(
             JSON.stringify(polylineBarriers)
@@ -647,7 +648,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `polygonBarriers=${encodeURIComponent(
             JSON.stringify(polygonBarriers)
@@ -680,7 +681,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
 
         // origins
         expect(Object.keys(response.origins)).toContain("geoJson");
@@ -769,7 +770,7 @@ describe("originDestinationMatrix", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
 
         // origins
         expect(Object.keys(response.origins)).not.toContain("geoJson");

--- a/packages/arcgis-rest-routing/test/serviceArea.test.ts
+++ b/packages/arcgis-rest-routing/test/serviceArea.test.ts
@@ -105,8 +105,9 @@ const facilitiesFeatureSet: IFeatureSet = {
 //   "https://foo.com/ArcGIS/rest/services/Network/USA/NAServer/";
 
 describe("serviceArea", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should throw an error when a serviceArea request is made without a token", (done) => {
     fetchMock.once("*", ServiceArea);
 
@@ -138,7 +139,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/ServiceAreas/NAServer/ServiceArea_World/solveServiceArea"
         );
@@ -181,7 +182,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain("returnFacilities=true");
         expect(options.body).toContain("returnBarriers=true");
         expect(options.body).toContain("returnPolylineBarriers=true");
@@ -216,7 +217,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain("returnFacilities=false");
         expect(options.body).toContain("returnBarriers=false");
         expect(options.body).toContain("returnPolylineBarriers=false");
@@ -245,7 +246,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `facilities=${encodeURIComponent(
             "-118.3417932,34.00451385;-118.08788,34.01752;-118.20327,34.19382"
@@ -274,7 +275,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `facilities=${encodeURIComponent(
             "-118.3417932,34.00451385;-118.08788,34.01752;-118.20327,34.19382"
@@ -303,7 +304,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `facilities=${encodeURIComponent(
             "-118.3417932,34.00451385;-118.08788,34.01752;-118.20327,34.19382"
@@ -332,7 +333,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `facilities=${encodeURIComponent(
             JSON.stringify(facilitiesFeatureSet)
@@ -362,7 +363,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `travelDirection=esriNATravelDirectionToFacility`
         );
@@ -390,7 +391,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `travelDirection=esriNATravelDirectionFromFacility`
         );
@@ -418,7 +419,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `barriers=${encodeURIComponent("-117.1957,34.0564;-117.184,34.0546")}`
         );
@@ -446,7 +447,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `barriers=${encodeURIComponent(JSON.stringify(barriersFeatureSet))}`
         );
@@ -474,7 +475,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `polylineBarriers=${encodeURIComponent(
             JSON.stringify(polylineBarriers)
@@ -504,7 +505,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(options.body).toContain(
           `polygonBarriers=${encodeURIComponent(
             JSON.stringify(polygonBarriers)
@@ -533,7 +534,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(Object.keys(response.saPolygons)).not.toContain("fieldAliases");
         done();
       })
@@ -558,7 +559,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(Object.keys(response.saPolygons)).toContain("geoJson");
         expect(Object.keys(response.saPolygons.geoJson)).toContain("type");
         expect(response.saPolygons.geoJson.type).toEqual("FeatureCollection");
@@ -590,7 +591,7 @@ describe("serviceArea", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(Object.keys(response.saPolygons)).not.toContain("geoJson");
         done();
       })

--- a/packages/arcgis-rest-routing/test/solveRoute.test.ts
+++ b/packages/arcgis-rest-routing/test/solveRoute.test.ts
@@ -125,8 +125,9 @@ const stopsFeatureSet: IFeatureSet = {
 //   "https://foo.com/ArcGIS/rest/services/Network/USA/NAServer/";
 
 describe("solveRoute", () => {
-  afterEach(fetchMock.restore);
-
+  afterEach(() => {
+    fetchMock.restore();
+  });
   it("should throw an error when a solveRoute request is made without a token", (done) => {
     fetchMock.once("*", Solve);
 
@@ -155,7 +156,7 @@ describe("solveRoute", () => {
     solveRoute({ stops, authentication: MOCK_AUTH })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -192,7 +193,7 @@ describe("solveRoute", () => {
     solveRoute({ stops: stops3, authentication: MOCK_AUTH })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -232,7 +233,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -272,7 +273,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -312,7 +313,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -352,7 +353,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -392,7 +393,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -432,7 +433,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -472,7 +473,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -512,7 +513,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -552,7 +553,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(url).toEqual(
           "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve"
         );
@@ -642,7 +643,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(Object.keys(response.routes)).toContain("geoJson");
         done();
       })
@@ -670,7 +671,7 @@ describe("solveRoute", () => {
     })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
-        const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+        const [url, options] = fetchMock.lastCall("*");
         expect(Object.keys(response.routes)).not.toContain("geoJson");
         done();
       })

--- a/scripts/test-helpers.ts
+++ b/scripts/test-helpers.ts
@@ -2,6 +2,7 @@
  * Apache-2.0 */
 
 import { File } from "@esri/arcgis-rest-form-data";
+import fetchMock from "fetch-mock";
 
 export const TOMORROW = (function () {
   const now = new Date();
@@ -32,3 +33,5 @@ export const isNode = new Function(
 export const isBrowser = new Function(
   "try {return this===window;}catch(e){ return false;}"
 )();
+
+fetchMock.config.overwriteRoutes = true;


### PR DESCRIPTION
This PR fixes #1052 by upgrading from `fetch-mock@5.0.0` to `fetch-mock@9.0.0` and all the ugliness that produces. This mostly involved removing all our manually defined types and fixing a few key tests.