### PR TITLE
docs(arcgis-rest-request): fix link

### DIFF
--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -265,7 +265,7 @@ export interface IArcGISIdentityManagerOptions {
  *
  * **It is not recommended to construct `ArcGISIdentityManager` directly**. Instead there are several static methods used for specific workflows. The 2 primary workflows relate to oAuth 2.0:
  *
- * * {@linkcode ArcGISIdentityManager.beginOAuth2} and {@linkcode ArcGISIdentityManager.completeOAuth2()} for oAuth 2.0 in browser-only environment.
+ * * {@linkcode ArcGISIdentityManager.beginOAuth2} and {@linkcode ArcGISIdentityManager.completeOAuth2} for oAuth 2.0 in browser-only environment.
  * * {@linkcode ArcGISIdentityManager.authorize} and {@linkcode ArcGISIdentityManager.exchangeAuthorizationCode} for oAuth 2.0 for server-enabled application.
  *
  * Other more specialized helpers for less common workflows also exist:


### PR DESCRIPTION
This link on this page is not working because of the presence of the parenthesis in the link:
https://developers.arcgis.com/arcgis-rest-js/api-reference/arcgis-rest-request/ArcGISIdentityManager/
![image](https://github.com/Esri/arcgis-rest-js/assets/137905994/68fbdd4a-10ca-4160-bd07-87a191a3e118)
