### PR TITLE
fix: small change to trigger a catch-up release

### DIFF
--- a/packages/arcgis-rest-request/src/ApplicationCredentialsManager.ts
+++ b/packages/arcgis-rest-request/src/ApplicationCredentialsManager.ts
@@ -150,7 +150,7 @@ export function ApplicationSession(
   options: IApplicationCredentialsManagerOptions
 ) {
   console.log(
-    "DEPRECATED:, 'ApplicationSession' is deprecated. Use 'ApplicationCredentialsManager' instead."
+    "DEPRECATED: 'ApplicationSession' is deprecated. Use 'ApplicationCredentialsManager' instead."
   );
 
   return new ApplicationCredentialsManager(options);


### PR DESCRIPTION
This is a small change to:

1. Test to ensure the new automatic build process is working
2. Do a release to catch up on any committed code that has not been released in the past ~ 1 year

See: https://github.com/Esri/arcgis-rest-js/pull/1158#pullrequestreview-2064793888

If this works properly, I will issue similar PRs for the other packages.