### PR TITLE
build: add manual workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,66 @@
+name: Build, Test, Release
+
+# On pushes to master (i.e. merging a PR)
+# run all tests, on win, macos, linux, on node 12 & 14
+on: workflow_dispatch
+
+jobs:
+  # First, build and test on multiple os's
+  # and multuple versions of node
+  build_and_test:
+    name: Build and Test
+
+    runs-on: ${{ matrix.os }}
+
+    # PRs will run tests on node 14,16 on ubuntu, macos and windows
+    # so for the release, we're just running node 16@ubuntu
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [18]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test in Chrome
+        run: npm run test:chrome:ci
+
+      - name: Test in Node
+        run: npm run test:node
+
+      - uses: codecov/codecov-action@v1
+        with:
+          directory: ./coverage
+
+  # If the build and test works, run a release
+  release:
+    name: Release
+    needs: [build_and_test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm run release:dry

--- a/package-lock.json
+++ b/package-lock.json
@@ -41139,7 +41139,7 @@
     },
     "packages/arcgis-rest-request": {
       "name": "@esri/arcgis-rest-request",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@esri/arcgis-rest-fetch": "^4.0.0",


### PR DESCRIPTION
This PR adds a test workflow that we can run to do releases manually rather then the weird re-run a failed workflow that we currently do.

Currently setup to do a dry run for testing.