### PR TITLE
feat(arcgis-rest-portal): add searchCommunityUsers method to allow fo…

### DIFF
--- a/packages/arcgis-rest-portal/src/users/search-users.ts
+++ b/packages/arcgis-rest-portal/src/users/search-users.ts
@@ -43,7 +43,7 @@ export function searchUsers(
  * searchCommunityUsers({ q: 'tommy', authentication })
  *   .then(response) // response.total => 355
  * ```
- * Search a all portals for users.
+ * Search all portals for users.
  *
  * @param search - A RequestOptions object to pass through to the endpoint.
  * @returns A Promise that will resolve with the data from the response.

--- a/packages/arcgis-rest-portal/src/users/search-users.ts
+++ b/packages/arcgis-rest-portal/src/users/search-users.ts
@@ -20,7 +20,7 @@ export interface IUserSearchOptions extends ISearchOptions {
 
 /**
  * ```js
- * import { searchItems } from "@esri/arcgis-rest-portal";
+ * import { searchUsers } from "@esri/arcgis-rest-portal";
  * //
  * searchUsers({ q: 'tommy', authentication })
  *   .then(response) // response.total => 355
@@ -34,4 +34,22 @@ export function searchUsers(
   search: IUserSearchOptions | SearchQueryBuilder
 ): Promise<ISearchResult<IUser>> {
   return genericSearch<IUser>(search, "user");
+}
+
+/**
+ * ```js
+ * import { searchCommunityUsers } from "@esri/arcgis-rest-portal";
+ * //
+ * searchCommunityUsers({ q: 'tommy', authentication })
+ *   .then(response) // response.total => 355
+ * ```
+ * Search a all portals for users.
+ *
+ * @param search - A RequestOptions object to pass through to the endpoint.
+ * @returns A Promise that will resolve with the data from the response.
+ */
+export function searchCommunityUsers(
+  search: IUserSearchOptions | SearchQueryBuilder
+): Promise<ISearchResult<IUser>> {
+  return genericSearch<IUser>(search, "communityUser");
 }

--- a/packages/arcgis-rest-portal/src/util/generic-search.ts
+++ b/packages/arcgis-rest-portal/src/util/generic-search.ts
@@ -22,7 +22,7 @@ export function genericSearch<T extends IItem | IGroup | IUser>(
     | ISearchOptions
     | ISearchGroupContentOptions
     | SearchQueryBuilder,
-  searchType: "item" | "group" | "groupContent" | "user"
+  searchType: "item" | "group" | "groupContent" | "user" | "communityUser"
 ): Promise<ISearchResult<T>> {
   let options: IRequestOptions;
   if (typeof search === "string" || search instanceof SearchQueryBuilder) {
@@ -79,8 +79,11 @@ export function genericSearch<T extends IItem | IGroup | IUser>(
         );
       }
       break;
+    case "communityUser":
+      path = "/community/users";
+      break;
     default:
-      // "users"
+      // "user"
       path = "/portals/self/users/search";
       break;
   }

--- a/packages/arcgis-rest-portal/test/users/search.test.ts
+++ b/packages/arcgis-rest-portal/test/users/search.test.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { searchUsers } from "../../src/users/search-users";
+import { searchUsers, searchCommunityUsers } from "../../src/users/search-users";
 import { UserSearchResponse } from "../mocks/users/user-search";
 
 import * as fetchMock from "fetch-mock";
@@ -32,6 +32,39 @@ describe("users", () => {
             "https://myorg.maps.arcgis.com/sharing/rest/portals/self/users/search?f=json&q=role%3Aorg_user%20OR%20role%3Aorg_publisher&num=100&token=fake-token"
           );
           expect(options.method).toBe("GET");
+          expect(response).toEqual(UserSearchResponse);
+          done();
+        })
+        .catch(e => {
+          fail(e);
+        });
+    });
+  });
+
+  describe("searchCommunityUsers", () => {
+    const MOCK_AUTH = {
+      getToken() {
+        return Promise.resolve("fake-token");
+      },
+      portal: "https://myorg.maps.arcgis.com/sharing/rest"
+    };
+
+    it("should make a simple, authenticated user search request", done => {
+      fetchMock.once("*", UserSearchResponse);
+
+      searchCommunityUsers({
+        q: "role:org_user OR role:org_publisher",
+        num: 100,
+        authentication: MOCK_AUTH
+      })
+        .then(response => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/community/users?f=json&q=role%3Aorg_user%20OR%20role%3Aorg_publisher&num=100&token=fake-token"
+          );
+          expect(options.method).toBe("GET");
+          expect(response).toEqual(UserSearchResponse);
           done();
         })
         .catch(e => {

--- a/packages/arcgis-rest-portal/test/users/search.test.ts
+++ b/packages/arcgis-rest-portal/test/users/search.test.ts
@@ -7,16 +7,16 @@ import { UserSearchResponse } from "../mocks/users/user-search";
 import * as fetchMock from "fetch-mock";
 
 describe("users", () => {
+  const MOCK_AUTH = {
+    getToken() {
+      return Promise.resolve("fake-token");
+    },
+    portal: "https://myorg.maps.arcgis.com/sharing/rest"
+  };
+
   afterEach(fetchMock.restore);
 
   describe("searchUsers", () => {
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
-      portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
-
     it("should make a simple, authenticated user search request", done => {
       fetchMock.once("*", UserSearchResponse);
 
@@ -42,13 +42,6 @@ describe("users", () => {
   });
 
   describe("searchCommunityUsers", () => {
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
-      portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
-
     it("should make a simple, authenticated user search request", done => {
       fetchMock.once("*", UserSearchResponse);
 


### PR DESCRIPTION
[1119](https://github.com/Esri/arcgis-rest-js/issues/1119)

- Refactors `genericSearch` to support calling [/community/users](https://developers.arcgis.com/rest/users-groups-and-items/user-search.htm) endpoint when `searchType` is `communityUser`
- Adds `searchCommunityUsers` method that calls through to `genericSearch`, passing a `searchType` of `communityUser`

V3