### PR TITLE
docs: removed references to `arcgis-rest-service-admin`

### DIFF
--- a/packages/arcgis-rest-feature-service/src/addToServiceDefinition.ts
+++ b/packages/arcgis-rest-feature-service/src/addToServiceDefinition.ts
@@ -35,7 +35,7 @@ export interface IAddToServiceDefinitionResult {
  * Add layer(s) and/or table(s) to a hosted feature service. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/add-to-definition-feature-service-.htm) for more information.
  *
  *  ```js
- * import { addToServiceDefinition } from '@esri/arcgis-rest-service-admin';
+ * import { addToServiceDefinition } from '@esri/arcgis-rest-feature-service';
  * //
  * addToServiceDefinition(serviceurl, {
  *   authentication: ArcGISIdentityManager,

--- a/packages/arcgis-rest-feature-service/src/createFeatureService.ts
+++ b/packages/arcgis-rest-feature-service/src/createFeatureService.ts
@@ -152,7 +152,7 @@ export interface ICreateServiceResult {
  * import {
  *   createFeatureService,
  *   addToServiceDefinition
- * } from '@esri/arcgis-rest-service-admin';
+ * } from '@esri/arcgis-rest-feature-service';
  * //
  * createFeatureService({
  *   authentication: ArcGISIdentityManager,

--- a/packages/arcgis-rest-feature-service/src/helpers.ts
+++ b/packages/arcgis-rest-feature-service/src/helpers.ts
@@ -273,7 +273,6 @@ export interface IViewServiceSources {
  * `IFeatureServiceDefinition` can also be imported from the following packages:
  *
  * ```js
- * import { IFeatureServiceDefinition } from "@esri/arcgis-rest-service-admin";
  * import { IFeatureServiceDefinition } from "@esri/arcgis-rest-feature-service";
  * ```
  */
@@ -380,12 +379,6 @@ export interface IFeatureServiceDefinition {
 
 /**
  * Root element in the web map specifying an array of table objects.
- *
- * `ITable` can also be imported from the following packages:
- *
- * ```js
- * import { ITable } from "@esri-arcgis-rest-service-admin"
- * ```
  */
 export interface ITable {
   /** Table name */
@@ -675,14 +668,6 @@ export interface ITemplate {
   prototype?: IFeature;
 }
 
-/**
- * `ILayerDefinition` can also be imported from the following packages:
- *
- * ```js
- * import { ILayerDefinition } from "@esri/arcgis-rest-service-admin";
- * import { ILayerDefinition } from "@esri/arcgis-rest-feature-service";
- * ```
- */
 export interface ILayerDefinition extends IHasZM {
   /** Boolean value indicating whether the geometry of the features in the layer can be edited. */
   allowGeometryUpdates?: boolean;

--- a/packages/arcgis-rest-feature-service/src/updateServiceDefinition.ts
+++ b/packages/arcgis-rest-feature-service/src/updateServiceDefinition.ts
@@ -20,7 +20,7 @@ export interface IUpdateServiceDefinitionResult {
  * Update a definition property in a hosted feature service. See the [REST Documentation](https://developers.arcgis.com/rest/services-reference/online/update-definition-feature-service-.htm) for more information.
  *
  * ```js
- * import { updateServiceDefinition } from '@esri/arcgis-rest-service-admin';
+ * import { updateServiceDefinition } from '@esri/arcgis-rest-feature-service';
  * //
  * updateServiceDefinition(serviceurl, {
  *   authentication: ArcGISIdentityManager,

--- a/packages/arcgis-rest-request/src/types/geometry.ts
+++ b/packages/arcgis-rest-request/src/types/geometry.ts
@@ -20,7 +20,6 @@ export interface IHasZM {
  *
  * ```js
  * import { ISpatialReference } from "@esri/arcgis-rest-geocoding";
- * import { ISpatialReference } from "@esri/arcgis-rest-service-admin";
  * import { ISpatialReference } from "@esri/arcgis-rest-feature-service";
  * ```
  */


### PR DESCRIPTION
Removed all references to `arcgis-rest-service-admin`, which is an old package name that was replaced by `arcgis-rest-feature-service`. See here:

- https://github.com/Esri/arcgis-rest-js/pull/930
- https://github.com/Esri/arcgis-rest-js/issues/933
