### PR TITLE
fix(arcgis-rest-feature-service): add additional statistic types

### DIFF
--- a/packages/arcgis-rest-feature-service/src/helpers.ts
+++ b/packages/arcgis-rest-feature-service/src/helpers.ts
@@ -60,7 +60,7 @@ export interface IEditFeatureResult {
   error?: {
     code: number;
     description: string;
-  }
+  };
 }
 
 /**
@@ -170,7 +170,7 @@ function stripQueryString(url: string) {
 
 export interface IStatisticDefinition {
   /**
-   * Statistical operation to perform (count, sum, min, max, avg, stddev, var, percentile_cont, percentile_disc).
+   * Statistical operation to perform (count, sum, min, max, avg, stddev, var, percentile_cont, percentile_disc, EnvelopeAggregate, CentroidAggregate, ConvexHullAggregate).
    */
   statisticType:
     | "count"
@@ -181,7 +181,10 @@ export interface IStatisticDefinition {
     | "stddev"
     | "var"
     | "percentile_cont"
-    | "percentile_disc";
+    | "percentile_disc"
+    | "EnvelopeAggregate"
+    | "CentroidAggregate"
+    | "ConvexHullAggregate";
   /**
    * Parameters to be used along with statisticType. Currently, only applicable for percentile_cont (continuous percentile) and percentile_disc (discrete percentile).
    */


### PR DESCRIPTION
#1043 

These are currently supported in ArcGIS Online hosted feature services, but not in ArcGIS Enterprise. So these are not yet in the [ArcGIS REST API Documentation](https://github.com/Esri/arcgis-rest-js/issues/1043#issuecomment-1357972948) because they are not supported in ArcGIS Enterprise yet. But due to the request in #1043 and also the fact that they are built into other client libraries like the [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-StatisticDefinition.html#statisticType), we think it's valid to put these types into ArcGIS REST JS.

## Demo

Because these are not in the REST API documentation yet, I had to look up what are the actual string names. They can be found in the JSON info of a Feature Service layer, for example [here](https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Major_Cities_/FeatureServer/0?f=pjson) - scroll down to the `supportedSpatialAggregationStatistics`:
![image](https://github.com/Esri/arcgis-rest-js/assets/137905994/ce98969a-363b-4067-a905-5029abc64bb4)

Also, to verify these are correct, I constructed a test REST call - here is an example using `EnvelopeAggregate`:

https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Major_Cities_/FeatureServer/0/query?where=1%3D1&outFields=*&returnGeometry=true&groupByFieldsForStatistics=STATE_ABBR&outStatistics=%5B%0D%0A++%7B%0D%0A++++%22statisticType%22%3A+%22AVG%22%2C%0D%0A++++%22onStatisticField%22%3A+%22POPULATION%22%2C%0D%0A++++%22outStatisticFieldName%22%3A+%22avg_pop%22%0D%0A++%7D%2C%0D%0A++%7B%0D%0A++++%22statisticType%22%3A+%22EnvelopeAggregate%22%2C%0D%0A++++%22outStatisticFieldName%22%3A+%22aggregateExtent%22%0D%0A++%7D%0D%0A%5D&f=html

