### PR TITLE
Add node 22 to tests

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [18, 20]
+        node: [18, 20, 22]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18, 20]
+        node: [18, 20, 22]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Node 22 is LTS right now.

https://nodejs.org/en/about/previous-releases

![image](https://github.com/user-attachments/assets/f2893614-ea58-40a2-8ce1-7b17a6ae8250)
