### PR TITLE
fix: postMessage must send a Credential that is usable by JSSDK

### DIFF
--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -1317,7 +1317,7 @@ export class ArcGISIdentityManager
       if (isValidOrigin && isValidType) {
         let msg = {};
         if (isTokenValid) {
-          const credential = this.toJSON();
+          const credential = this.toCredential();
           msg = {
             type: "arcgis:auth:credential",
             credential

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -1880,7 +1880,7 @@ describe("ArcGISIdentityManager", () => {
         "arcgis:auth:credential",
         "should send credential type"
       );
-      expect(args[0].credential.username).toBe(
+      expect(args[0].credential.userId).toBe(
         "jsmith",
         "should send credential"
       );


### PR DESCRIPTION
In the 3.x -> 4.x transition, the structure returned as part of the postMessage auth flow changed. It needs to be shaped like a [Credential](https://developers.arcgis.com/javascript/latest/api-reference/esri-identity-Credential.html) that the JS SDK can use to instantiate an IdentityMgr

Have verified this in Hub