### PR TITLE
feat(arcgis-rest-portal): require `start` and `num` params

### DIFF
--- a/packages/arcgis-rest-portal/src/items/content.ts
+++ b/packages/arcgis-rest-portal/src/items/content.ts
@@ -43,12 +43,14 @@ export interface IUserContentResponse extends IPagedResponse {
 export const getUserContent = (
   requestOptions: IUserContentRequestOptions
 ): Promise<IUserContentResponse> => {
-  const {
-    folderId: folder,
-    start = 1,
-    num = 10,
-    authentication
-  } = requestOptions;
+  const { folderId: folder, start, num, authentication } = requestOptions;
+
+  if (typeof start !== "number" || typeof num !== "number") {
+    return Promise.reject(
+      new Error("Both 'start' and 'num' are required for getUserContent.")
+    );
+  }
+
   const suffix = folder ? `/${folder}` : "";
 
   return determineOwner(requestOptions)

--- a/packages/arcgis-rest-portal/test/items/content.test.ts
+++ b/packages/arcgis-rest-portal/test/items/content.test.ts
@@ -65,7 +65,7 @@ describe("getContent", () => {
       ]
     };
 
-    it("should get the user content defaulting the start and num parameters", (done) => {
+    it("should throw an error if start or num parameters are not provided", (done) => {
       fetchMock.once("*", mockResponse);
 
       const requestOptions: IUserContentRequestOptions = {
@@ -75,15 +75,14 @@ describe("getContent", () => {
 
       getUserContent(requestOptions)
         .then((response) => {
-          expect(fetchMock.called()).toEqual(true);
-          const [url, options] = fetchMock.lastCall("*");
-          expect(url).toEqual(
-            `https://myorg.maps.arcgis.com/sharing/rest/content/users/${requestOptions.owner}?f=json&start=1&num=10&token=fake-token`
-          );
-          done();
+          fail("Expected function to throw an error, but it resolved");
         })
         .catch((e) => {
-          fail(e);
+          expect(e).toBeDefined();
+          expect(e.message).toBe(
+            "Both 'start' and 'num' are required for getUserContent."
+          );
+          done();
         });
     });
 


### PR DESCRIPTION
Resolves #853.

This PR introduces a runtime check to ensure that the `getUserContent()` function aligns with the breaking change in the ArcGIS REST API (v9.2), which now requires pagination parameters. The parameters `start` and `num` are now required to run the function, removing defaults.

#### Changes
- Added a runtime check that checks whether `start` and `num` parameters are present in `content.ts`. An error is thrown if either is missing.
- Removed previous unit test in `content.test.ts` that verified defaulting of `start` and `num`.
- Added unit test in `content.test.ts` to verify the function throws when `start` and `num` parameters are absent.

#### Testing
- Ran `npm test` to confirm all tests pass.