### PR TITLE
fix: add token property to IAuthenticationManager

### DIFF
--- a/packages/arcgis-rest-demographics/test/getGeography.test.ts
+++ b/packages/arcgis-rest-demographics/test/getGeography.test.ts
@@ -5,6 +5,7 @@ import fetchMock from "fetch-mock";
 import { getGeography } from "../src/getGeography.js";
 
 const MOCK_AUTH = {
+  token: "token",
   getToken() {
     return Promise.resolve("token");
   },

--- a/packages/arcgis-rest-demographics/test/queryDemographicData.test.ts
+++ b/packages/arcgis-rest-demographics/test/queryDemographicData.test.ts
@@ -5,6 +5,7 @@ import fetchMock from "fetch-mock";
 import { queryDemographicData } from "../src/queryDemographicData.js";
 
 const MOCK_AUTH = {
+  token: "token",
   getToken() {
     return Promise.resolve("token");
   },

--- a/packages/arcgis-rest-geocoding/test/bulk.test.ts
+++ b/packages/arcgis-rest-geocoding/test/bulk.test.ts
@@ -20,19 +20,21 @@ const addresses = [
   }
 ];
 
+const MOCK_AUTH = {
+  token: "token",
+  getToken() {
+    return Promise.resolve("token");
+  },
+  portal: "https://mapsdev.arcgis.com"
+};
+
 describe("geocode", () => {
   afterEach(() => {
     fetchMock.restore();
   });
+
   it("should make a bulk geocoding request, even with an unmatchable record", (done) => {
     fetchMock.once("*", GeocodeAddresses);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     bulkGeocode({ addresses, authentication: MOCK_AUTH })
       .then((response) => {
@@ -206,13 +208,6 @@ describe("geocode", () => {
 
   it("should support rawResponse", (done) => {
     fetchMock.once("*", GeocodeAddresses);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     bulkGeocode({ addresses, authentication: MOCK_AUTH, rawResponse: true })
       .then((response: any) => {

--- a/packages/arcgis-rest-portal/test/groups/get.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/get.test.ts
@@ -99,6 +99,7 @@ describe("groups", () => {
 
   describe("authenticted methods", () => {
     const MOCK_AUTH = {
+      token: "token",
       getToken() {
         return Promise.resolve("fake-token");
       },

--- a/packages/arcgis-rest-portal/test/groups/search.test.ts
+++ b/packages/arcgis-rest-portal/test/groups/search.test.ts
@@ -122,6 +122,7 @@ describe("groups", () => {
 
   describe("authenticted methods", () => {
     const MOCK_AUTH = {
+      token: "token",
       getToken() {
         return Promise.resolve("fake-token");
       },

--- a/packages/arcgis-rest-portal/test/users/search.test.ts
+++ b/packages/arcgis-rest-portal/test/users/search.test.ts
@@ -10,6 +10,7 @@ import { UserSearchResponse } from "../mocks/users/user-search.js";
 
 describe("users", () => {
   const MOCK_AUTH = {
+    token: "token",
     getToken() {
       return Promise.resolve("fake-token");
     },

--- a/packages/arcgis-rest-portal/test/util/determine-username.test.ts
+++ b/packages/arcgis-rest-portal/test/util/determine-username.test.ts
@@ -16,6 +16,7 @@ describe("determineUsername", () => {
     const requestOptions = {
       username: "c@sey",
       authentication: {
+        token: "fake",
         portal: "https://bar.com/arcgis/sharing/rest",
         username: "bob",
         getUsername: function () {
@@ -34,6 +35,7 @@ describe("determineUsername", () => {
   it("should fallback to the username in the requestOptions authentication", () => {
     const requestOptions = {
       authentication: {
+        token: "fake",
         portal: "https://bar.com/arcgis/sharing/rest",
         username: "bob",
         getUsername: function () {
@@ -52,6 +54,7 @@ describe("determineUsername", () => {
   it("should fallback to getUsername() in the requestOptions authentication", () => {
     const requestOptions = {
       authentication: {
+        token: "fake",
         portal: "https://bar.com/arcgis/sharing/rest",
         getUsername: function () {
           return Promise.resolve("jsmith");

--- a/packages/arcgis-rest-portal/test/util/get-portal-settings.test.ts
+++ b/packages/arcgis-rest-portal/test/util/get-portal-settings.test.ts
@@ -13,6 +13,7 @@ describe("portal", () => {
   describe("getPortalSettings", () => {
     // setup an authmgr to use in all these tests
     const MOCK_AUTH = {
+      token: "fake-token",
       getToken() {
         return Promise.resolve("fake-token");
       },

--- a/packages/arcgis-rest-portal/test/util/get-portal-url.test.ts
+++ b/packages/arcgis-rest-portal/test/util/get-portal-url.test.ts
@@ -11,6 +11,7 @@ describe("getPortalUrl", () => {
   it("should use the portal from authorization if passed", () => {
     const requestOptions = {
       authentication: {
+        token: "token",
         portal: "https://foo.com/arcgis/sharing/rest",
         getToken() {
           return Promise.resolve("fake");
@@ -24,6 +25,7 @@ describe("getPortalUrl", () => {
   it("should use the portal in the requestOptions if passed", () => {
     const requestOptions = {
       authentication: {
+        token: "token",
         portal: "https://foo.com/arcgis/sharing/rest",
         getToken() {
           return Promise.resolve("fake");

--- a/packages/arcgis-rest-portal/test/util/portal.test.ts
+++ b/packages/arcgis-rest-portal/test/util/portal.test.ts
@@ -10,18 +10,20 @@ import {
   SubscriptionInfoResponse
 } from "./../mocks/portal/response.js";
 
+// setup an authmgr to use in all these tests
+const MOCK_AUTH = {
+  token: "fake-token",
+  getToken() {
+    return Promise.resolve("fake-token");
+  },
+  portal: "https://myorg.maps.arcgis.com/sharing/rest"
+};
+
 describe("portal", () => {
   afterEach(() => {
     fetchMock.restore();
   });
   describe("getPortal", () => {
-    // setup an authmgr to use in all these tests
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
-      portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
     const MOCK_REQOPTS = {
       authentication: MOCK_AUTH
     };
@@ -60,13 +62,6 @@ describe("portal", () => {
     });
   });
   describe("getSelf", () => {
-    // setup an authmgr to use in all these tests
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
-      portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
     const MOCK_REQOPTS = {
       authentication: MOCK_AUTH
     };
@@ -90,13 +85,6 @@ describe("portal", () => {
   });
 
   describe("getSubscriptionInfo", () => {
-    // setup an authmgr to use in all these tests
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("fake-token");
-      },
-      portal: "https://myorg.maps.arcgis.com/sharing/rest"
-    };
     const MOCK_REQOPTS = {
       authentication: MOCK_AUTH
     };

--- a/packages/arcgis-rest-request/src/ApiKeyManager.ts
+++ b/packages/arcgis-rest-request/src/ApiKeyManager.ts
@@ -36,6 +36,13 @@ export class ApiKeyManager
   private key: string;
 
   /**
+   * The current API key as a string.
+   */
+  get token() {
+    return this.key;
+  }
+
+  /**
    * The preferred method for creating an instance of `ApiKeyManager`.
    */
   public static fromKey(apiKey: string | IApiKeyOptions) {

--- a/packages/arcgis-rest-request/src/ApplicationCredentialsManager.ts
+++ b/packages/arcgis-rest-request/src/ApplicationCredentialsManager.ts
@@ -66,9 +66,16 @@ export class ApplicationCredentialsManager
   public portal: string;
   private clientId: string;
   private clientSecret: string;
-  private token: string;
+  private _token: string;
   private expires: Date;
   private duration: number;
+
+  /**
+   * The current token. This may be invalid, expired or `undefined`. To guarantee a valid token, use the {@linkcode ApplicationCredentialsManager.getToken} method instead.
+   */
+  public get token() {
+    return this._token;
+  }
 
   /**
    * Preferred method for creating an `ApplicationCredentialsManager`
@@ -89,7 +96,7 @@ export class ApplicationCredentialsManager
     super(options);
     this.clientId = options.clientId;
     this.clientSecret = options.clientSecret;
-    this.token = options.token;
+    this._token = options.token;
     this.expires = options.expires;
     this.portal = options.portal || "https://www.arcgis.com/sharing/rest";
     this.duration = options.duration || 7200;
@@ -127,7 +134,7 @@ export class ApplicationCredentialsManager
     return fetchToken(`${this.portal}/oauth2/token/`, options)
       .then((response) => {
         this._pendingTokenRequest = null;
-        this.token = response.token;
+        this._token = response.token;
         this.expires = response.expires;
         return response.token;
       })

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -267,6 +267,7 @@ export function internalRequest(
 
     authentication = {
       portal: "https://www.arcgis.com/sharing/rest",
+      token: rawToken,
       getToken: () => {
         return Promise.resolve(rawToken);
       }

--- a/packages/arcgis-rest-request/src/utils/IAuthenticationManager.ts
+++ b/packages/arcgis-rest-request/src/utils/IAuthenticationManager.ts
@@ -21,6 +21,11 @@ export interface IAuthenticationManager {
   portal: string;
 
   /**
+   * Getter for consistency between ArcGISIdentityManager and older ArcGIS REST JS verisons. This token may be invalid, expired or `undefined`. To guarentee a valid token, use the {@linkcode IAuthenticationManager.getToken} method instead.
+   */
+  get token(): string;
+
+  /**
    * Returns the proper token for a given URL and request options.
    * @param url The requested URL.
    * @param requestOptions the requests options.

--- a/packages/arcgis-rest-request/src/utils/IAuthenticationManager.ts
+++ b/packages/arcgis-rest-request/src/utils/IAuthenticationManager.ts
@@ -23,7 +23,7 @@ export interface IAuthenticationManager {
   /**
    * Getter for consistency between ArcGISIdentityManager and older ArcGIS REST JS verisons. This token may be invalid, expired or `undefined`. To guarentee a valid token, use the {@linkcode IAuthenticationManager.getToken} method instead.
    */
-  get token(): string;
+  token: string;
 
   /**
    * Returns the proper token for a given URL and request options.

--- a/packages/arcgis-rest-request/test/ApiKey.test.ts
+++ b/packages/arcgis-rest-request/test/ApiKey.test.ts
@@ -132,5 +132,15 @@ describe("ApiKeyManager", () => {
           fail(e);
         });
     });
+
+    describe(".token", () => {
+      it("should return the token", () => {
+        const session = ApiKeyManager.fromKey({
+          key: "token"
+        });
+
+        expect(session.token).toEqual("token");
+      });
+    });
   });
 });

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -25,6 +25,14 @@ import {
   isNode
 } from "../../../scripts/test-helpers.js";
 
+const MOCK_AUTH = {
+  token: "token",
+  portal: "https://www.arcgis.com/sharing/rest",
+  getToken() {
+    return Promise.resolve("token");
+  }
+};
+
 describe("request()", () => {
   afterEach(() => {
     fetchMock.restore();
@@ -159,13 +167,6 @@ describe("request()", () => {
   it("should use the `authentication` option to authenticate a request", (done) => {
     fetchMock.once("*", WebMapAsText);
 
-    const MOCK_AUTH = {
-      portal: "https://www.arcgis.com/sharing/rest",
-      getToken() {
-        return Promise.resolve("token");
-      }
-    };
-
     request(
       "https://www.arcgis.com/sharing/rest/content/items/43a8e51789044d9480a20089a84129ad/data",
       {
@@ -188,13 +189,6 @@ describe("request()", () => {
 
   it("should hide token in POST body in browser environments otherwise it should hide token in `X-ESRI_AUTHORIZATION` header in Node", (done) => {
     fetchMock.once("*", SharingRestInfo);
-
-    const MOCK_AUTH = {
-      portal: "https://www.arcgis.com/sharing/rest",
-      getToken() {
-        return Promise.resolve("token");
-      }
-    };
 
     request("https://www.arcgis.com/sharing/rest/info", {
       authentication: MOCK_AUTH,
@@ -270,13 +264,6 @@ describe("request()", () => {
   it("should switch from GET to POST when url is longer than specified and replace token in header with token in POST body", (done) => {
     fetchMock.once("*", SharingRestInfo);
     const restInfoUrl = "https://www.arcgis.com/sharing/rest/info";
-
-    const MOCK_AUTH = {
-      portal: "https://www.arcgis.com/sharing/rest",
-      getToken() {
-        return Promise.resolve("token");
-      }
-    };
 
     request(restInfoUrl, {
       authentication: MOCK_AUTH,
@@ -458,13 +445,6 @@ describe("request()", () => {
     console.warn = jasmine.createSpy().and.callFake(() => {
       return;
     });
-
-    const MOCK_AUTH = {
-      portal: "https://www.arcgis.com/sharing/rest",
-      getToken() {
-        return Promise.resolve("token");
-      }
-    };
 
     setDefaultRequestOptions({
       authentication: MOCK_AUTH

--- a/packages/arcgis-rest-request/test/utils/ArcGISAuthError.test.ts
+++ b/packages/arcgis-rest-request/test/utils/ArcGISAuthError.test.ts
@@ -46,10 +46,12 @@ describe("ArcGISRequestError", () => {
 
   describe("retry", () => {
     const MockAuth: {
+      token: string;
       portal: string;
       getToken: any;
       retryHandler: IRetryAuthError;
     } = {
+      token: "token",
       portal: "https://www.arcgis.com/sharing/rest",
       getToken() {
         return Promise.resolve("token");

--- a/packages/arcgis-rest-routing/test/closestFacility.test.ts
+++ b/packages/arcgis-rest-routing/test/closestFacility.test.ts
@@ -168,6 +168,14 @@ const facilitiesUrl = {
 // const customRoutingUrl =
 //   "https://foo.com/ArcGIS/rest/services/Network/USA/NAServer/";
 
+const MOCK_AUTH = {
+  token: "token",
+  getToken() {
+    return Promise.resolve("token");
+  },
+  portal: "https://mapsdev.arcgis.com"
+};
+
 describe("closestFacility", () => {
   afterEach(() => {
     fetchMock.restore();
@@ -191,13 +199,6 @@ describe("closestFacility", () => {
 
   it("should make a simple closestFacility request (Point Arrays)", (done) => {
     fetchMock.once("*", ClosestFacility);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     closestFacility({
       incidents,
@@ -237,13 +238,6 @@ describe("closestFacility", () => {
   it("should pass default values", (done) => {
     fetchMock.once("*", ClosestFacility);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     closestFacility({
       incidents,
       facilities,
@@ -273,13 +267,6 @@ describe("closestFacility", () => {
 
   it("should allow default values to be overridden", (done) => {
     fetchMock.once("*", ClosestFacility);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     closestFacility({
       incidents,
@@ -314,13 +301,6 @@ describe("closestFacility", () => {
   it("should make a simple closestFacility request (array of objects - lat/lon)", (done) => {
     fetchMock.once("*", ClosestFacility);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     closestFacility({
       incidents: incidentsLatLong,
       facilities: facilitiesLatLong,
@@ -347,13 +327,6 @@ describe("closestFacility", () => {
 
   it("should make a simple closestFacility request (array of objects - latitude/longitude)", (done) => {
     fetchMock.once("*", ClosestFacility);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     closestFacility({
       incidents: incidentsLatitudeLongitude,
@@ -382,13 +355,6 @@ describe("closestFacility", () => {
   it("should make a simple closestFacility request (array of IPoint)", (done) => {
     fetchMock.once("*", ClosestFacility);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     closestFacility({
       incidents: incidentsPoint,
       facilities: facilitiesPoint,
@@ -415,13 +381,6 @@ describe("closestFacility", () => {
 
   it("should make a simple closestFacility request (FeatureSet)", (done) => {
     fetchMock.once("*", ClosestFacility);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     closestFacility({
       incidents: incidentsFeatureSet,
@@ -450,13 +409,6 @@ describe("closestFacility", () => {
   it("should make a simple closestFacility request (JSON with url)", (done) => {
     fetchMock.once("*", ClosestFacility);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     closestFacility({
       incidents: incidentsUrl,
       facilities: facilitiesUrl,
@@ -482,13 +434,6 @@ describe("closestFacility", () => {
   it("should include proper travelDirection", (done) => {
     fetchMock.once("*", ClosestFacility);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     closestFacility({
       incidents: incidentsPoint,
       facilities: facilitiesPoint,
@@ -511,13 +456,6 @@ describe("closestFacility", () => {
 
   it("should include proper travelDirection", (done) => {
     fetchMock.once("*", ClosestFacility);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     closestFacility({
       incidents: incidentsPoint,
@@ -542,13 +480,6 @@ describe("closestFacility", () => {
   it("should pass point barriers (array of IPoint)", (done) => {
     fetchMock.once("*", ClosestFacility);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     closestFacility({
       incidents: incidentsPoint,
       facilities: facilitiesPoint,
@@ -572,13 +503,6 @@ describe("closestFacility", () => {
   it("should pass point barriers (FeatureSet)", (done) => {
     fetchMock.once("*", ClosestFacility);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     closestFacility({
       incidents: incidentsPoint,
       facilities: facilitiesPoint,
@@ -601,13 +525,6 @@ describe("closestFacility", () => {
 
   it("should pass polyline barriers", (done) => {
     fetchMock.once("*", ClosestFacility);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     closestFacility({
       incidents: incidentsPoint,
@@ -634,13 +551,6 @@ describe("closestFacility", () => {
   it("should pass polygon barriers", (done) => {
     fetchMock.once("*", ClosestFacility);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     closestFacility({
       incidents: incidentsPoint,
       facilities: facilitiesPoint,
@@ -666,13 +576,6 @@ describe("closestFacility", () => {
   it("should include routes.geoJson in the return", (done) => {
     fetchMock.once("*", ClosestFacility);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     closestFacility({
       incidents: incidentsPoint,
       facilities: facilitiesPoint,
@@ -697,13 +600,6 @@ describe("closestFacility", () => {
 
   it("should not include routes.geoJson in the return for non-4326", (done) => {
     fetchMock.once("*", ClosestFacilityWebMercator);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     closestFacility({
       incidents: incidentsPoint,

--- a/packages/arcgis-rest-routing/test/originDestinationMatrix.test.ts
+++ b/packages/arcgis-rest-routing/test/originDestinationMatrix.test.ts
@@ -152,6 +152,14 @@ const destinationsFeatureSet: IFeatureSet = {
   ]
 };
 
+const MOCK_AUTH = {
+  token: "token",
+  getToken() {
+    return Promise.resolve("token");
+  },
+  portal: "https://mapsdev.arcgis.com"
+};
+
 describe("originDestinationMatrix", () => {
   afterEach(() => {
     fetchMock.restore();
@@ -174,13 +182,6 @@ describe("originDestinationMatrix", () => {
 
   it("should make a simple originDestinationMatrix request (Point Arrays)", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     originDestinationMatrix({
       origins,
@@ -223,13 +224,6 @@ describe("originDestinationMatrix", () => {
   it("should pass default values", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     originDestinationMatrix({
       origins,
       destinations,
@@ -256,13 +250,6 @@ describe("originDestinationMatrix", () => {
 
   it("should allow default values to be overridden", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     originDestinationMatrix({
       origins,
@@ -296,13 +283,6 @@ describe("originDestinationMatrix", () => {
   it("should make a originDestinationMatrix request with a custom endpoint", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     originDestinationMatrix({
       origins,
       destinations,
@@ -325,13 +305,6 @@ describe("originDestinationMatrix", () => {
 
   it("should make a simple originDestinationMatrix request (array of objects - lat/lon)", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     originDestinationMatrix({
       origins: originsLatLong,
@@ -359,13 +332,6 @@ describe("originDestinationMatrix", () => {
   it("should make a simple originDestinationMatrix request (array of objects - latitude/longitude)", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     originDestinationMatrix({
       origins: originsLatitudeLongitude,
       destinations: destinationsLatitudeLongitude,
@@ -391,13 +357,6 @@ describe("originDestinationMatrix", () => {
 
   it("should make a simple originDestinationMatrix request (array of IPoint)", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     originDestinationMatrix({
       origins: originsPoint,
@@ -425,13 +384,6 @@ describe("originDestinationMatrix", () => {
   it("should make a simple originDestinationMatrix request (FeatureSet)", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     originDestinationMatrix({
       origins: originsFeatureSet,
       destinations: destinationsFeatureSet,
@@ -458,13 +410,6 @@ describe("originDestinationMatrix", () => {
   it("should include proper outputType (esriNAODOutputSparseMatrix)", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     originDestinationMatrix({
       origins,
       destinations,
@@ -485,13 +430,6 @@ describe("originDestinationMatrix", () => {
 
   it("should include proper outputType (esriNAODOutputStraightLines)", (done) => {
     fetchMock.once("*", OriginDestinationMatrix_esriNAODOutputStraightLines);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     originDestinationMatrix({
       origins,
@@ -516,13 +454,6 @@ describe("originDestinationMatrix", () => {
   it("should include proper outputType (esriNAODOutputNoLines)", (done) => {
     fetchMock.once("*", OriginDestinationMatrix_esriNAODOutputNoLines);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     originDestinationMatrix({
       origins,
       destinations,
@@ -543,13 +474,6 @@ describe("originDestinationMatrix", () => {
 
   it("should pass point barriers (array of IPoint)", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     originDestinationMatrix({
       origins,
@@ -573,13 +497,6 @@ describe("originDestinationMatrix", () => {
   it("should pass point barriers (FeatureSet)", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     originDestinationMatrix({
       origins,
       destinations,
@@ -601,13 +518,6 @@ describe("originDestinationMatrix", () => {
 
   it("should pass polyline barriers", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     originDestinationMatrix({
       origins,
@@ -633,13 +543,6 @@ describe("originDestinationMatrix", () => {
   it("should pass polygon barriers", (done) => {
     fetchMock.once("*", OriginDestinationMatrix);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     originDestinationMatrix({
       origins,
       destinations,
@@ -663,13 +566,6 @@ describe("originDestinationMatrix", () => {
 
   it("should include geoJson for any geometries in the return", (done) => {
     fetchMock.once("*", OriginDestinationMatrix_AllBarrierTypes);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     originDestinationMatrix({
       origins,
@@ -749,13 +645,6 @@ describe("originDestinationMatrix", () => {
 
   it("should not include routes.geoJson in the return for non-4326", (done) => {
     fetchMock.once("*", OriginDestinationMatrix_AllBarrierTypes_WebMercator);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     originDestinationMatrix({
       origins,

--- a/packages/arcgis-rest-routing/test/serviceArea.test.ts
+++ b/packages/arcgis-rest-routing/test/serviceArea.test.ts
@@ -104,6 +104,14 @@ const facilitiesFeatureSet: IFeatureSet = {
 // const customRoutingUrl =
 //   "https://foo.com/ArcGIS/rest/services/Network/USA/NAServer/";
 
+const MOCK_AUTH = {
+  token: "token",
+  getToken() {
+    return Promise.resolve("token");
+  },
+  portal: "https://mapsdev.arcgis.com"
+};
+
 describe("serviceArea", () => {
   afterEach(() => {
     fetchMock.restore();
@@ -125,13 +133,6 @@ describe("serviceArea", () => {
 
   it("should make a simple serviceArea request (Point Arrays)", (done) => {
     fetchMock.once("*", ServiceArea);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     serviceArea({
       facilities,
@@ -166,13 +167,6 @@ describe("serviceArea", () => {
   it("should pass default values", (done) => {
     fetchMock.once("*", ServiceArea);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     serviceArea({
       facilities,
       params: {
@@ -198,13 +192,6 @@ describe("serviceArea", () => {
 
   it("should allow default values to be overridden", (done) => {
     fetchMock.once("*", ServiceArea);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     serviceArea({
       facilities,
@@ -233,13 +220,6 @@ describe("serviceArea", () => {
   it("should make a simple serviceArea request (array of objects - lat/lon)", (done) => {
     fetchMock.once("*", ServiceArea);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     serviceArea({
       facilities: facilitiesLatLong,
       authentication: MOCK_AUTH
@@ -261,13 +241,6 @@ describe("serviceArea", () => {
 
   it("should make a simple serviceArea request (array of objects - latitude/longitude)", (done) => {
     fetchMock.once("*", ServiceArea);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     serviceArea({
       facilities: facilitiesLatitudeLongitude,
@@ -291,13 +264,6 @@ describe("serviceArea", () => {
   it("should make a simple serviceArea request (array of IPoint)", (done) => {
     fetchMock.once("*", ServiceArea);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     serviceArea({
       facilities: facilitiesPoint,
       authentication: MOCK_AUTH
@@ -319,13 +285,6 @@ describe("serviceArea", () => {
 
   it("should make a simple serviceArea request (FeatureSet)", (done) => {
     fetchMock.once("*", ServiceArea);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     serviceArea({
       facilities: facilitiesFeatureSet,
@@ -349,13 +308,6 @@ describe("serviceArea", () => {
   it("should include proper travelDirection", (done) => {
     fetchMock.once("*", ServiceArea);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     serviceArea({
       facilities: facilitiesPoint,
       travelDirection: "facilitiesToIncidents",
@@ -376,13 +328,6 @@ describe("serviceArea", () => {
 
   it("should include proper travelDirection", (done) => {
     fetchMock.once("*", ServiceArea);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     serviceArea({
       facilities: facilitiesPoint,
@@ -405,13 +350,6 @@ describe("serviceArea", () => {
   it("should pass point barriers (array of IPoint)", (done) => {
     fetchMock.once("*", ServiceArea);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     serviceArea({
       facilities: facilitiesPoint,
       barriers,
@@ -433,13 +371,6 @@ describe("serviceArea", () => {
   it("should pass point barriers (FeatureSet)", (done) => {
     fetchMock.once("*", ServiceArea);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     serviceArea({
       facilities: facilitiesPoint,
       barriers: barriersFeatureSet,
@@ -460,13 +391,6 @@ describe("serviceArea", () => {
 
   it("should pass polyline barriers", (done) => {
     fetchMock.once("*", ServiceArea);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     serviceArea({
       facilities: facilitiesPoint,
@@ -491,13 +415,6 @@ describe("serviceArea", () => {
   it("should pass polygon barriers", (done) => {
     fetchMock.once("*", ServiceArea);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     serviceArea({
       facilities: facilitiesPoint,
       polygonBarriers,
@@ -521,13 +438,6 @@ describe("serviceArea", () => {
   it("should not include routes.fieldAliases in the return", (done) => {
     fetchMock.once("*", ServiceArea);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     serviceArea({
       facilities: facilitiesPoint,
       authentication: MOCK_AUTH
@@ -545,13 +455,6 @@ describe("serviceArea", () => {
 
   it("should include routes.geoJson in the return", (done) => {
     fetchMock.once("*", ServiceArea);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     serviceArea({
       facilities: facilitiesPoint,
@@ -574,13 +477,6 @@ describe("serviceArea", () => {
 
   it("should not include routes.geoJson in the return for non-4326", (done) => {
     fetchMock.once("*", ServiceAreaWebMercator);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     serviceArea({
       facilities: facilitiesPoint,

--- a/packages/arcgis-rest-routing/test/solveRoute.test.ts
+++ b/packages/arcgis-rest-routing/test/solveRoute.test.ts
@@ -124,6 +124,14 @@ const stopsFeatureSet: IFeatureSet = {
 // const customRoutingUrl =
 //   "https://foo.com/ArcGIS/rest/services/Network/USA/NAServer/";
 
+const MOCK_AUTH = {
+  token: "token",
+  getToken() {
+    return Promise.resolve("token");
+  },
+  portal: "https://mapsdev.arcgis.com"
+};
+
 describe("solveRoute", () => {
   afterEach(() => {
     fetchMock.restore();
@@ -145,13 +153,6 @@ describe("solveRoute", () => {
 
   it("should make a simple solveRoute request (array of stops)", (done) => {
     fetchMock.once("*", Solve);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     solveRoute({ stops, authentication: MOCK_AUTH })
       .then((response) => {
@@ -183,13 +184,6 @@ describe("solveRoute", () => {
   it("should make a simple solveRoute request (array of 3d stops)", (done) => {
     fetchMock.once("*", Solve);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     solveRoute({ stops: stops3, authentication: MOCK_AUTH })
       .then((response) => {
         expect(fetchMock.called()).toEqual(true);
@@ -219,13 +213,6 @@ describe("solveRoute", () => {
 
   it("should make a simple solveRoute request (array of objects - lat/lon)", (done) => {
     fetchMock.once("*", Solve);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     solveRoute({
       stops: stopsObjectsLatLong,
@@ -260,13 +247,6 @@ describe("solveRoute", () => {
   it("should make a simple solveRoute request (array of objects - 3d lat/lon)", (done) => {
     fetchMock.once("*", Solve);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     solveRoute({
       stops: stopsObjectsLatLong3,
       authentication: MOCK_AUTH
@@ -300,13 +280,6 @@ describe("solveRoute", () => {
   it("should make a simple solveRoute request (array of objects - latitude/longitude)", (done) => {
     fetchMock.once("*", Solve);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     solveRoute({
       stops: stopsObjectsLatitudeLongitude,
       authentication: MOCK_AUTH
@@ -339,13 +312,6 @@ describe("solveRoute", () => {
 
   it("should make a simple solveRoute request (array of objects - 3d latitude/longitude)", (done) => {
     fetchMock.once("*", Solve);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     solveRoute({
       stops: stopsObjectsLatitudeLongitude3,
@@ -380,13 +346,6 @@ describe("solveRoute", () => {
   it("should make a simple solveRoute request (array of objects - latitude/longitude)", (done) => {
     fetchMock.once("*", Solve);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     solveRoute({
       stops: stopsObjectsLatitudeLongitude,
       authentication: MOCK_AUTH
@@ -419,13 +378,6 @@ describe("solveRoute", () => {
 
   it("should make a simple solveRoute request (array of objects - 3d latitude/longitude)", (done) => {
     fetchMock.once("*", Solve);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     solveRoute({
       stops: stopsObjectsLatitudeLongitude3,
@@ -460,13 +412,6 @@ describe("solveRoute", () => {
   it("should make a simple solveRoute request (array of IPoint)", (done) => {
     fetchMock.once("*", Solve);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     solveRoute({
       stops: stopsObjectsPoint,
       authentication: MOCK_AUTH
@@ -499,13 +444,6 @@ describe("solveRoute", () => {
 
   it("should make a simple solveRoute request (array of 3d IPoint)", (done) => {
     fetchMock.once("*", Solve);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     solveRoute({
       stops: stopsObjectsPoint3,
@@ -540,13 +478,6 @@ describe("solveRoute", () => {
   it("should make a simple solveRoute request (FeatureSet)", (done) => {
     fetchMock.once("*", Solve);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     solveRoute({
       stops: stopsFeatureSet,
       authentication: MOCK_AUTH
@@ -577,13 +508,6 @@ describe("solveRoute", () => {
   it("should transform compressed geometry into geometry", (done) => {
     fetchMock.once("*", Solve);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     solveRoute({
       stops: stopsObjectsPoint,
       authentication: MOCK_AUTH
@@ -602,13 +526,6 @@ describe("solveRoute", () => {
 
   it("should not fail when no directions are returned", (done) => {
     fetchMock.once("*", SolveNoDirections);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     solveRoute({
       stops: stopsObjectsPoint,
@@ -630,13 +547,6 @@ describe("solveRoute", () => {
   it("should include routes.geoJson in the return", (done) => {
     fetchMock.once("*", Solve);
 
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
-
     solveRoute({
       stops: stopsObjectsPoint,
       authentication: MOCK_AUTH
@@ -654,13 +564,6 @@ describe("solveRoute", () => {
 
   it("should not include routes.geoJson in the return for non-4326", (done) => {
     fetchMock.once("*", SolveWebMercator);
-
-    const MOCK_AUTH = {
-      getToken() {
-        return Promise.resolve("token");
-      },
-      portal: "https://mapsdev.arcgis.com"
-    };
 
     solveRoute({
       stops: stopsObjectsPoint,


### PR DESCRIPTION
This should resolve the issues in https://github.com/Esri/arcgis-rest-js/issues/1209 by adding the `token` getter back to `IAuthenticationManager`.`IUserAuthe