### PR TITLE
docs(arcgis-rest-portal): update incorrect documentation for getUserMembership()

### DIFF
--- a/packages/arcgis-rest-portal/src/sharing/helpers.ts
+++ b/packages/arcgis-rest-portal/src/sharing/helpers.ts
@@ -68,7 +68,7 @@ export function isOrgAdmin(
  * If you have the group object, check the `userMembership.memberType` property instead of calling this method.
  *
  * @param requestOptions
- * @returns A Promise that resolves with "owner" | "admin" | "member" | "nonmember"
+ * @returns A Promise that resolves with "owner" | "admin" | "member" | "none"
  */
 export function getUserMembership(
   requestOptions: IGroupSharingOptions

--- a/packages/arcgis-rest-portal/test/sharing/helpers.test.ts
+++ b/packages/arcgis-rest-portal/test/sharing/helpers.test.ts
@@ -15,7 +15,7 @@ describe("sharing helpers ::", () => {
     fetchMock.restore();
   });
   describe("getUserMembership ::", () => {
-    it("should return nonmember if group could not be fetched", (done) => {
+    it("should return none if group could not be fetched", (done) => {
       fetchMock.once(
         "https://myorg.maps.arcgis.com/sharing/rest/community/groups/tb6?f=json&token=fake-token",
         GroupNoAccessResponse


### PR DESCRIPTION
Resoles #1197.

This PR updates the documentation for the `getUserMembership()` function. The previous docs incorrectly suggested that the function returns a `Promise` resolving to the `GroupMembership` value `"nonmember"`, when actually it returns `"none"`, per the [GroupMembership documentation](https://developers.arcgis.com/arcgis-rest-js/api-reference/arcgis-rest-portal/GroupMembership/).

#### Changes
- Updated the return value description in the `getUserMembership()` documentation in `helpers.ts`, replacing `nonmember` with `none`.
- Updated corresponding comments in `helpers.test.ts`.

#### Testing
- Ran `npm test` to confirm all tests pass.