### PR TITLE
Fix #1231 by allowing a custom state object to opt out of originalUrl behavior

### DIFF
--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -179,7 +179,7 @@ export interface IOAuth2Options {
   style?: "" | "light" | "dark";
 
   /**
-   * Custom value for oAuth 2.0 state. A random identifier will be generated if this is not passed. You may also pass a plain object and the `id` property will be used as the state value. Of an object is passed all properties will be serialized and made available when the {@linkcode ArcGISIdentityManager.completeOAuth2} method is called. If a string is passed it will be available as the `id` property and an additional `originalUrl` property will be added containing the URL of the page that initiated the oAuth 2.0 process.
+   * Custom value for oAuth 2.0 state. A random identifier will be generated if this is not passed. You may also pass a plain object and the `id` property will be used as the state value. If an object is passed, all properties will be serialized and made available when the {@linkcode ArcGISIdentityManager.completeOAuth2} method is called. If a string is passed, it will be available as the `id` property and an additional `originalUrl` property will be added containing the URL of the page that initiated the oAuth 2.0 process.
    */
   state?: string | IOAuthState;
 

--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -23,7 +23,9 @@ import {
 } from "./utils/ArcGISTokenRequestError.js";
 import { NODEJS_DEFAULT_REFERER_HEADER } from "./index.js";
 import { AuthenticationManagerBase } from "./AuthenticationManagerBase.js";
-
+import { getOauthStateId } from "./utils/getOauthStateId.js";
+import { encodeOauthState } from "./utils/encodeOauthState.js";
+import { IOAuthState } from "./types/oauthState.js";
 /**
  * distinguish between an ICredential and IArcGISIdentityManagerOptions
  */
@@ -178,9 +180,9 @@ export interface IOAuth2Options {
   style?: "" | "light" | "dark";
 
   /**
-   * Custom value for oAuth 2.0 state. A random identifier will be generated if this is not passed.
+   * Custom value for oAuth 2.0 state. A random identifier will be generated if this is not passed.You may also pass a plain object and the `id` property will be used as the state value. Of an object is passed all properties will be serialized and made available when the {@linkcode ArcGISIdentityManager.completeOAuth2} method is called. If a string is passed it will be available as the `id` property and an additional `originalUrl` property will be added containing the URL of the page that initiated the oAuth 2.0 process.
    */
-  state?: string;
+  state?: string | IOAuthState;
 
   [key: string]: any;
 }
@@ -269,6 +271,11 @@ export interface IArcGISIdentityManagerOptions {
    * The referer to use when getting the token with `.signIn()`
    */
   referer?: string;
+
+  /**
+   * The OAuth 2.0 state object that was provided when the oAuth 2.0 process was initiated.
+   */
+  state?: IOAuthState;
 }
 
 /**
@@ -388,7 +395,7 @@ export class ArcGISIdentityManager
      * Generate a  random string for the `state` param and store it in local storage. This is used
      * to validate that all parts of the oAuth process were performed on the same client.
      */
-    const stateId = state || generateRandomString(win);
+    const stateId = getOauthStateId(state, win);
     const stateStorageKey = `ARCGIS_REST_JS_AUTH_STATE_${clientId}`;
 
     win.localStorage.setItem(stateStorageKey, stateId);
@@ -400,10 +407,7 @@ export class ArcGISIdentityManager
       response_type: pkce ? "code" : "token",
       expiration: expiration,
       redirect_uri: redirectUri,
-      state: JSON.stringify({
-        id: stateId,
-        originalUrl: win.location.href // this is used to reset the URL back the original URL upon return
-      }),
+      state: encodeOauthState(stateId, state, win.location.href),
       locale: locale,
       style: style
     };
@@ -493,7 +497,8 @@ export class ArcGISIdentityManager
                   username: e.detail.username,
                   refreshToken: e.detail.refreshToken,
                   refreshTokenExpires: e.detail.refreshTokenExpires,
-                  redirectUri
+                  redirectUri,
+                  state: e.detail.state
                 })
               );
             },
@@ -573,6 +578,7 @@ export class ArcGISIdentityManager
         return;
       }
 
