### PR TITLE
fix(arcgis-rest-request): isSameOrigin returns false when url arg is null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33540,7 +33540,7 @@
     },
     "packages/arcgis-rest-request": {
       "name": "@esri/arcgis-rest-request",
-      "version": "4.6.0",
+      "version": "4.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@esri/arcgis-rest-fetch": "^4.0.0",

--- a/packages/arcgis-rest-request/src/utils/isSameOrigin.ts
+++ b/packages/arcgis-rest-request/src/utils/isSameOrigin.ts
@@ -9,7 +9,7 @@
  */
 export function isSameOrigin(url: string, win?: Window | undefined): boolean {
   /* istanbul ignore next */
-  if (!win && !window) {
+  if ((!win && !window) || !url) {
     return false;
   } else {
     win = win || window;

--- a/packages/arcgis-rest-request/test/utils/isSameOrigin.test.ts
+++ b/packages/arcgis-rest-request/test/utils/isSameOrigin.test.ts
@@ -33,6 +33,17 @@ describe("isSameOrigin", () => {
     expect(result).toBe(false);
   });
 
+  it("should return false when the url is falsey", () => {
+    const mockWindow = {
+      location: {
+        origin: "https://example.com"
+      }
+    } as unknown as Window & typeof globalThis;
+
+    const result = isSameOrigin(null, mockWindow);
+    expect(result).toBe(false);
+  });
+
   it("should handle URLs that do not start with the origin", () => {
     const mockWindow = {
       location: {


### PR DESCRIPTION
* Fixes a JS error that is observed when `isSameOrigin` is called with a `null` value for it's `url` arg.

Context: Survey views in the Hub application appear to have regressed when [PR-15058](https://github.com/ArcGIS/opendata-ui/commit/63ee661c585c2d6f49606e5af6c6d67dbd6f173a) merged which bumped our `@esri/arcgis-rest-request` dependency from `4.5.1` to `4.7.1`. When this occurs, a JavaScript error is raised from `isSameOrigin` because a value of `null` is being passed as `url`, which is referenced from the survey's Stakeholder Feature Service View. This worked with V3 of RestJS and with `4.5.1`.