### PR TITLE
feat(arcgis-rest-portal): add searchCommunityUsers method to allow fo…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44354,7 +44354,7 @@
     },
     "packages/arcgis-rest-places": {
       "name": "@esri/arcgis-rest-places",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -44371,7 +44371,7 @@
     },
     "packages/arcgis-rest-portal": {
       "name": "@esri/arcgis-rest-portal",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/packages/arcgis-rest-portal/src/users/search-users.ts
+++ b/packages/arcgis-rest-portal/src/users/search-users.ts
@@ -20,7 +20,7 @@ export interface IUserSearchOptions extends ISearchOptions {
  * Search a portal for users.
  *
  * ```js
- * import { searchItems } from "@esri/arcgis-rest-portal";
+ * import { searchUsers } from "@esri/arcgis-rest-portal";
  * //
  * searchUsers({ q: 'tommy', authentication })
  *   .then(response) // response.total => 355

--- a/packages/arcgis-rest-portal/src/users/search-users.ts
+++ b/packages/arcgis-rest-portal/src/users/search-users.ts
@@ -34,3 +34,21 @@ export function searchUsers(
 ): Promise<ISearchResult<IUser>> {
   return genericSearch<IUser>(search, "user");
 }
+
+/**
+ * ```js
+ * import { searchCommunityUsers } from "@esri/arcgis-rest-portal";
+ * //
+ * searchCommunityUsers({ q: 'tommy', authentication })
+ *   .then(response) // response.total => 355
+ * ```
+ * Search all portals for users.
+ *
+ * @param search - A RequestOptions object to pass through to the endpoint.
+ * @returns A Promise that will resolve with the data from the response.
+ */
+export function searchCommunityUsers(
+  search: IUserSearchOptions | SearchQueryBuilder
+): Promise<ISearchResult<IUser>> {
+  return genericSearch<IUser>(search, "communityUser");
+}

--- a/packages/arcgis-rest-portal/src/util/generic-search.ts
+++ b/packages/arcgis-rest-portal/src/util/generic-search.ts
@@ -24,7 +24,7 @@ export function genericSearch<T extends IItem | IGroup | IUser>(
     | ISearchOptions
     | ISearchGroupContentOptions
     | SearchQueryBuilder,
-  searchType: "item" | "group" | "groupContent" | "user"
+  searchType: "item" | "group" | "groupContent" | "user" | "communityUser"
 ): Promise<ISearchResult<T>> {
   let options: IRequestOptions;
   if (typeof search === "string" || search instanceof SearchQueryBuilder) {
@@ -80,6 +80,9 @@ export function genericSearch<T extends IItem | IGroup | IUser>(
           new Error("you must pass a `groupId` option to `searchGroupContent`")
         );
       }
+      break;
+    case "communityUser":
+      path = "/community/users";
       break;
     default:
       // "users"

--- a/packages/arcgis-rest-portal/test/users/search.test.ts
+++ b/packages/arcgis-rest-portal/test/users/search.test.ts
@@ -2,21 +2,24 @@
  * Apache-2.0 */
 
 import fetchMock from "fetch-mock";
-import { searchUsers } from "../../src/users/search-users.js";
+import {
+  searchUsers,
+  searchCommunityUsers
+} from "../../src/users/search-users.js";
 import { UserSearchResponse } from "../mocks/users/user-search.js";
 
 describe("users", () => {
+  const MOCK_AUTH = {
+    getToken() {
+      return Promise.resolve("fake-token");
+    },
+    portal: "https://myorg.maps.arcgis.com/sharing/rest"
+  };
+
   afterEach(() => {
     fetchMock.restore();
   });
   describe("searchUsers", () => {
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
-      portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
-
     it("should make a simple, authenticated user search request", (done) => {
       fetchMock.once("*", UserSearchResponse);
 
@@ -32,6 +35,32 @@ describe("users", () => {
             "https://myorg.maps.arcgis.com/sharing/rest/portals/self/users/search?f=json&q=role%3Aorg_user%20OR%20role%3Aorg_publisher&num=100&token=fake-token"
           );
           expect(options.method).toBe("GET");
+          expect(response).toEqual(UserSearchResponse);
+          done();
+        })
+        .catch((e) => {
+          fail(e);
+        });
+    });
+  });
+
+  describe("searchCommunityUsers", () => {
+    it("should make a simple, authenticated user search request", (done) => {
+      fetchMock.once("*", UserSearchResponse);
+
+      searchCommunityUsers({
+        q: "role:org_user OR role:org_publisher",
+        num: 100,
+        authentication: MOCK_AUTH
+      })
+        .then((response) => {
+          expect(fetchMock.called()).toEqual(true);
+          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/community/users?f=json&q=role%3Aorg_user%20OR%20role%3Aorg_publisher&num=100&token=fake-token"
+          );
+          expect(options.method).toBe("GET");
+          expect(response).toEqual(UserSearchResponse);
           done();
         })
         .catch((e) => {

--- a/packages/arcgis-rest-portal/test/users/search.test.ts
+++ b/packages/arcgis-rest-portal/test/users/search.test.ts
@@ -55,7 +55,7 @@ describe("users", () => {
       })
         .then((response) => {
           expect(fetchMock.called()).toEqual(true);
-          const [url, options]: [string, RequestInit] = fetchMock.lastCall("*");
+          const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/community/users?f=json&q=role%3Aorg_user%20OR%20role%3Aorg_publisher&num=100&token=fake-token"
           );


### PR DESCRIPTION
[1119](https://github.com/Esri/arcgis-rest-js/issues/1119)

- Refactors `genericSearch` to support calling [/community/users](https://developers.arcgis.com/rest/users-groups-and-items/user-search.htm) endpoint when `searchType` is `communityUser`
- Adds `searchCommunityUsers` method that calls through to `genericSearch`, passing a `searchType` of `communityUser`

V4