### PR TITLE
Revert "fix: postMessage must send a Credential that is usable by JSSDK"

### DIFF
--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -1317,7 +1317,7 @@ export class ArcGISIdentityManager
       if (isValidOrigin && isValidType) {
         let msg = {};
         if (isTokenValid) {
-          const credential = this.toCredential();
+          const credential = this.toJSON();
           msg = {
             type: "arcgis:auth:credential",
             credential

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -1880,7 +1880,7 @@ describe("ArcGISIdentityManager", () => {
         "arcgis:auth:credential",
         "should send credential type"
       );
-      expect(args[0].credential.userId).toBe(
+      expect(args[0].credential.username).toBe(
         "jsmith",
         "should send credential"
       );


### PR DESCRIPTION
Reverts Esri/arcgis-rest-js#1223

Turns out that currently some apps (dashboard) expect `messsage.data.credential` to be the shape of `idManager.toCredential()` , and others (survey 123) expect it to be the shape of `idManager.toJSON()`.

Also, in #1223, we only updated the function on parent side that sends the message, but we did **not** update [the function that an embedded app would use to create an ArcGISIdentityManager instance from the message](https://github.com/Esri/arcgis-rest-js/blob/d93bf0a8801b34a8125d988947f8128b5eaa2f4d/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts#L907) - that's still expecting the shape of `toJSON()`. 

Furthermore, we can't just update that to `ArcGISIdentityManager.fromCredential(message.data.credential)`, b/c that now requires a second argument of w/ server info - so I'm not sure what is the best way forward.

For now I propose that we revert the "fix" and at least apps that expect `toJSON()` will work while we come up w/ a more robust fix.
