### PR TITLE
chore: npm serve command

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "typedoc": "typedoc --options ./typedoc.json",
     "prettify:packages-jsons": "prettier-package-json --write ./**/*/package.json",
     "release:dry": "multi-semantic-release --dry-run --deps.bump=inherit --deps.release=inherit --ignore-private-packages --debug ",
-    "release": "multi-semantic-release --deps.bump=inherit --deps.release=inherit --ignore-private-packages"
+    "release": "multi-semantic-release --deps.bump=inherit --deps.release=inherit --ignore-private-packages",
+    "serve": "node scripts/run-demo-server.js"
   },
   "engines": {
     "npm": ">=7.0.0",


### PR DESCRIPTION
Just for convenience, adds an npm command (`npm run serve`) to run the script that is already here in the repo.