### PR TITLE
feat(arcgis-rest-request): add option to override request function

### DIFF
--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -2,6 +2,8 @@ import { HTTPMethods } from "./HTTPMethods.js";
 import { IParams } from "./IParams.js";
 import { IAuthenticationManager } from "./IAuthenticationManager.js";
 
+// NOTE: the `requestOptionsKeys` array in ./append-custom-params.ts
+// must be kept in sync with this interface
 /**
  * Options for the `request()` method.
  */

--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -62,4 +62,19 @@ export interface IRequestOptions {
    * Suppress any ArcGIS REST JS related warnings for this request.
    */
   suppressWarnings?: boolean;
+
+  /**
+   * Override the default function for making the request. This is mainly useful for testing purposes (i.e. so you can pass in a spy).
+   * @param requestOptions
+   * @returns
+   */
+  request?: (
+    url: string,
+    requestOptions: InternalRequestOptions
+  ) => Promise<any>;
 }
+
+/**
+ * Options for the function that will be making the actual request.
+ */
+export type InternalRequestOptions = Omit<IRequestOptions, "request">;

--- a/packages/arcgis-rest-request/src/utils/append-custom-params.ts
+++ b/packages/arcgis-rest-request/src/utils/append-custom-params.ts
@@ -23,7 +23,8 @@ export function appendCustomParams<T extends IRequestOptions>(
     "maxUrlLength",
     "headers",
     "signal",
-    "suppressWarnings"
+    "suppressWarnings",
+    "request"
   ];
 
   const options: T = {

--- a/packages/arcgis-rest-request/src/utils/append-custom-params.ts
+++ b/packages/arcgis-rest-request/src/utils/append-custom-params.ts
@@ -11,15 +11,19 @@ export function appendCustomParams<T extends IRequestOptions>(
   keys: Array<keyof T>,
   baseOptions?: Partial<T>
 ): IRequestOptions {
+  // NOTE: this must be kept in sync with the keys in IRequestOptions
   const requestOptionsKeys = [
     "params",
     "httpMethod",
     "rawResponse",
     "authentication",
+    "hideToken",
     "portal",
-    "fetch",
+    "credentials",
     "maxUrlLength",
-    "headers"
+    "headers",
+    "signal",
+    "suppressWarnings"
   ];
 
   const options: T = {

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -779,4 +779,25 @@ describe("request()", () => {
       });
     });
   });
+
+  it("should use a passed in request function", (done) => {
+    const url =
+      "https://www.arcgis.com/sharing/rest/content/items/43a8e51789044d9480a20089a84129ad/data";
+    const options = {
+      httpMethod: "GET",
+      params: { f: "text" }
+    } as const;
+    const requestSpy = jasmine
+      .createSpy()
+      .and.returnValue(Promise.resolve(WebMapAsText));
+    request(url, { ...options, request: requestSpy })
+      .then(() => {
+        expect(requestSpy.calls.count()).toBe(1);
+        expect(requestSpy.calls.argsFor(0)).toEqual([url, options]);
+        done();
+      })
+      .catch((e) => {
+        fail(e);
+      });
+  });
 });


### PR DESCRIPTION
Resolves the issue raised in https://github.com/Esri/arcgis-rest-js/pull/904#issuecomment-911938760 by adding a `request` option that allows users to override the implementation of `request()` as @patrickarlt suggested.

~~NOTE this is based on the branch from #1212 b/c I need the changes in that branch in order to test locally.~~
