### PR TITLE
add token prefixes to oauth conditional

### DIFF
--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -290,7 +290,9 @@ export function internalRequest(
     /* istanbul ignore else - we don't need to test NOT warning people */
     if (
       !options.authentication.startsWith("AAPK") &&
+      !options.authentication.startsWith("AAPT") &&
       !options.authentication.startsWith("AATK") && // doesn't look like an API Key
+      !options.authentication.startsWith("AAST") && // doesn't look like a session token
       !options.suppressWarnings && // user doesn't want to suppress warnings for this request
       !(globalThis as any).ARCGIS_REST_JS_SUPPRESS_TOKEN_WARNING // we haven't shown the user this warning yet
     ) {


### PR DESCRIPTION
Fix for #1253 

Prevent warnings about OAuth 2.0 tokens showing up when you pass an API key or basemap session token.