### PR TITLE
docs: reference correct classes

### DIFF
--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -19,7 +19,7 @@ export interface IRequestOptions {
    */
   rawResponse?: boolean;
   /**
-   * The instance of {@linkcode ApiKey}, {@linkcode ArcGISIdentityManager} or {@linkcode ApplicationSession} to use to authenticate this request. A token may also be passed directly as a string however using the built in authentication managers is encouraged.
+   * The instance of {@linkcode ArcGISIdentityManager}, {@linkcode ApplicationCredentialsManager} or {@linkcode APIKeyManager} to use to authenticate this request. A token may also be passed directly as a string however using the built in authentication managers is encouraged.
    */
   authentication?: IAuthenticationManager | string;
   /**


### PR DESCRIPTION
- The [`ApiKey` class was renamed to `ApiKeyManager` for v4](https://developers.arcgis.com/arcgis-rest-js/release-notes/upgrade-v3-v4/#renamed-classes) but we missed updating this link.
- The [`ApplicationSession` class was renamed to `ApplicationCredentialsManager` for v4](https://developers.arcgis.com/arcgis-rest-js/release-notes/upgrade-v3-v4/#renamed-classes) but we missed updating this link.

This change should fix the dead links on https://developers.arcgis.com/arcgis-rest-js/api-reference/arcgis-rest-demographics/IRequestOptions/  
![image](https://github.com/user-attachments/assets/82515801-a3dc-4e17-ad35-2860aca86b7c)
