### PR TITLE
docs: do not use polyfill.io due to a security issue

### DIFF
--- a/demos/attachments/index.html
+++ b/demos/attachments/index.html
@@ -4,7 +4,7 @@
 
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
 
 <div class="container-fluid">
   <div class="row">

--- a/demos/oauth2-browser-retry/index.html
+++ b/demos/oauth2-browser-retry/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>ArcGIS REST JS Browser OAuth2 - retry</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
   </head>
   <body>
     <div id="app-wrapper">

--- a/demos/oauth2-browser/index.html
+++ b/demos/oauth2-browser/index.html
@@ -5,7 +5,7 @@
     <title>ArcGIS REST JS Browser OAuth2</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="./style.css">
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
   </head>
   <body>
     <div id="app-wrapper">


### PR DESCRIPTION
closes #1172

The only usage of polyfill[.]io is in the old v3 demos. Even though generally we are not maintaining those, we think this security issue is big enough to warrent a small change, for those who may stumble on these in the future.

This switches to using the safe cloudflare version instead: https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet

