### PR TITLE
feat(arcgis-rest-portal): add removeItemThumbnail()

### DIFF
--- a/packages/arcgis-rest-portal/src/items/remove.ts
+++ b/packages/arcgis-rest-portal/src/items/remove.ts
@@ -138,3 +138,31 @@ export function removeFolder(requestOptions: IFolderIdOptions): Promise<{
     return request(url, requestOptions);
   });
 }
+
+/**
+ * Delete an item's thumbnail. See the [REST Documentation](https://developers.arcgis.com/rest/users-groups-and-items/delete-item-thumbnail.htm) for more information.
+ *
+ * ```js
+ * import { removeItemThumbnail } from "@esri/arcgis-rest-portal";
+ *
+ * removeItemThumbnail({
+ *   id: "3ef",
+ *   owner: "c@sey",
+ *   authentication
+ * })
+ *   .then(response)
+ * ```
+ *
+ * @param requestOptions - Options for the request
+ * @returns A Promise that deletes a thumbnail.
+ */
+export function removeItemThumbnail(
+  requestOptions: IUserItemOptions
+): Promise<{ success: boolean }> {
+  return determineOwner(requestOptions).then((owner) => {
+    const url = `${getPortalUrl(requestOptions)}/content/users/${owner}/items/${
+      requestOptions.id
+    }/deleteThumbnail`;
+    return request(url, requestOptions);
+  });
+}

--- a/packages/arcgis-rest-portal/test/items/remove.test.ts
+++ b/packages/arcgis-rest-portal/test/items/remove.test.ts
@@ -6,7 +6,8 @@ import {
   removeFolder,
   removeItem,
   removeItemResource,
-  removeItemRelationship
+  removeItemRelationship,
+  removeItemThumbnail
 } from "../../src/items/remove.js";
 
 import { ItemSuccessResponse } from "../mocks/items/item.js";
@@ -245,6 +246,29 @@ describe("search", () => {
           const [url, options] = fetchMock.lastCall("*");
           expect(url).toEqual(
             "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/3ef/delete"
+          );
+          expect(options.method).toBe("POST");
+          expect(options.body).toContain(encodeParam("f", "json"));
+          expect(options.body).toContain(encodeParam("token", "fake-token"));
+          done();
+        })
+        .catch((e) => {
+          fail(e);
+        });
+    });
+
+    it("should delete an item's thumbnail successfully", (done) => {
+      fetchMock.once("*", { success: true });
+
+      removeItemThumbnail({
+        id: "3ef",
+        owner: "dbouwman",
+        ...MOCK_USER_REQOPTS
+      })
+        .then((response) => {
+          const [url, options] = fetchMock.lastCall("*");
+          expect(url).toEqual(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/dbouwman/items/3ef/deleteThumbnail"
           );
           expect(options.method).toBe("POST");
           expect(options.body).toContain(encodeParam("f", "json"));


### PR DESCRIPTION
Resolves #780.

This PR adds the `removeItemThumbnail()` function, allowing users to delete an item's thumbnail via a POST request to the ArcGIS REST API.

#### Changes
- Implements `removeItemThumbnail()` in `remove.ts`.
- Adds unit tests in `remove.test.ts` to verify correct API calls and responses.
- Contains documentation with usage examples.

#### Testing
- Ran `npm test` to confirm all tests pass.

Note: This is my first PR to this project. I’m open to any suggestions or feedback!