### PR TITLE
fix (arcgis-rest-request): add missing orgId property for group

### DIFF
--- a/packages/arcgis-rest-request/src/types/group.ts
+++ b/packages/arcgis-rest-request/src/types/group.ts
@@ -69,4 +69,5 @@ export interface IGroup extends IGroupAdd {
     applications?: number;
   };
   hasCategorySchema?: boolean;
+  orgId?: string;
 }


### PR DESCRIPTION
The orgId property is missing from the IGroup interface. 

See [https://developers.arcgis.com/rest/users-groups-and-items/group.htm](https://developers.arcgis.com/rest/users-groups-and-items/group.htm)