### PR TITLE
fix(arcgis-rest-places): update pagination values for latest API

### DIFF
--- a/packages/arcgis-rest-places/src/utils.ts
+++ b/packages/arcgis-rest-places/src/utils.ts
@@ -2,7 +2,7 @@ export const baseUrl =
   "https://places-api.arcgis.com/arcgis/rest/services/places-service/v1";
 
 export function hasNextPage(response: any) {
-  return !!response?.links?.next;
+  return !!response?.links?.next || !!response?.pagination?.nextUrl;
 }
 
 export function getNextPageParams(currentOffset = 0, currentPageSize = 10) {

--- a/packages/arcgis-rest-places/test/findPlacesNearPoint.test.ts
+++ b/packages/arcgis-rest-places/test/findPlacesNearPoint.test.ts
@@ -1,5 +1,5 @@
 import { ApiKeyManager } from "@esri/arcgis-rest-request";
-import fetchMock from "fetch-mock";
+import fetchMock, { MockCall } from "fetch-mock";
 import { findPlacesNearPoint } from "../src/index.js";
 import {
   placeNearPointMockNoMoreResults,
@@ -21,7 +21,7 @@ describe("findPlacesNearPoint()", () => {
       authentication: ApiKeyManager.fromKey("MOCK_KEY")
     });
 
-    const [url, options] = fetchMock.lastCall("*");
+    const [url, options] = fetchMock.lastCall("*") as MockCall;
 
     expect(response.results).toEqual(
       placeNearPointMockNoMoreResults.results as any

--- a/packages/arcgis-rest-places/test/mocks/nearPoint.mock.ts
+++ b/packages/arcgis-rest-places/test/mocks/nearPoint.mock.ts
@@ -179,6 +179,6 @@ export const placeNearPointMockNoMoreResults = {
   maxResultsExceeded: false,
   pagination: {
     previousUrl:
-      "https://placesdev-api.arcgis.com//arcgis/rest/services/places-service/v1/places/near-point?x=-3.18830000&y=55.95330000&radius=100.00000000&f=json&offset=0&pageSize=10"
+      "https://placesdev-api.arcgis.com/arcgis/rest/services/places-service/v1/places/near-point?x=-3.18830000&y=55.95330000&radius=100.00000000&f=json&offset=0&pageSize=10"
   }
 };

--- a/packages/arcgis-rest-places/test/mocks/nearPoint.mock.ts
+++ b/packages/arcgis-rest-places/test/mocks/nearPoint.mock.ts
@@ -177,9 +177,8 @@ export const placeNearPointMockNoMoreResults = {
     }
   ],
   maxResultsExceeded: false,
-  links: {
-    base: "https://placesdev-api.arcgis.com/",
-    previous:
-      "/arcgis/rest/services/places-service/v1/places/near-point?x=-3.18830000&y=55.95330000&radius=100.00000000&f=json&offset=0&pageSize=10"
+  pagination: {
+    previousUrl:
+      "https://placesdev-api.arcgis.com//arcgis/rest/services/places-service/v1/places/near-point?x=-3.18830000&y=55.95330000&radius=100.00000000&f=json&offset=0&pageSize=10"
   }
 };

--- a/packages/arcgis-rest-places/test/mocks/withinExtent.mock.ts
+++ b/packages/arcgis-rest-places/test/mocks/withinExtent.mock.ts
@@ -148,6 +148,6 @@ export const placesWithinExtentMockNoMoreResults = {
   maxResultsExceeded: false,
   pagination: {
     previousUrl:
-      "https://places-service.esri.com//rest/v1/world/places/within-extent?xmin=-118.01333400&ymin=33.78193000&xmax=-117.79575300&ymax=33.87333700&categoryIds=13002&f=json&offset=0&pageSize=5&token=AAPK7d4bf083681e434b8d7593a08954e918ro7MqS9xFOIaAk7StSGVbajdmn5IDn1upbdHw9OiZbNx5YaeP51obAVmMVcmHuZ4"
+      "https://places-service.esri.com/rest/v1/world/places/within-extent?xmin=-118.01333400&ymin=33.78193000&xmax=-117.79575300&ymax=33.87333700&categoryIds=13002&f=json&offset=0&pageSize=5&token=AAPK7d4bf083681e434b8d7593a08954e918ro7MqS9xFOIaAk7StSGVbajdmn5IDn1upbdHw9OiZbNx5YaeP51obAVmMVcmHuZ4"
   }
 };

--- a/packages/arcgis-rest-places/test/mocks/withinExtent.mock.ts
+++ b/packages/arcgis-rest-places/test/mocks/withinExtent.mock.ts
@@ -146,9 +146,8 @@ export const placesWithinExtentMockNoMoreResults = {
     }
   ],
   maxResultsExceeded: false,
-  links: {
-    base: "https://places-service.esri.com/",
-    previous:
-      "/rest/v1/world/places/within-extent?xmin=-118.01333400&ymin=33.78193000&xmax=-117.79575300&ymax=33.87333700&categoryIds=13002&f=json&offset=0&pageSize=5&token=AAPK7d4bf083681e434b8d7593a08954e918ro7MqS9xFOIaAk7StSGVbajdmn5IDn1upbdHw9OiZbNx5YaeP51obAVmMVcmHuZ4"
+  pagination: {
+    previousUrl:
+      "https://places-service.esri.com//rest/v1/world/places/within-extent?xmin=-118.01333400&ymin=33.78193000&xmax=-117.79575300&ymax=33.87333700&categoryIds=13002&f=json&offset=0&pageSize=5&token=AAPK7d4bf083681e434b8d7593a08954e918ro7MqS9xFOIaAk7StSGVbajdmn5IDn1upbdHw9OiZbNx5YaeP51obAVmMVcmHuZ4"
   }
 };

--- a/packages/arcgis-rest-places/test/utils.test.ts
+++ b/packages/arcgis-rest-places/test/utils.test.ts
@@ -6,7 +6,6 @@ describe("hasNextPage()", () => {
   it("should return if a response has a next page of results", async () => {
     expect(
       hasNextPage({
-        maxResultsExceeded: true,
         links: {
           next: "next"
         }
@@ -15,17 +14,25 @@ describe("hasNextPage()", () => {
 
     expect(
       hasNextPage({
-        maxResultsExceeded: false
+        pagination: {
+          nextUrl: "next"
+        }
+      })
+    ).toBeTruthy();
+
+    expect(hasNextPage({})).toBeFalsy();
+    expect(hasNextPage(undefined)).toBeFalsy();
+
+    expect(
+      hasNextPage({
+        links: {}
       })
     ).toBeFalsy();
 
     expect(
       hasNextPage({
-        maxResultsExceeded: true,
-        links: {}
+        pagination: {}
       })
     ).toBeFalsy();
-
-    expect(hasNextPage(undefined)).toBeFalsy();
   });
 });


### PR DESCRIPTION
The places API will change the response structure for pagination info soon. This fixes REST JS to support both the old and new style responses so we can do a release an have everything ready to go when the change happens.