### PR TITLE
fix(arcgis-rest-request): appendCustomParams strips valid options

### DIFF
--- a/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
+++ b/packages/arcgis-rest-request/src/utils/IRequestOptions.ts
@@ -2,6 +2,8 @@ import { HTTPMethods } from "./HTTPMethods.js";
 import { IParams } from "./IParams.js";
 import { IAuthenticationManager } from "./IAuthenticationManager.js";
 
+// NOTE: the `requestOptionsKeys` array in ./append-custom-params.ts
+// must be kept in sync with this interface
 /**
  * Options for the `request()` method.
  */

--- a/packages/arcgis-rest-request/src/utils/append-custom-params.ts
+++ b/packages/arcgis-rest-request/src/utils/append-custom-params.ts
@@ -11,15 +11,19 @@ export function appendCustomParams<T extends IRequestOptions>(
   keys: Array<keyof T>,
   baseOptions?: Partial<T>
 ): IRequestOptions {
+  // NOTE: this must be kept in sync with the keys in IRequestOptions
   const requestOptionsKeys = [
     "params",
     "httpMethod",
     "rawResponse",
     "authentication",
+    "hideToken",
     "portal",
-    "fetch",
+    "credentials",
     "maxUrlLength",
-    "headers"
+    "headers",
+    "signal",
+    "suppressWarnings"
   ];
 
   const options: T = {


### PR DESCRIPTION
`requestOptionsKeys` were not in sync w/ `IRequestOptions`, which caused valid options to be stripped from the options.