### PR TITLE
fix(arcgis-rest-request): postMessage auth works w/ credential

### DIFF
--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -904,7 +904,13 @@ export class ArcGISIdentityManager
    */
   private static parentMessageHandler(event: any): ArcGISIdentityManager {
     if (event.data.type === "arcgis:auth:credential") {
-      return new ArcGISIdentityManager(event.data.credential);
+      const credential = event.data.credential as ICredential;
+      const serverInfo = {
+        hasPortal: true,
+        hasServer: false,
+        server: credential.server
+      } as IServerInfo;
+      return ArcGISIdentityManager.fromCredential(credential, serverInfo);
     }
     if (event.data.type === "arcgis:auth:error") {
       const err = new Error(event.data.error.message);
@@ -1318,10 +1324,10 @@ export class ArcGISIdentityManager
         let msg = {};
         if (isTokenValid) {
           const credential = this.toCredential();
-          msg = {
-            type: "arcgis:auth:credential",
-            credential
-          };
+          // the following line allows us to conform to our spec without changing other depended-on functionality
+          // https://github.com/Esri/arcgis-rest-js/blob/master/packages/arcgis-rest-auth/post-message-auth-spec.md#arcgisauthcredential
+          credential.server = credential.server.replace("/sharing/rest", "");
+          msg = { type: "arcgis:auth:credential", credential };
         } else {
           msg = {
             type: "arcgis:auth:error",

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -1811,6 +1811,14 @@ describe("ArcGISIdentityManager", () => {
       username: "jsmith"
     };
 
+    const credential: ICredential = {
+      expires: TOMORROW.getTime(),
+      server: token.portal,
+      ssl: false,
+      token: token.token,
+      userId: token.username
+    };
+
     it(".disablePostMessageAuth removes event listener", () => {
       const removeSpy = spyOn(MockWindow, "removeEventListener");
       const session = new ArcGISIdentityManager(token);
@@ -1958,7 +1966,7 @@ describe("ArcGISIdentityManager", () => {
           postMessage(msg: any, origin: string) {
             Win._fn({
               origin: "https://origin.com",
-              data: { type: "arcgis:auth:credential", credential: token },
+              data: { type: "arcgis:auth:credential", credential },
               source: Win.parent
             });
           }
@@ -1994,7 +2002,7 @@ describe("ArcGISIdentityManager", () => {
             // fire a second we want to intercept
             Win._fn({
               origin: "https://origin.com",
-              data: { type: "arcgis:auth:credential", credential: token },
+              data: { type: "arcgis:auth:credential", credential },
               source: Win.parent
             });
           }


### PR DESCRIPTION
## Background

The Hub team is in the process of migrating from ArcGIS REST JS 3.x to 4.x and we discovered a change in the payload that is sent/expected when [passing authentication from a parent app to an embedded app via postMessage](https://esri.github.io/arcgis-rest-js/guides/embedded-apps/). For us, this manifested as a failure to pass authentication from the Hub to an embedded Dashboard, but surprisingly not to an embedded Survey123 application.
 
Furthermore, we consider this change in payload to be a bug, b/c the old payload, an [ICredential](https://developers.arcgis.com/arcgis-rest-js/api-reference/arcgis-rest-request/ICredential/), was suitable for initiating authentication w/ either ArcGIS REST JS or the Maps SDK for JavaScript, whereas the new payload, an [IArcGISIdentityManagerOptions](https://developers.arcgis.com/arcgis-rest-js/api-reference/arcgis-rest-request/IArcGISIdentityManagerOptions/), would need to be transformed to work with the Maps SDK for JavaScript.

We suspect that some ArcGIS apps either have not upgraded to 4.x, or have made accommodations to handle both the old and new payload formats.

## Proposal

We propose:
- The parent app _always_ sends the  original`ICredential` format that is compatible w/ the Maps SDK (i.e. can be passed directly to [esriId.registerToken()](https://developers.arcgis.com/javascript/latest/api-reference/esri-identity-IdentityManager.html#registerToken)), REST JS 3.x, and (as of this PR) REST JS 4.x
- A client app using 4.x will (as of this PR) expect the `ICredential` payload, but also fallback to handling the  `IArcGISIdentityManagerOptions` format that would have been sent by a 4.x parent that has not yet updated to the latest version.

## Status

We thought we addressed this in #1223, we missed a couple of things, which are now included in this PR:

1. [this line](https://github.com/Esri/arcgis-rest-js/blob/master/packages/arcgis-rest-auth/src/UserSession.ts#L1108)
2. Also, we only updated the function on parent side that sends the message (`createPostMessageHandler`), but we did **not** update [the function that an embedded app would use to create an ArcGISIdentityManager instance from the message (`parentMessageHandler`)](https://github.com/Esri/arcgis-rest-js/blob/d93bf0a8801b34a8125d988947f8128b5eaa2f4d/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts#L907) - that's still expecting the shape of `toJSON()`. 

I have confirmed that this worked in our app for at least dashboards and surveys:

![image](https://github.com/user-attachments/assets/d994d32c-abcc-4970-ace0-2868a60009a7)

![image](https://github.com/user-attachments/assets/ffbe7b88-de73-4b0d-8b94-37d35c0114dd)
