### PR TITLE
chore: migrate elevation tests to ArcGIS REST JS

### DIFF
--- a/jasmine.json
+++ b/jasmine.json
@@ -3,7 +3,6 @@
   "spec_files": [
     "arcgis-rest-demographics/{src,test}/**/*.test.ts",
     "arcgis-rest-developer-credentials/{src,test}/**/*.test.ts",
-    "arcgis-rest-elevation/{src,test}/**/*.test.ts",
     "arcgis-rest-feature-service/{src,test}/**/*.test.ts",
     "arcgis-rest-geocoding/{src,test}/**/*.test.ts",
     "arcgis-rest-portal/{src,test}/**/*.test.ts",

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -15,7 +15,6 @@ module.exports = function (config) {
     files: [
       "packages/arcgis-rest-demographics/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-developer-credentials/{src,test}/**/!(*.test.live).ts",
-      "packages/arcgis-rest-elevation/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-feature-service/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-geocoding/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-places/{src,test}/**/!(*.test.live).ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23348,7 +23348,7 @@
     },
     "packages/arcgis-rest-basemap-sessions": {
       "name": "@esri/arcgis-rest-basemap-sessions",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -23422,7 +23422,7 @@
     },
     "packages/arcgis-rest-feature-service": {
       "name": "@esri/arcgis-rest-feature-service",
-      "version": "4.2.0",
+      "version": "4.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/packages/arcgis-rest-basemap-sessions/test/BasemapStyleSession.test.ts
+++ b/packages/arcgis-rest-basemap-sessions/test/BasemapStyleSession.test.ts
@@ -8,7 +8,9 @@ import {
 } from "../src/index.js";
 import { MOCK_START_TIME, MOCK_END_TIME, TWELVE_HOURS } from "./test-utils.js";
 import fetchMock from "fetch-mock";
-import { Emitter } from "mitt";
+import { ApiKeyManager } from "@esri/arcgis-rest-request";
+
+const MOCK_AUTH = ApiKeyManager.fromKey("fake-token");
 
 function createMockSession() {
   return new BasemapStyleSession({
@@ -18,7 +20,7 @@ function createMockSession() {
     startTime: MOCK_START_TIME,
     endTime: MOCK_END_TIME,
     expires: new Date(MOCK_END_TIME.getTime() - DEFAULT_SAFETY_MARGIN * 1000),
-    authentication: "token"
+    authentication: MOCK_AUTH
   });
 }
 
@@ -41,7 +43,7 @@ async function startMockSession(
   const session = await BasemapStyleSession.start({
     ...{
       styleFamily: "arcgis",
-      authentication: "token"
+      authentication: MOCK_AUTH
     },
     ...sessionParams
   });
@@ -83,7 +85,7 @@ describe("BasemapStyleSession", () => {
       startTime: MOCK_START_TIME,
       endTime: MOCK_END_TIME,
       expires: new Date(MOCK_END_TIME.getTime() - DEFAULT_SAFETY_MARGIN * 1000),
-      authentication: "token"
+      authentication: MOCK_AUTH
     });
 
     expect(session).toBeDefined();
@@ -94,7 +96,7 @@ describe("BasemapStyleSession", () => {
     try {
       await BasemapStyleSession.start({
         duration: 9,
-        authentication: "token"
+        authentication: MOCK_AUTH
       });
     } catch (error) {
       expect(error).toEqual(
@@ -107,7 +109,7 @@ describe("BasemapStyleSession", () => {
     try {
       await BasemapStyleSession.start({
         duration: 43201,
-        authentication: "token"
+        authentication: MOCK_AUTH
       });
     } catch (error) {
       expect(error).toEqual(
@@ -157,7 +159,7 @@ describe("BasemapStyleSession", () => {
     expect(session.safetyMargin).toBe(DEFAULT_SAFETY_MARGIN);
     expect((session as any).expirationCheckInterval).toBe(10000); // 10 seconds
     expect(session.styleFamily).toBe("arcgis");
-    expect(session.authentication).toBe("token");
+    expect(session.authentication).toBe(MOCK_AUTH);
     expect(session.canRefresh).toBe(true);
     expect(await session.getToken()).toBe("fake-token");
     expect(session.autoRefresh).toBe(false);
@@ -170,7 +172,7 @@ describe("BasemapStyleSession", () => {
 
     expect(url.startsWith(DEFAULT_START_BASEMAP_STYLE_SESSION_URL)).toBe(true);
     expect(url).toContain("styleFamily=arcgis");
-    expect(url).toContain("token=token");
+    expect(url).toContain("token=fake-token");
     expect(url).toContain("durationSeconds=43200");
     expect(url).toContain("f=json");
   });
@@ -178,7 +180,7 @@ describe("BasemapStyleSession", () => {
   test("should start a new BasemapStyleSession with a custom duration", async () => {
     const session = await startMockSession({
       duration: 60,
-      authentication: "token"
+      authentication: MOCK_AUTH
     });
 
     // Validate the session object
@@ -198,7 +200,7 @@ describe("BasemapStyleSession", () => {
     );
     expect((session as any).expirationCheckInterval).toBe(600);
     expect(session.styleFamily).toBe("arcgis");
-    expect(session.authentication).toBe("token");
+    expect(session.authentication).toBe(MOCK_AUTH);
     expect(session.canRefresh).toBe(true);
     expect(await session.getToken()).toBe("fake-token");
     expect(session.autoRefresh).toBe(false);
@@ -211,14 +213,14 @@ describe("BasemapStyleSession", () => {
 
     expect(url.startsWith(DEFAULT_START_BASEMAP_STYLE_SESSION_URL)).toBe(true);
     expect(url).toContain("styleFamily=arcgis");
-    expect(url).toContain("token=token");
+    expect(url).toContain("token=fake-token");
     expect(url).toContain("durationSeconds=60");
     expect(url).toContain("f=json");
   });
 
   test("should start a new BasemapStyleSession with a custom safetyMargin", async () => {
     const session = await startMockSession({
-      authentication: "token",
+      authentication: MOCK_AUTH,
       safetyMargin: 600
     });
 
@@ -239,7 +241,7 @@ describe("BasemapStyleSession", () => {
     );
     expect((session as any).expirationCheckInterval).toBe(10000);
     expect(session.styleFamily).toBe("arcgis");
-    expect(session.authentication).toBe("token");
+    expect(session.authentication).toBe(MOCK_AUTH);
     expect(session.canRefresh).toBe(true);
     expect(await session.getToken()).toBe("fake-token");
     expect(session.autoRefresh).toBe(false);
@@ -252,7 +254,7 @@ describe("BasemapStyleSession", () => {
 
     expect(url.startsWith(DEFAULT_START_BASEMAP_STYLE_SESSION_URL)).toBe(true);
     expect(url).toContain("styleFamily=arcgis");
-    expect(url).toContain("token=token");
+    expect(url).toContain("token=fake-token");
     expect(url).toContain("durationSeconds=43200");
     expect(url).toContain("f=json");
   });
@@ -266,7 +268,7 @@ describe("BasemapStyleSession", () => {
     });
 
     const session = await BasemapStyleSession.start({
-      authentication: "token"
+      authentication: MOCK_AUTH
     });
 
     // Validate the session object
@@ -281,7 +283,7 @@ describe("BasemapStyleSession", () => {
       DEFAULT_START_BASEMAP_STYLE_SESSION_URL
     );
     expect(session.styleFamily).toBe("arcgis");
-    expect(session.authentication).toBe("token");
+    expect(session.authentication).toBe(MOCK_AUTH);
     expect(session.canRefresh).toBe(true);
     expect(await session.getToken()).toBe("fake-token");
     expect(session.autoRefresh).toBe(false);
@@ -294,7 +296,7 @@ describe("BasemapStyleSession", () => {
 
     expect(url.startsWith(DEFAULT_START_BASEMAP_STYLE_SESSION_URL)).toBe(true);
     expect(url).toContain("styleFamily=arcgis");
-    expect(url).toContain("token=token");
+    expect(url).toContain("token=fake-token");
     expect(url).toContain("durationSeconds=43200");
     expect(url).toContain("f=json");
   });

--- a/packages/arcgis-rest-basemap-sessions/test/utils/startNewSession.test.ts
+++ b/packages/arcgis-rest-basemap-sessions/test/utils/startNewSession.test.ts
@@ -5,9 +5,10 @@ import {
   IStartSessionResponse
 } from "../../src/utils/startNewSession.js";
 import { MOCK_START_TIME, MOCK_END_TIME } from "../test-utils.js";
+import { ApiKeyManager } from "@esri/arcgis-rest-request";
 
 const MOCK_URL = "https://example.com/startSession";
-const MOCK_AUTH = "fake-token";
+const MOCK_AUTH = ApiKeyManager.fromKey("fake-token");
 
 describe("startNewSession", () => {
   afterEach(() => {
@@ -24,7 +25,7 @@ describe("startNewSession", () => {
 
     fetchMock.getOnce(
       {
-        url: `${MOCK_URL}?f=json&styleFamily=arcgis&durationSeconds=43200&token=${MOCK_AUTH}`
+        url: `${MOCK_URL}?f=json&styleFamily=arcgis&durationSeconds=43200&token=fake-token`
       },
       {
         status: 200,
@@ -50,7 +51,7 @@ describe("startNewSession", () => {
 
     fetchMock.getOnce(
       {
-        url: `${MOCK_URL}?f=json&styleFamily=open&durationSeconds=3600&token=${MOCK_AUTH}`
+        url: `${MOCK_URL}?f=json&styleFamily=open&durationSeconds=3600&token=fake-token`
       },
       {
         status: 200,

--- a/packages/arcgis-rest-elevation/test/findElevationAtManyPoints.test.ts
+++ b/packages/arcgis-rest-elevation/test/findElevationAtManyPoints.test.ts
@@ -1,3 +1,4 @@
+import { expect, test, describe, afterEach } from "vitest";
 import { ApiKeyManager } from "@esri/arcgis-rest-request";
 import fetchMock from "fetch-mock";
 import { findElevationAtManyPoints } from "../src/index.js";
@@ -9,7 +10,7 @@ describe("findElevationAtManyPoints()", () => {
     fetchMock.restore();
   });
 
-  it("should return elevation at points with mean sea level as the reference", async () => {
+  test("should return elevation at points with mean sea level as the reference", async () => {
     fetchMock.mock("*", atManyPointsDefaultResult);
 
     let response = await findElevationAtManyPoints({
@@ -25,7 +26,7 @@ describe("findElevationAtManyPoints()", () => {
     expect(response.result).toEqual(atManyPointsDefaultResult.result);
   });
 
-  it("should return elevation at points with ellipsoid as the reference", async () => {
+  test("should return elevation at points with ellipsoid as the reference", async () => {
     fetchMock.mock("*", atManyPointsEllipsoidResult);
 
     const response = await findElevationAtManyPoints({

--- a/packages/arcgis-rest-elevation/test/findElevationAtPoint.test.ts
+++ b/packages/arcgis-rest-elevation/test/findElevationAtPoint.test.ts
@@ -1,3 +1,4 @@
+import { expect, test, describe, afterEach } from "vitest";
 import { ApiKeyManager } from "@esri/arcgis-rest-request";
 import fetchMock from "fetch-mock";
 import { findElevationAtPoint } from "../src/index.js";
@@ -9,7 +10,7 @@ describe("findElevationAtPoint()", () => {
     fetchMock.restore();
   });
 
-  it("should return elevation at a point with mean sea level as the reference", async () => {
+  test("should return elevation at a point with mean sea level as the reference", async () => {
     fetchMock.mock("*", atPointDefaultResult);
 
     const response = await findElevationAtPoint({
@@ -26,7 +27,7 @@ describe("findElevationAtPoint()", () => {
     expect(url).toContain("token=MOCK_KEY");
   });
 
-  it("should return elevation at a point with ellipsoid as the reference", async () => {
+  test("should return elevation at a point with ellipsoid as the reference", async () => {
     fetchMock.mock("*", atPointEllipsoidResult);
 
     const response = await findElevationAtPoint({

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,11 +3,15 @@ import { defineConfig } from "vite";
 export default defineConfig({
   test: {
     include: [
-      "packages/arcgis-rest-basemap-sessions/**/*.{test,spec}.?(c|m)[jt]s?(x)"
+      "packages/arcgis-rest-basemap-sessions/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "packages/arcgis-rest-elevation/**/*.{test,spec}.?(c|m)[jt]s?(x)"
     ],
     coverage: {
       enabled: true,
-      include: ["packages/arcgis-rest-basemap-sessions/src/**/*.{ts,js}"],
+      include: [
+        "packages/arcgis-rest-basemap-sessions/src/**/*.{ts,js}",
+        "packages/arcgis-rest-elevation/src/**/*.{ts,js}"
+      ],
       provider: "istanbul",
       reporter: ["json", "html", "cobertura"],
       reportsDirectory: "./coverage/vitest",


### PR DESCRIPTION
This PR migrates the elevation tests to Vitest as an example of https://github.com/Esri/arcgis-rest-js/issues/1251

This also makes some changes to reduce console noise in the tests by passing a auth manager instead of a raw token.