### PR TITLE
feat(arcgis-rest-feature-service): add support for f=geojson to queryAllFeatures()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23422,7 +23422,7 @@
     },
     "packages/arcgis-rest-feature-service": {
       "name": "@esri/arcgis-rest-feature-service",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -367,7 +367,7 @@ export async function queryAllFeatures(
 
     const returnedCount = response.features.length;
 
-    // check if the response has exceededTransferLimit handles both thes stantard json and geojson responses
+    // check if the response has exceededTransferLimit handles both the standard json and geojson responses
     const exceededTransferLimit =
       response.exceededTransferLimit ||
       (response as any).properties?.exceededTransferLimit;

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -17,7 +17,6 @@ import {
   ISharedQueryOptions,
   IStatisticDefinition
 } from "./helpers.js";
-import { inspect } from "util";
 
 /**
  * Request options to fetch a feature by id.

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -17,6 +17,7 @@ import {
   ISharedQueryOptions,
   IStatisticDefinition
 } from "./helpers.js";
+import { inspect } from "util";
 
 /**
  * Request options to fetch a feature by id.
@@ -367,8 +368,13 @@ export async function queryAllFeatures(
 
     const returnedCount = response.features.length;
 
+    // check if the response has exceededTransferLimit handles both thes stantard json and geojson responses
+    const exceededTransferLimit =
+      response.exceededTransferLimit ||
+      (response as any).properties?.exceededTransferLimit;
+
     // check if there are more features
-    if (returnedCount < pageSize || !response.exceededTransferLimit) {
+    if (returnedCount < pageSize || !exceededTransferLimit) {
       hasMore = false;
     } else {
       offset += pageSize;


### PR DESCRIPTION
This adds support for using `f=geojson` in `queryAllFeatures()` which I missed while reviewing the [original PR](https://github.com/Esri/arcgis-rest-js/issues/1246).

https://github.com/Esri/arcgis-rest-js/issues/1234