### PR TITLE
chore: prepare for branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          # This parameter is required to make sure sematic-relase exactly use the provided GitHub Token
+          # See https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#pushing-package.json-changes-to-a-master-branch
+          persist-credentials: false
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: npm
 
       - name: Install
         run: npm ci
@@ -72,6 +78,7 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT to allow bypassing the branch protection for direct push to main
+          GITHUB_TOKEN: ${{ secrets.ESRI_DCDEV_SERVICE_ACCOUNT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run release


### PR DESCRIPTION
Esri is enforcing branch protection to repositories that contain code to be deployed in a FedRAMP-regulated environment (Hub). The protection rules include:
* Require Pull Request reviews before all merging
* Requires approval by at least one person
* Require pull request conversation resolution before merging

This repository is part of the effort. The PR will update the release pipeline to use a personal access token for release so that the `sematic-release` direct push (by the token owner) can be tolerated. Before merging this PR, the protection rules and the PAT secret should be added into the repository setting first.