### PR TITLE
docs: mark platform self related things @private @internal

### DIFF
--- a/packages/arcgis-rest-request/src/app-tokens.ts
+++ b/packages/arcgis-rest-request/src/app-tokens.ts
@@ -42,6 +42,8 @@ export function exchangeToken(
 }
 
 /**
+ * @internal
+ * @private
  * Response from the `platformSelf(...)` function.
  */
 export interface IPlatformSelfResponse {
@@ -61,6 +63,8 @@ export interface IPlatformSelfResponse {
 }
 
 /**
+ * @internal
+ * @private
  * Request a token for a specific application using the esri_aopc encrypted cookie
  *
  * When a client app boots up, it will know its clientId and the redirectUri for use


### PR DESCRIPTION
Mark type and method as `@private` and `@internal` to exclude them from the docs. Was not sure which was needed, as `@private` suggests it's for private class members, where as `@internal` is more generic.

For v3, we had to add these types to the exclude list as tsdoc did not seem to respect `--excludeInternal` or `--excludePrivate` flags