### PR TITLE
feat: support no cors requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33523,7 +33523,7 @@
     },
     "packages/arcgis-rest-portal": {
       "name": "@esri/arcgis-rest-portal",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33540,7 +33540,7 @@
     },
     "packages/arcgis-rest-request": {
       "name": "@esri/arcgis-rest-request",
-      "version": "4.4.0",
+      "version": "4.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@esri/arcgis-rest-fetch": "^4.0.0",

--- a/packages/arcgis-rest-request/src/requestConfig.ts
+++ b/packages/arcgis-rest-request/src/requestConfig.ts
@@ -1,0 +1,40 @@
+/* istanbul ignore file */
+// Note: currently this is all internal to the package, and we are not exposing
+// anything that a user can set... but we need all this to be able to ensure
+// that multiple instances of the package can share the same config.
+
+export interface IRequestConfig {
+  noCorsDomains: string[];
+  crossOriginNoCorsDomains: Record<string, number>;
+  pendingNoCorsRequests: PendingRequestCache;
+}
+
+export type PendingRequestCache = {
+  [key: string]: Promise<void>;
+};
+
+/**
+ * The default config for the request module. This is used to store
+ * the no-cors domains and pending requests.
+ */
+const DEFAULT_ARCGIS_REQUEST_CONFIG: IRequestConfig = {
+  noCorsDomains: [],
+  crossOriginNoCorsDomains: {},
+  pendingNoCorsRequests: {}
+};
+
+const GLOBAL_VARIABLE_NAME = "ARCGIS_REST_JS_NO_CORS";
+
+// Set the global variable to the default config if it is not aleady defined
+// This is done to ensure that all instances of rest-request work with a single
+// instance of the config
+if (!(globalThis as any)[GLOBAL_VARIABLE_NAME]) {
+  (globalThis as any)[GLOBAL_VARIABLE_NAME] = {
+    ...DEFAULT_ARCGIS_REQUEST_CONFIG
+  } as IRequestConfig;
+}
+
+// export the settings as immutable consts that read from the global config
+export const requestConfig = (globalThis as any)[
+  GLOBAL_VARIABLE_NAME
+] as IRequestConfig;

--- a/packages/arcgis-rest-request/src/utils/isSameOrigin.ts
+++ b/packages/arcgis-rest-request/src/utils/isSameOrigin.ts
@@ -1,0 +1,19 @@
+/**
+ * Is the given URL the same origin as the current window?
+ * Used to determine if we need to do any additional cross-origin
+ * handling for the request.
+ * @param url
+ * @param win - optional window object to use for origin comparison
+ *             (useful for testing)
+ * @returns
+ */
+export function isSameOrigin(url: string, win?: Window | undefined): boolean {
+  /* istanbul ignore next */
+  if (!win && !window) {
+    return false;
+  } else {
+    win = win || window;
+    const origin = win.location?.origin;
+    return url.startsWith(origin);
+  }
+}

--- a/packages/arcgis-rest-request/src/utils/sendNoCorsRequest.ts
+++ b/packages/arcgis-rest-request/src/utils/sendNoCorsRequest.ts
@@ -1,0 +1,167 @@
+import { requestConfig } from "../requestConfig.js";
+
+/**
+ * Send a no-cors request to the passed uri. This is used to pick up
+ * a cookie from a 3rd party server to meet a requirement of some authentication
+ * flows.
+ * @param url
+ * @returns
+ */
+export function sendNoCorsRequest(url: string): Promise<void> {
+  // drop any query params, other than f=json
+  const urlObj = new URL(url);
+  url = urlObj.origin + urlObj.pathname;
+
+  if (urlObj.search.includes("f=json")) {
+    url += "?f=json";
+  }
+
+  const origin = urlObj.origin;
+
+  // If we have already sent a no-cors request to this url, return the promise
+  // so we don't send multiple requests
+  if (requestConfig.pendingNoCorsRequests[origin]) {
+    return requestConfig.pendingNoCorsRequests[origin];
+  }
+
+  // Make the request and add to the cache
+  requestConfig.pendingNoCorsRequests[origin] = fetch(url, {
+    mode: "no-cors",
+    credentials: "include",
+    cache: "no-store"
+  })
+    .then((response) => {
+      // Add to the list of cross-origin no-cors domains
+      // if the domain is not already in the list
+      if (requestConfig.noCorsDomains.indexOf(origin) === -1) {
+        requestConfig.noCorsDomains.push(origin);
+      }
+
+      // Hold the timestamp of this request so we can decide when to
+      // send another request to this domain
+      requestConfig.crossOriginNoCorsDomains[origin.toLowerCase()] = Date.now();
+
+      // Remove the pending request from the cache
+      delete requestConfig.pendingNoCorsRequests[origin];
+
+      // Due to limitations of fetchMock at the version of the tooling
+      // in this project, we can't mock the response type of a no-cors request
+      // and thus we can't test this. So we are going to comment this out
+      // and leave it in place for now. If we need to test this, we can
+      // update the tooling to a version that supports this. Also
+      // JS SDK does not do this check, so we are going to leave it out for now.
+
+      // ================================================================
+      // no-cors requests are opaque to javascript
+      // and thus will always return a response with a type of "opaque"
+      // if (response.type === "opaque") {
+      //   return Promise.resolve();
+      // } else {
+      //   // Not sure if this is possible, but since we have a check above
+      //   // lets handle the else case
+      //   return Promise.reject(
+      //     new Error(`no-cors request to ${origin} not opaque`)
+      //   );
+      // }
+      // ================================================================
+    })
+    .catch((e) => {
+      // Not sure this is necessary, but if the request fails
+      // we should remove it from the pending requests
+      // and return a rejected promise with some information
+      delete requestConfig.pendingNoCorsRequests[origin];
+      return Promise.reject(new Error(`no-cors request to ${origin} failed`));
+    });
+  // return the promise
+  return requestConfig.pendingNoCorsRequests[origin];
+}
+
+/**
+ * Allow us to get the no-cors domains that are registered
+ * so we can pass them into the identity manager
+ * @returns
+ */
+export function getRegisteredNoCorsDomains(): string[] {
+  // return the no-cors domains
+  return requestConfig.noCorsDomains;
+}
+
+/**
+ * Register the domains that are allowed to be used in no-cors requests
+ * This is called by `request` when the portal/self response is intercepted
+ * and the `.authorizedCrossOriginNoCorsDomains` property is set.
+ * @param authorizedCrossOriginNoCorsDomains
+ */
+export function registerNoCorsDomains(
+  authorizedCrossOriginNoCorsDomains: string[]
+): void {
+  // register the domains
+  authorizedCrossOriginNoCorsDomains.forEach((domain: string) => {
+    // ensure domain is lower case and ensure protocol is included
+    domain = domain.toLowerCase();
+    if (/^https?:\/\//.test(domain)) {
+      addNoCorsDomain(domain);
+    } else {
+      // no protocol present, so add http and https
+      addNoCorsDomain("http://" + domain);
+      addNoCorsDomain("https://" + domain);
+    }
+  });
+}
+
+/**
+ * Ensure we don't get duplicate domains in the no-cors domains list
+ * @param domain
+ */
+function addNoCorsDomain(url: string): void {
+  // Since the caller of this always ensures a protocol is present
+  // we can safely use the URL constructor to get the origin
+  // and add it to the no-cors domains list
+  const uri = new URL(url);
+  const domain = uri.origin;
+  if (requestConfig.noCorsDomains.indexOf(domain) === -1) {
+    requestConfig.noCorsDomains.push(domain);
+  }
+}
+
+/**
+ *  Is the origin of the passed url in the no-cors domains list?
+ * @param url
+ * @returns
+ */
+export function isNoCorsDomain(url: string): boolean {
+  let result = false;
+
+  if (requestConfig.noCorsDomains.length) {
+    // is the current url in the no-cors domains?
+    const origin = new URL(url).origin.toLowerCase();
+    result = requestConfig.noCorsDomains.some((domain) => {
+      return origin.includes(domain);
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Is the origin of the passed url in the no-cors domains list
+ * and do we need to send a no-cors request?
+ *
+ * @param url
+ * @returns
+ */
+export function isNoCorsRequestRequired(url: string): boolean {
+  let result = false;
+  // is the current origin in the no-cors domains?
+  if (isNoCorsDomain(url)) {
+    const origin = new URL(url).origin.toLowerCase();
+
+    // check if we have sent a no-cors request to this domain in the last hour
+    const lastRequest = requestConfig.crossOriginNoCorsDomains[origin] || 0;
+    if (Date.now() - 60 * 60000 > lastRequest) {
+      result = true;
+    }
+  }
+
+  return result;
+}

--- a/packages/arcgis-rest-request/test/utils/isSameOrigin.test.ts
+++ b/packages/arcgis-rest-request/test/utils/isSameOrigin.test.ts
@@ -1,0 +1,53 @@
+import { isSameOrigin } from "../../src/utils/isSameOrigin.js";
+
+describe("isSameOrigin", () => {
+  it("should return true if the URL is the same origin as the current window", () => {
+    const mockWindow = {
+      location: {
+        origin: "https://example.com"
+      }
+    } as unknown as Window & typeof globalThis;
+
+    const result = isSameOrigin("https://example.com/resource", mockWindow);
+    expect(result).toBe(true);
+  });
+
+  it("should return false if the URL is a different origin than the current window", () => {
+    const mockWindow = {
+      location: {
+        origin: "https://example.com"
+      }
+    } as unknown as Window & typeof globalThis;
+
+    const result = isSameOrigin(
+      "https://another-domain.com/resource",
+      mockWindow
+    );
+    expect(result).toBe(false);
+  });
+
+  it("should return false if the window object has no location or origin", () => {
+    const mockWindow = {} as unknown as Window & typeof globalThis;
+
+    const result = isSameOrigin("https://example.com/resource", mockWindow);
+    expect(result).toBe(false);
+  });
+
+  it("should handle URLs that do not start with the origin", () => {
+    const mockWindow = {
+      location: {
+        origin: "https://example.com"
+      }
+    } as unknown as Window & typeof globalThis;
+
+    const result = isSameOrigin("http://example.com/resource", mockWindow);
+    expect(result).toBe(false);
+  });
+  if (typeof window !== "undefined") {
+    // Although this should work in node, it somehow doesn't
+    it("should work if win is undefined", () => {
+      const result = isSameOrigin("http://example.com/resource");
+      expect(result).toBe(false);
+    });
+  }
+});

--- a/packages/arcgis-rest-request/test/utils/sendNoCorsRequest.test.ts
+++ b/packages/arcgis-rest-request/test/utils/sendNoCorsRequest.test.ts
@@ -1,0 +1,191 @@
+import {
+  sendNoCorsRequest,
+  getRegisteredNoCorsDomains,
+  registerNoCorsDomains,
+  isNoCorsDomain,
+  isNoCorsRequestRequired
+} from "../../src/utils/sendNoCorsRequest.js";
+
+import fetchMock from "fetch-mock";
+import { requestConfig } from "../../src/requestConfig.js";
+
+describe("sendNoCorsRequest utils:", () => {
+  beforeEach(() => {
+    // Reset requestConfig before each test
+    requestConfig.pendingNoCorsRequests = {};
+    requestConfig.noCorsDomains = [];
+    requestConfig.crossOriginNoCorsDomains = {};
+  });
+
+  describe("sendNoCorsRequest:", () => {
+    it("should send a no-cors request and cache the call", async () => {
+      const url = "https://example.com/resource";
+      fetchMock.once(url, { status: 200 });
+
+      await sendNoCorsRequest(url);
+
+      const [lastUrl, lastOptions] = fetchMock.lastCall()!;
+      expect(lastUrl).toBe("https://example.com/resource");
+      expect(lastOptions).toEqual({
+        mode: "no-cors",
+        credentials: "include",
+        cache: "no-store"
+      });
+      expect(requestConfig.noCorsDomains).toContain("https://example.com");
+    });
+
+    it("strips path and leaves on f=json", async () => {
+      const url = "https://example.com/resource/more?fat=cat&f=json";
+      fetchMock.once("https://example.com/resource/more?f=json", {
+        status: 200
+      });
+
+      await sendNoCorsRequest(url);
+      const [lastUrl, lastOptions] = fetchMock.lastCall()!;
+      expect(lastUrl).toBe("https://example.com/resource/more?f=json");
+      expect(lastOptions).toEqual({
+        mode: "no-cors",
+        credentials: "include",
+        cache: "no-store"
+      });
+
+      expect(requestConfig.noCorsDomains).toContain("https://example.com");
+    });
+
+    it("does not duplicate entry in noCorsDomains", async () => {
+      requestConfig.noCorsDomains = ["https://example.com"];
+      const url = "https://example.com/resource/more?fat=cat&f=json";
+      fetchMock.once("https://example.com/resource/more?f=json", {
+        status: 200
+      });
+
+      await sendNoCorsRequest(url);
+
+      expect(requestConfig.noCorsDomains).toEqual(["https://example.com"]);
+    });
+
+    it("should not send duplicate no-cors requests for the same origin", async () => {
+      const url = "https://example2.com/resource";
+      fetchMock.once(url, { status: 200 });
+
+      await Promise.all([sendNoCorsRequest(url), sendNoCorsRequest(url)]);
+
+      const calls = fetchMock.calls(url);
+      expect(calls.length).toBe(1);
+      expect(requestConfig.pendingNoCorsRequests).toEqual({});
+      expect(requestConfig.noCorsDomains).toContain("https://example2.com");
+      expect(
+        requestConfig.crossOriginNoCorsDomains["https://example2.com"]
+      ).toBeDefined();
+    });
+
+    if (typeof window !== "undefined") {
+      // This test can't work in node because we spy on window.fetch
+      it("should reject if the no-cors request fails", async () => {
+        const url = "https://example.com/resource";
+        spyOn(window, "fetch").and.returnValue(
+          Promise.reject(new Error("Network error"))
+        );
+
+        try {
+          await sendNoCorsRequest(url);
+          fail("Expected sendNoCorsRequest to throw an error");
+        } catch (error) {
+          const e = error as Error;
+          expect(e.name).toBe("Error");
+          expect(e.message).toBe(
+            "no-cors request to https://example.com failed"
+          );
+        }
+      });
+    }
+  });
+
+  describe("getRegisteredNoCorsDomains:", () => {
+    it("should return the list of registered no-cors domains", () => {
+      requestConfig.noCorsDomains = [
+        "https://example.com",
+        "https://another.com"
+      ];
+      const domains = getRegisteredNoCorsDomains();
+
+      expect(domains).toEqual(["https://example.com", "https://another.com"]);
+    });
+  });
+
+  describe("registerNoCorsDomains:", () => {
+    it("should register domains", () => {
+      const domains = ["https://example.com", "another.com"];
+      registerNoCorsDomains(domains);
+
+      expect(requestConfig.noCorsDomains).toContain("https://example.com");
+      expect(requestConfig.noCorsDomains).toContain("http://another.com");
+      expect(requestConfig.noCorsDomains).toContain("https://another.com");
+    });
+    it("should not allow duplicates", () => {
+      const domains = ["https://example.com"];
+      registerNoCorsDomains(domains);
+      registerNoCorsDomains(domains);
+      expect(requestConfig.noCorsDomains.length).toBe(1);
+      expect(requestConfig.noCorsDomains).toContain("https://example.com");
+    });
+  });
+
+  describe("isNoCorsDomain:", () => {
+    it("should return true if the domain is in the no-cors domains list", () => {
+      requestConfig.noCorsDomains = ["https://example.com"];
+      const result = isNoCorsDomain("https://example.com/resource");
+
+      expect(result).toBeTruthy();
+    });
+
+    it("should return false if the domain is not in the no-cors domains list", () => {
+      requestConfig.noCorsDomains = ["https://example.com"];
+      const result = isNoCorsDomain("https://another.com/resource");
+
+      expect(result).toBeFalsy();
+    });
+    it("should return false if no-cors domains list is empty", () => {
+      requestConfig.noCorsDomains = [];
+      const result = isNoCorsDomain("https://another.com/resource");
+
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe("isNoCorsRequestRequired:", () => {
+    it("returns false if no no-cors domains are set", () => {
+      const result = isNoCorsRequestRequired("https://example.com/resource");
+      expect(result).toBeFalsy();
+    });
+    it("should return true if a no-cors request is required", () => {
+      requestConfig.noCorsDomains = ["https://example.com"];
+      requestConfig.crossOriginNoCorsDomains = {
+        "https://example.com": Date.now() - 2 * 60 * 60000
+      }; // 2 hours ago
+
+      const result = isNoCorsRequestRequired("https://example.com/resource");
+
+      expect(result).toBeTruthy();
+    });
+    it("should return true if a no-cors request has not been sent", () => {
+      requestConfig.noCorsDomains = ["https://example.com"];
+      requestConfig.crossOriginNoCorsDomains = {};
+
+      const result = isNoCorsRequestRequired("https://example.com/resource");
+
+      expect(result).toBeTruthy();
+    });
+
+    it("should return false if a no-cors request is not required", () => {
+      requestConfig.noCorsDomains = ["https://example.com"];
+      requestConfig.crossOriginNoCorsDomains = {
+        "https://example.com": Date.now()
+      };
+
+      const result = isNoCorsRequestRequired("https://example.com/resource");
+
+      expect(result).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
Add support for no-cors requests when `portalSelf.authorizedCrossOriginNoCorsDomains` is set, and requests are made to the domains listed.

This is a simple porting of the implementation in 3.x, up to 4.x. Utils and related tests were copied directly, and changes in `request` were slightly different, owing to changes in that function from 3.x to 4.x.