### PR TITLE
fix: api reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ request(url).then((response) => {
 
 ### API Reference
 
-The documentation is published at http://esri.github.io/arcgis-rest-js/ (source code [here](/docs/src)).
+https://developers.arcgis.com/arcgis-rest-js/
+
+Version 3.x documentation http://esri.github.io/arcgis-rest-js/.
 
 ### Instructions
 


### PR DESCRIPTION
And update the repo about website url to https://developers.arcgis.com/arcgis-rest-js/ as well.