+      // istanbul ignore else: We don't need to test that we do nothing here. This will be removed in a future release.
       if (originalUrl) {
         win.history.replaceState(win.history.state, "", originalUrl);
       }
@@ -585,17 +591,15 @@ export class ArcGISIdentityManager
     }
 
     // create a function to create the final ArcGISIdentityManager from the token info.
-    function createManager(
-      oauthInfo: IFetchTokenResponse,
-      originalUrl: string
-    ) {
+    function createManager(oauthInfo: IFetchTokenResponse, state: IOAuthState) {
       win.localStorage.removeItem(stateStorageKey);
 
       if (popup && win.opener) {
         win.opener.dispatchEvent(
           new CustomEvent(`arcgis-rest-js-popup-auth-${clientId}`, {
             detail: {
-              ...oauthInfo
+              ...oauthInfo,
+              state
             }
           })
         );
@@ -605,7 +609,10 @@ export class ArcGISIdentityManager
         return;
       }
 
-      win.history.replaceState(win.history.state, "", originalUrl);
+      // istanbul ignore else: We don't need to test that we do nothing here. This will be removed in a future release.
+      if (state.originalUrl) {
+        win.history.replaceState(win.history.state, "", state.originalUrl);
+      }
 
       return new ArcGISIdentityManager({
         clientId,
@@ -623,7 +630,8 @@ export class ArcGISIdentityManager
           /* istanbul ignore next: TypeScript wont compile if we omit redirectUri */ location.href.replace(
             location.search,
             ""
-          )
+          ),
+        state
       });
     }
 
@@ -647,6 +655,7 @@ export class ArcGISIdentityManager
 
       return reportError(errorMessage, error, state.originalUrl);
     }
+
     /**
      * If we are using PKCE the authorization code will be in the query params.
      * For implicit grants the token will be in the hash.
@@ -672,10 +681,7 @@ export class ArcGISIdentityManager
         }
       })
         .then((tokenResponse) => {
-          return createManager(
-            { ...tokenResponse, ...state },
-            state.originalUrl
-          );
+          return createManager({ ...tokenResponse, ...state }, state);
         })
         .catch((e) => {
           return reportError(e.originalMessage, e.code, state.originalUrl);
@@ -694,7 +700,7 @@ export class ArcGISIdentityManager
             username: params.username,
             ...state
           },
-          state.originalUrl
+          state
         )
       );
     }
@@ -1041,6 +1047,11 @@ export class ArcGISIdentityManager
   public readonly referer: string;
 
   /**
+   * The state object that was provided to the OAuth 2.0 process.
+   */
+  public readonly state: IOAuthState;
+
+  /**
    * Hydrated by a call to [getPortal()](#getPortal-summary).
    */
   private _portalInfo: any;
@@ -1095,6 +1106,7 @@ export class ArcGISIdentityManager
     this.redirectUri = options.redirectUri;
     this.server = options.server;
     this.referer = options.referer;
+    this.state = options.state;
 
     this.federatedServers = {};
     this.trustedDomains = [];

--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -179,7 +179,7 @@ export interface IOAuth2Options {
   style?: "" | "light" | "dark";
 
   /**
-   * Custom value for oAuth 2.0 state. A random identifier will be generated if this is not passed.You may also pass a plain object and the `id` property will be used as the state value. Of an object is passed all properties will be serialized and made available when the {@linkcode ArcGISIdentityManager.completeOAuth2} method is called. If a string is passed it will be available as the `id` property and an additional `originalUrl` property will be added containing the URL of the page that initiated the oAuth 2.0 process.
+   * Custom value for oAuth 2.0 state. A random identifier will be generated if this is not passed. You may also pass a plain object and the `id` property will be used as the state value. Of an object is passed all properties will be serialized and made available when the {@linkcode ArcGISIdentityManager.completeOAuth2} method is called. If a string is passed it will be available as the `id` property and an additional `originalUrl` property will be added containing the URL of the page that initiated the oAuth 2.0 process.
    */
   state?: string | IOAuthState;
 

--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -640,7 +640,7 @@ export class ArcGISIdentityManager
         "no-auth-state"
       );
     }
