### PR TITLE
feat(arcgis-rest-portal): add getFolderContent() to fetch user folder contents

### DIFF
--- a/packages/arcgis-rest-portal/src/items/get.ts
+++ b/packages/arcgis-rest-portal/src/items/get.ts
@@ -16,7 +16,8 @@ import {
   IItemRelationshipOptions,
   IUserItemOptions,
   determineOwner,
-  FetchReadMethodName
+  FetchReadMethodName,
+  IFolderIdOptions
 } from "./helpers.js";
 
 /**
@@ -444,4 +445,42 @@ function getItemFile(
           .text()
           .then((text: string) => JSON.parse(scrubControlChars(text)));
   });
+}
+
+/**
+ * Get the content of a folder for a user.
+ *
+ * ```ts
+ * import { getFolderContent } from "@esri/arcgis-rest-portal";
+ *
+ * getFolderContent({ owner: "john_doe", folderName: "abcd1234"}, num: 10, start: 30 )
+ *   .then(response);
+ * ```
+ *
+ * @param options - Options for the request like owner, folderId
+ * @param num - Option for the number of folders to be returned
+ * @param start - Option for start
+ * @returns A Promise that resolves with the folder's content.
+ */
+export function getFolderContent(
+  options: IFolderIdOptions,
+  num?: number,
+  start?: number
+): Promise<any> {
+  const url = `${getPortalUrl(options)}/content/users/${options.owner}/${
+    options.folderId
+  }`;
+
+  // merge pagination parameters
+  const requestOptions: IRequestOptions = {
+    httpMethod: "GET",
+    ...options,
+    params: {
+      ...options.params,
+      num: num || 10,
+      start: start || 1
+    }
+  };
+
+  return request(url, requestOptions);
 }

--- a/packages/arcgis-rest-portal/test/items/get.test.ts
+++ b/packages/arcgis-rest-portal/test/items/get.test.ts
@@ -14,7 +14,8 @@ import {
   getRelatedItems,
   getItemInfo,
   getItemMetadata,
-  getItemResource
+  getItemResource,
+  getFolderContent
 } from "../../src/items/get.js";
 
 import {
@@ -24,7 +25,8 @@ import {
   RelatedItemsResponse,
   ItemInfoResponse,
   ItemMetadataResponse,
-  ItemFormJsonResponse
+  ItemFormJsonResponse,
+  ItemSuccessResponse
 } from "../mocks/items/item.js";
 
 import { GetItemResourcesResponse } from "../mocks/items/resources.js";
@@ -596,6 +598,85 @@ describe("get", () => {
           );
           expect(options.method).toBe("POST");
           expect(options.body).toContain("f=json");
+          done();
+        })
+        .catch((e) => {
+          fail(e);
+        });
+    });
+
+    it("should return folder content for a user with default num and start", (done) => {
+      fetchMock.once("*", ItemSuccessResponse);
+
+      getFolderContent({
+        folderId: "testFolder",
+        owner: "testUser",
+        authentication: MOCK_USER_SESSION
+      })
+        .then((response) => {
+          expect(fetchMock.called()).toBe(true);
+          const [url, options] = fetchMock.lastCall("*");
+
+          expect(url).toBe(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/testUser/testFolder?f=json&num=10&start=1&token=fake-token"
+          );
+          expect(options.method).toBe("GET");
+          expect(response).toEqual(ItemSuccessResponse);
+          done();
+        })
+        .catch((e) => {
+          fail(e);
+        });
+    });
+
+    it("should return folder content for a user with custom num and start", (done) => {
+      fetchMock.once("*", ItemSuccessResponse);
+
+      getFolderContent(
+        {
+          folderId: "testFolder",
+          owner: "testUser",
+          authentication: MOCK_USER_SESSION
+        },
+        14,
+        3
+      )
+        .then((response) => {
+          expect(fetchMock.called()).toBe(true);
+          const [url, options] = fetchMock.lastCall("*");
+
+          expect(url).toBe(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/testUser/testFolder?f=json&num=14&start=3&token=fake-token"
+          );
+          expect(options.method).toBe("GET");
+          expect(response).toEqual(ItemSuccessResponse);
+          done();
+        })
+        .catch((e) => {
+          fail(e);
+        });
+    });
+
+    it("should return folder content for a user with custom num and default start", (done) => {
+      fetchMock.once("*", ItemSuccessResponse);
+
+      getFolderContent(
+        {
+          folderId: "testFolder",
+          owner: "testUser",
+          authentication: MOCK_USER_SESSION
+        },
+        14
+      )
+        .then((response) => {
+          expect(fetchMock.called()).toBe(true);
+          const [url, options] = fetchMock.lastCall("*");
+
+          expect(url).toBe(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/users/testUser/testFolder?f=json&num=14&start=1&token=fake-token"
+          );
+          expect(options.method).toBe("GET");
+          expect(response).toEqual(ItemSuccessResponse);
           done();
         })
         .catch((e) => {


### PR DESCRIPTION
Resolves #769.

This PR adds the getFolderContent() function, allowing users to fetch content within a particular folder via a GET request to the ArcGIS REST API. This function also follows the standard paging patterns used across the API, such as `num` and `start`, allowing for consistent pagination of folder contents.

**Changes**

- Implements `getFolderContent()` in `get.ts`.
- Adds unit tests in `get.test.ts` to verify correct API calls and responses.
- Contains documentation with usage examples.

**Testing**

- Ran npm test to confirm all tests pass.

Note: Open to feedback, especially on implementation details.