### PR TITLE
queryAllFeatures()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23422,7 +23422,7 @@
     },
     "packages/arcgis-rest-feature-service": {
       "name": "@esri/arcgis-rest-feature-service",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -23510,7 +23510,7 @@
     },
     "packages/arcgis-rest-portal": {
       "name": "@esri/arcgis-rest-portal",
-      "version": "4.6.1",
+      "version": "4.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -23527,7 +23527,7 @@
     },
     "packages/arcgis-rest-request": {
       "name": "@esri/arcgis-rest-request",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@esri/arcgis-rest-fetch": "^4.0.0",

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -298,6 +298,8 @@ export async function queryAllFeatures(
     const pagedOptions = {
       ...requestOptions,
       params: {
+        where: "1=1",
+        outFields: "*",
         ...(requestOptions.params || {}),
         resultOffset: offset,
         resultRecordCount: recordCountToUse

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -204,3 +204,106 @@ export function queryFeatures(
 
   return request(`${cleanUrl(requestOptions.url)}/query`, queryOptions);
 }
+
+/**
+ * Query a feature service to retrieve all features. See [REST Documentation](https://developers.arcgis.com/rest/services-reference/query-feature-service-layer-.htm) for more information.
+ *
+ * ```js
+ * import { queryAllFeatures } from '@esri/arcgis-rest-feature-service';
+ *
+ * queryAllFeatures({
+ *   url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3",
+ *   where: "STATE_NAME = 'Alaska'"
+ * })
+ *   .then(result)
+ * ```
+ *
+ * @param requestOptions - Options for the request
+ * @returns A Promise that will resolve with the query response.
+ */
+export async function queryAllFeatures(
+  requestOptions: IQueryFeaturesOptions
+): Promise<IQueryFeaturesResponse> {
+  const pageSize = 2000;
+  let allFeatures: any[] = [];
+  let offset = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const pagedOptions = {
+      ...requestOptions,
+      params: {
+        ...(requestOptions.params || {}),
+        resultOffset: offset,
+        resultRecordCount: pageSize
+      }
+    };
+
+    const queryOptions = appendCustomParams<IQueryFeaturesOptions>(
+      pagedOptions,
+      [
+        "where",
+        "objectIds",
+        "relationParam",
+        "time",
+        "distance",
+        "units",
+        "outFields",
+        "geometry",
+        "geometryType",
+        "spatialRel",
+        "returnGeometry",
+        "maxAllowableOffset",
+        "geometryPrecision",
+        "inSR",
+        "outSR",
+        "gdbVersion",
+        "returnDistinctValues",
+        "returnIdsOnly",
+        "returnCountOnly",
+        "returnExtentOnly",
+        "orderByFields",
+        "groupByFieldsForStatistics",
+        "outStatistics",
+        "returnZ",
+        "returnM",
+        "multipatchOption",
+        "resultOffset",
+        "resultRecordCount",
+        "quantizationParameters",
+        "returnCentroid",
+        "resultType",
+        "historicMoment",
+        "returnTrueCurves",
+        "sqlFormat",
+        "returnExceededLimitFeatures",
+        "f"
+      ],
+      {
+        httpMethod: "GET",
+        params: {
+          where: "1=1",
+          outFields: "*",
+          ...pagedOptions.params
+        }
+      }
+    );
+    const response: IQueryFeaturesResponse = await request(
+      `${cleanUrl(requestOptions.url)}/query`,
+      queryOptions
+    );
+
+    allFeatures = allFeatures.concat(response.features);
+
+    if (response.features.length < pageSize) {
+      hasMore = false;
+    } else {
+      offset += pageSize;
+    }
+  }
+
+  return {
+    ...requestOptions,
+    features: allFeatures
+  };
+}

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -130,7 +130,7 @@ export interface IQueryAllFeaturesOptions extends ISharedQueryOptions {
    * NOTE: for "pbf" you must also supply `rawResponse: true`
    * and parse the response yourself using `response.arrayBuffer()`
    */
-  f?: "json" | "geojson" | "pbf";
+  f?: "json" | "geojson";
   /**
    * someday...
    *
@@ -336,7 +336,6 @@ export async function queryAllFeatures(
         "historicMoment",
         "returnTrueCurves",
         "sqlFormat",
-        "returnExceededLimitFeatures",
         "f"
       ],
       {
@@ -344,6 +343,7 @@ export async function queryAllFeatures(
         params: {
           where: "1=1",
           outFields: "*",
+          returnExceededLimitFeatures: true,
           ...pagedOptions.params
         }
       }

--- a/packages/arcgis-rest-feature-service/test/query.test.ts
+++ b/packages/arcgis-rest-feature-service/test/query.test.ts
@@ -8,7 +8,6 @@ import {
   queryAllFeatures,
   queryRelated,
   IQueryFeaturesOptions,
-  IQueryAllFeaturesOptions,
   IQueryRelatedOptions
 } from "../src/index.js";
 

--- a/packages/arcgis-rest-feature-service/test/query.test.ts
+++ b/packages/arcgis-rest-feature-service/test/query.test.ts
@@ -189,7 +189,7 @@ describe("queryAllFeatures", () => {
     });
 
     fetchMock.mock(
-      `${serviceUrl}/query?f=json&resultOffset=0&resultRecordCount=2000&where=1%3D1&outFields=*`,
+      `${serviceUrl}/query?f=json&where=1%3D1&outFields=*&resultOffset=0&resultRecordCount=2000`,
       {
         features: page1Features,
         exceededTransferLimit: true
@@ -197,7 +197,7 @@ describe("queryAllFeatures", () => {
     );
 
     fetchMock.mock(
-      `${serviceUrl}/query?f=json&resultOffset=2000&resultRecordCount=2000&where=1%3D1&outFields=*`,
+      `${serviceUrl}/query?f=json&where=1%3D1&outFields=*&resultOffset=2000&resultRecordCount=2000`,
       {
         features: page2Features,
         exceededTransferLimit: false
@@ -205,9 +205,7 @@ describe("queryAllFeatures", () => {
     );
 
     const result = await queryAllFeatures({
-      url: serviceUrl,
-      where: "1=1",
-      outFields: "*"
+      url: serviceUrl
     });
 
     expect(result.features.length).toBe(pageSize + 1);
@@ -221,7 +219,7 @@ describe("queryAllFeatures", () => {
     });
 
     fetchMock.getOnce(
-      `${serviceUrl}/query?f=json&resultOffset=0&resultRecordCount=2000&where=1%3D1&outFields=*`,
+      `${serviceUrl}/query?f=json&where=1%3D1&outFields=*&resultOffset=0&resultRecordCount=2000`,
       {
         features: page2Features // only one feature
       }
@@ -245,7 +243,7 @@ describe("queryAllFeatures", () => {
     });
 
     fetchMock.getOnce(
-      `${serviceUrl}/query?f=json&resultRecordCount=${customCount}&resultOffset=0&where=1%3D1&outFields=*`,
+      `${serviceUrl}/query?f=json&where=1%3D1&outFields=*&resultRecordCount=${customCount}&resultOffset=0`,
       {
         features: page1Features.slice(0, customCount)
       }
@@ -269,7 +267,7 @@ describe("queryAllFeatures", () => {
     });
 
     fetchMock.getOnce(
-      `${serviceUrl}/query?f=json&resultRecordCount=2000&resultOffset=0&where=1%3D1&outFields=*`,
+      `${serviceUrl}/query?f=json&where=1%3D1&outFields=*&resultRecordCount=2000&resultOffset=0`,
       {
         features: page1Features
       }
@@ -282,6 +280,23 @@ describe("queryAllFeatures", () => {
       params: {
         resultRecordCount: 3000 // greater than maxRecordCount
       }
+    });
+
+    expect(result.features.length).toBe(pageSize);
+  });
+
+  it("fall back to a default size of 2000 if thes service does not return a page size", async () => {
+    fetchMock.getOnce(`${serviceUrl}?f=json`, {});
+
+    fetchMock.getOnce(
+      `${serviceUrl}/query?f=json&where=1%3D1&outFields=*&resultOffset=0&resultRecordCount=2000`,
+      {
+        features: page1Features
+      }
+    );
+
+    const result = await queryAllFeatures({
+      url: serviceUrl
     });
 
     expect(result.features.length).toBe(pageSize);


### PR DESCRIPTION
Same as https://github.com/Esri/arcgis-rest-js/pull/1237 but passing  `where=1=1` and `outFields=*` by default.