-    console.log({ stateId, state, options });
+
     if (state.id !== stateId) {
       return reportError(
         "Saved client state did not match server sent state.",

--- a/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
+++ b/packages/arcgis-rest-request/src/ArcGISIdentityManager.ts
@@ -8,7 +8,6 @@ import { IAuthenticationManager } from "./utils/IAuthenticationManager.js";
 import { ITokenRequestOptions } from "./utils/ITokenRequestOptions.js";
 import { decodeQueryString } from "./utils/decode-query-string.js";
 import { encodeQueryString } from "./utils/encode-query-string.js";
-import { IUser } from "./types/user.js";
 import { fetchToken, IFetchTokenResponse } from "./fetch-token.js";
 import { canUseOnlineToken, isFederated } from "./federation-utils.js";
 import { IAppAccess, validateAppAccess } from "./validate-app-access.js";
@@ -641,7 +640,7 @@ export class ArcGISIdentityManager
         "no-auth-state"
       );
     }
-
+    console.log({ stateId, state, options });
     if (state.id !== stateId) {
       return reportError(
         "Saved client state did not match server sent state.",

--- a/packages/arcgis-rest-request/src/types/oauthState.ts
+++ b/packages/arcgis-rest-request/src/types/oauthState.ts
@@ -1,0 +1,5 @@
+export interface IOAuthState {
+  id: string;
+  originalUrl?: string;
+  [key: string]: any;
+}

--- a/packages/arcgis-rest-request/src/utils/encodeOauthState.ts
+++ b/packages/arcgis-rest-request/src/utils/encodeOauthState.ts
@@ -1,0 +1,12 @@
+import { IOAuthState } from "../types/oauthState.js";
+
+export function encodeOauthState(
+  stateId: string,
+  state?: string | IOAuthState,
+  originalUrl?: string
+): string {
+  if (typeof state === "string" || !state) {
+    return JSON.stringify({ id: stateId, originalUrl });
+  }
+  return JSON.stringify({ id: stateId, ...state });
+}

--- a/packages/arcgis-rest-request/src/utils/getOauthStateId.ts
+++ b/packages/arcgis-rest-request/src/utils/getOauthStateId.ts
@@ -1,0 +1,14 @@
+import { IOAuthState } from "../types/oauthState.js";
+import { generateRandomString } from "./generate-random-string.js";
+
+export function getOauthStateId(
+  state?: string | IOAuthState,
+  win?: Window
+): string {
+  if (typeof state === "string") {
+    return state;
+  } else if (typeof state === "object") {
+    return state.id;
+  }
+  return generateRandomString(win);
+}

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -12,11 +12,8 @@ import {
   ErrorTypes,
   ArcGISTokenRequestError,
   ArcGISTokenRequestErrorCodes,
-  IServerInfo,
-  ITokenRequestOptions,
-  IOAuth2Options
+  IServerInfo
 } from "../src/index.js";
-import { FormData } from "@esri/arcgis-rest-form-data";
 import {
   YESTERDAY,
   TOMORROW,
@@ -1483,6 +1480,11 @@ describe("ArcGISIdentityManager", () => {
               expect(session.tokenExpires.getUTCMinutes()).toBe(
                 expectedDate.getUTCMinutes()
               );
+              expect(session.state).toEqual({
+                id: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                originalUrl: "https://test.com"
+              });
+              expect(PopupMockWindow.close).toHaveBeenCalled();
             })
             .catch((e) => {
               fail(e);
@@ -1630,6 +1632,66 @@ describe("ArcGISIdentityManager", () => {
             .then(() => {
               expect(MockWindow.location.href).toBe(
                 "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId12345&response_type=code&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=%7B%22id%22%3A%22AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%22%2C%22originalUrl%22%3A%22https%3A%2F%2Ftest.com%22%7D&locale=&style=&code_challenge_method=plain&code_challenge=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&foo=bar"
+              );
+            })
+            .catch((e) => {
+              fail(e);
+            });
+        });
+
+        it("should pass a custom state object", () => {
+          let PopupMockWindow = createMock();
+          PopupMockWindow.location.search =
+            "?code=auth_code&state=%7B%22id%22%3A%22myCustomId%22%2C%22customStateProperty%22%3A%22test%22%7D";
+          PopupMockWindow.opener = MockWindow;
+
+          fetchMock.post("*", {
+            access_token: "token",
+            expires_in: 1800,
+            username: "c@sey",
+            ssl: true,
+            refresh_token: "refresh_token",
+            refresh_token_expires_in: 1209600
+          });
+
+          window.addEventListener("arcgis-rest-js-popup-auth-start", () => {
+            setTimeout(() => {
+              ArcGISIdentityManager.completeOAuth2(
+                {
+                  clientId: "customStateTestClientId",
+                  redirectUri: "http://example-app.com/redirect"
+                },
+                PopupMockWindow
+              );
+            }, 100);
+          });
+
+          return ArcGISIdentityManager.beginOAuth2(
+            {
+              clientId: "customStateTestClientId",
+              redirectUri: "http://example-app.com/redirect",
+              state: {
+                id: "myCustomId",
+                customStateProperty: "test"
+              }
+            },
+            MockWindow
+          )
+            .then((session) => {
+              expect(MockWindow.open).toHaveBeenCalledWith(
+                "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=customStateTestClientId&response_type=code&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=%7B%22id%22%3A%22myCustomId%22%2C%22customStateProperty%22%3A%22test%22%7D&locale=&style=&code_challenge_method=S256&code_challenge=DwBzhbb51LfusnSGBa_hqYSgo7-j8BTQnip4TOnlzRo",
+                "oauth-window",
+                "height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes"
+              );
+
+              expect(session.state).toEqual({
+                id: "myCustomId",
+                customStateProperty: "test"
+              });
+
+              // now - 5 minutes (offset) + the above expiration (1800 seconds)
+              const expectedDate = new Date(
+                Date.now() - 5 * 60 * 1000 + 1800 * 1000
               );
             })
             .catch((e) => {

--- a/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
+++ b/packages/arcgis-rest-request/test/ArcGISIdentityManager.test.ts
@@ -21,7 +21,6 @@ import {
   isBrowser,
   isNode
 } from "../../../scripts/test-helpers.js";
-
 describe("ArcGISIdentityManager", () => {
   afterEach(() => {
     fetchMock.restore();
@@ -1119,6 +1118,10 @@ describe("ArcGISIdentityManager", () => {
         MockWindow = createMock();
       });
 
+      afterEach(() => {
+        MockWindow = null;
+      });
+
       describe(".beginOAuth2() without PKCE", () => {
         it("should authorize via implicit grant in a popup", () => {
           let PopupMockWindow: any;
@@ -1437,7 +1440,7 @@ describe("ArcGISIdentityManager", () => {
             setTimeout(() => {
               ArcGISIdentityManager.completeOAuth2(
                 {
-                  clientId: "clientId1234",
+                  clientId: "clientIdBasicPKCE",
                   redirectUri: "http://example-app.com/redirect"
                 },
                 PopupMockWindow
@@ -1447,14 +1450,14 @@ describe("ArcGISIdentityManager", () => {
 
           return ArcGISIdentityManager.beginOAuth2(
             {
-              clientId: "clientId1234",
+              clientId: "clientIdBasicPKCE",
               redirectUri: "http://example-app.com/redirect"
             },
             MockWindow
           )
             .then((session) => {
               expect(MockWindow.open).toHaveBeenCalledWith(
-                "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientId1234&response_type=code&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=%7B%22id%22%3A%22AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%22%2C%22originalUrl%22%3A%22https%3A%2F%2Ftest.com%22%7D&locale=&style=&code_challenge_method=S256&code_challenge=DwBzhbb51LfusnSGBa_hqYSgo7-j8BTQnip4TOnlzRo",
+                "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientIdBasicPKCE&response_type=code&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=%7B%22id%22%3A%22AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%22%2C%22originalUrl%22%3A%22https%3A%2F%2Ftest.com%22%7D&locale=&style=&code_challenge_method=S256&code_challenge=DwBzhbb51LfusnSGBa_hqYSgo7-j8BTQnip4TOnlzRo",
                 "oauth-window",
                 "height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes"
               );
@@ -1693,6 +1696,80 @@ describe("ArcGISIdentityManager", () => {
               const expectedDate = new Date(
                 Date.now() - 5 * 60 * 1000 + 1800 * 1000
               );
+            })
+            .catch((e) => {
+              fail(e);
+            });
+        });
+
+        it("should pass a custom state string", () => {
+          let PopupMockWindow = createMock();
+          PopupMockWindow.location.search =
+            "?code=auth_code&state=%7B%22id%22%3A%22customStateString%22%2C%22originalUrl%22%3A%22https%3A%2F%2Ftest.com%22%7D";
+          PopupMockWindow.opener = MockWindow;
+
+          fetchMock.post("*", {
+            access_token: "token",
+            expires_in: 1800,
+            username: "c@sey",
+            ssl: true,
+            refresh_token: "refresh_token",
+            refresh_token_expires_in: 1209600
+          });
+
+          window.addEventListener("arcgis-rest-js-popup-auth-start", () => {
+            setTimeout(() => {
+              ArcGISIdentityManager.completeOAuth2(
+                {
+                  clientId: "clientIdCustomStateString",
+                  redirectUri: "http://example-app.com/redirect"
+                },
+                PopupMockWindow
+              );
+            }, 100);
+          });
+
+          return ArcGISIdentityManager.beginOAuth2(
+            {
+              clientId: "clientIdCustomStateString",
+              redirectUri: "http://example-app.com/redirect",
+              state: "customStateString"
+            },
+            MockWindow
+          )
+            .then((session) => {
+              expect(MockWindow.open).toHaveBeenCalledWith(
+                "https://www.arcgis.com/sharing/rest/oauth2/authorize?client_id=clientIdCustomStateString&response_type=code&expiration=20160&redirect_uri=http%3A%2F%2Fexample-app.com%2Fredirect&state=%7B%22id%22%3A%22customStateString%22%2C%22originalUrl%22%3A%22https%3A%2F%2Ftest.com%22%7D&locale=&style=&code_challenge_method=S256&code_challenge=DwBzhbb51LfusnSGBa_hqYSgo7-j8BTQnip4TOnlzRo",
+                "oauth-window",
+                "height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes"
+              );
+
+              expect(session.token).toBe("token");
+              expect(session.username).toBe("c@sey");
+              expect(session.ssl).toBe(true);
+              expect(session.redirectUri).toBe(
+                "http://example-app.com/redirect"
+              );
+              // now - 5 minutes (offset) + the above expiration (1800 seconds)
+              const expectedDate = new Date(
+                Date.now() - 5 * 60 * 1000 + 1800 * 1000
+              );
+
+              // // The times will be off a few milliseconds because we have to wait for some async work to we just compare date, hour and minute values.
+              expect(session.tokenExpires.toDateString()).toBe(
+                expectedDate.toDateString()
+              );
+              expect(session.tokenExpires.getUTCHours()).toBe(
+                expectedDate.getUTCHours()
+              );
+              expect(session.tokenExpires.getUTCMinutes()).toBe(
+                expectedDate.getUTCMinutes()
+              );
+              expect(session.state).toEqual({
+                id: "customStateString",
+                originalUrl: "https://test.com"
+              });
+              expect(PopupMockWindow.close).toHaveBeenCalled();
             })
             .catch((e) => {
               fail(e);


### PR DESCRIPTION
This PR allows for a workaround to avoid #1231. This allows a custom object to be passed as the `state` property in `.beginOauth2()`. If an object is passed the `originalUrl` will not be encoded into the `state`.

```ts
ArcGISIdentityManager.beginOAuth2({
  cilentId,
  redirectUrl,
  state: {
    // an empty object will work to remove the originalUrl behavior
  }
});
```

Then in order to make `state` a little more useful it is also exposed on the resulting `ArcGISIdentityManager` instance so it can be accessed after the oAuth process is complete. 