### PR TITLE
chore: migrate arcgis-rest-geocoding package tests to Vitest

### DIFF
--- a/jasmine.json
+++ b/jasmine.json
@@ -5,7 +5,6 @@
     "arcgis-rest-developer-credentials/{src,test}/**/*.test.ts",
     "arcgis-rest-elevation/{src,test}/**/*.test.ts",
     "arcgis-rest-feature-service/{src,test}/**/*.test.ts",
-    "arcgis-rest-geocoding/{src,test}/**/*.test.ts",
     "arcgis-rest-portal/{src,test}/**/*.test.ts",
     "arcgis-rest-places/{src,test}/**/*.test.ts",
     "arcgis-rest-routing/{src,test}/**/*.test.ts",

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -17,7 +17,6 @@ module.exports = function (config) {
       "packages/arcgis-rest-developer-credentials/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-elevation/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-feature-service/{src,test}/**/!(*.test.live).ts",
-      "packages/arcgis-rest-geocoding/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-places/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-portal/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-request/{src,test}/**/!(*.test.live).ts",

--- a/packages/arcgis-rest-geocoding/test/geocode.test.ts
+++ b/packages/arcgis-rest-geocoding/test/geocode.test.ts
@@ -1,6 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, test, afterEach, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { geocode } from "../src/geocode.js";
 import {
@@ -17,157 +18,128 @@ describe("geocode", () => {
     fetchMock.restore();
   });
 
-  it("should make a simple, single geocoding request", (done) => {
+  test("should make a simple, single geocoding request", async () => {
     fetchMock.once("*", FindAddressCandidates);
 
-    geocode("LAX")
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain("singleLine=LAX");
-        // the only properties this lib tacks on
-        expect(response.spatialReference.wkid).toEqual(4326);
-        expect(response.geoJson.features.length).toBeGreaterThan(0);
-        expect(response.geoJson.features[0].properties.score).toBeGreaterThan(
-          0
-        );
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await geocode("LAX");
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain("singleLine=LAX");
+    // the only properties this lib tacks on
+    expect(response.spatialReference.wkid).toEqual(4326);
+    expect(response.geoJson.features.length).toBeGreaterThan(0);
+    expect(response.geoJson.features[0].properties.score).toBeGreaterThan(0);
   });
 
-  it("should a geocoding request with custom parameters", (done) => {
+  test("should a geocoding request with custom parameters", async () => {
     fetchMock.once("*", FindAddressCandidates);
 
-    geocode({ address: "1600 Pennsylvania Avenue", city: "Washington D.C." })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain(
-          `address=${encodeURIComponent("1600 Pennsylvania Avenue")}`
-        );
-        expect(options.body).toContain(
-          `city=${encodeURIComponent("Washington D.C.")}`
-        );
-        // the only property this lib tacks on
-        expect(response.spatialReference.wkid).toEqual(4326);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await geocode({
+      address: "1600 Pennsylvania Avenue",
+      city: "Washington D.C."
+    });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(
+      `address=${encodeURIComponent("1600 Pennsylvania Avenue")}`
+    );
+    expect(options.body).toContain(
+      `city=${encodeURIComponent("Washington D.C.")}`
+    );
+    // the only property this lib tacks on
+    expect(response.spatialReference.wkid).toEqual(4326);
   });
 
-  it("should make a simple, single geocoding request with a named parameter", (done) => {
+  test("should make a simple, single geocoding request with a named parameter", async () => {
     fetchMock.once("*", FindAddressCandidates);
 
-    geocode({
+    const response = await geocode({
       singleLine: "380 New York Street",
       outFields: ["Addr_type", "Score"]
-    })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
-        );
-        const singleLineEncoded = encodeURIComponent("380 New York Street");
-        expect(options.body).toContain(`singleLine=${singleLineEncoded}`);
-        const outFieldsEncoded = encodeURIComponent(
-          ["Addr_type", "Score"].join(",")
-        );
-        expect(options.body).toContain(`outFields=${outFieldsEncoded}`);
-        expect(response.spatialReference.wkid).toEqual(4326);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+    );
+    const singleLineEncoded = encodeURIComponent("380 New York Street");
+    expect(options.body).toContain(`singleLine=${singleLineEncoded}`);
+    const outFieldsEncoded = encodeURIComponent(
+      ["Addr_type", "Score"].join(",")
+    );
+    expect(options.body).toContain(`outFields=${outFieldsEncoded}`);
+    expect(response.spatialReference.wkid).toEqual(4326);
   });
 
-  it("should make a simple, single geocoding request with a custom parameter", (done) => {
+  test("should make a simple, single geocoding request with a custom parameter", async () => {
     fetchMock.once("*", FindAddressCandidates);
 
-    geocode({
+    const response = await geocode({
       params: {
         singleLine: "LAX",
         countryCode: "USA",
         outFields: ["Addr_type", "Score"]
       }
-    })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain("singleLine=LAX");
-        expect(options.body).toContain("countryCode=USA");
-        const outFieldsEncoded = encodeURIComponent(
-          ["Addr_type", "Score"].join(",")
-        );
-        expect(options.body).toContain(`outFields=${outFieldsEncoded}`);
-        // the only property this lib tacks on
-        expect(response.spatialReference.wkid).toEqual(4326);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain("singleLine=LAX");
+    expect(options.body).toContain("countryCode=USA");
+    const outFieldsEncoded = encodeURIComponent(
+      ["Addr_type", "Score"].join(",")
+    );
+    expect(options.body).toContain(`outFields=${outFieldsEncoded}`);
+    // the only property this lib tacks on
+    expect(response.spatialReference.wkid).toEqual(4326);
   });
 
-  it("should make a single geocoding request to a custom geocoding service", (done) => {
+  test("should make a single geocoding request to a custom geocoding service", async () => {
     fetchMock.once("*", FindAddressCandidates3857);
 
-    geocode({
+    const response = await geocode({
       endpoint: customGeocoderUrl,
       params: {
         outSr: 3857,
         address: "380 New York St",
         postal: 92373
       }
-    })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/findAddressCandidates"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain(
-          `address=${encodeURIComponent("380 New York St")}`
-        );
-        expect(options.body).toContain("postal=92373");
-        expect(options.body).toContain("outSr=3857");
-        // the only properties this lib tacks on
-        expect(response.spatialReference.wkid).toEqual(102100);
-        expect(response.geoJson).toBeUndefined();
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/findAddressCandidates"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(
+      `address=${encodeURIComponent("380 New York St")}`
+    );
+    expect(options.body).toContain("postal=92373");
+    expect(options.body).toContain("outSr=3857");
+    // the only properties this lib tacks on
+    expect(response.spatialReference.wkid).toEqual(102100);
+    expect(response.geoJson).toBeUndefined();
   });
 
-  it("should pass through all requestOptions when making a geocoding request", (done) => {
+  test("should pass through all requestOptions when making a geocoding request", async () => {
     fetchMock.once("*", FindAddressCandidates3857);
 
-    geocode({
+    const response = await geocode({
       endpoint: customGeocoderUrl,
       params: {
         outSr: 3857,
@@ -175,146 +147,113 @@ describe("geocode", () => {
         postal: 92373
       },
       httpMethod: "GET"
-    })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/findAddressCandidates?f=json&outSr=3857&address=380%20New%20York%20St&postal=92373"
-        );
-        expect(options.method).toBe("GET");
-        // the only property this lib tacks on
-        expect(response.spatialReference.wkid).toEqual(102100);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/findAddressCandidates?f=json&outSr=3857&address=380%20New%20York%20St&postal=92373"
+    );
+    expect(options.method).toBe("GET");
+    // the only property this lib tacks on
+    expect(response.spatialReference.wkid).toEqual(102100);
   });
 
-  it("should handle geocoders that return null extents for location candidates", (done) => {
+  test("should handle geocoders that return null extents for location candidates", async () => {
     fetchMock.once("*", FindAddressCandidatesNullExtent);
 
-    geocode("LAX")
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain("singleLine=LAX");
-        // the only property this lib tacks on
-        expect(response.spatialReference.wkid).toEqual(4326);
-        expect(
-          response.candidates.every((candidate) => candidate.extent == null)
-        );
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await geocode("LAX");
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain("singleLine=LAX");
+    // the only property this lib tacks on
+    expect(response.spatialReference.wkid).toEqual(4326);
+    expect(
+      response.candidates.every((candidate) => candidate.extent == null)
+    ).toBe(true);
   });
 
-  it("should support rawResponse", (done) => {
+  test("should support rawResponse", async () => {
     fetchMock.once("*", FindAddressCandidates);
-    geocode({
+    const response: any = await geocode({
       address: "1600 Pennsylvania Avenue",
       city: "Washington D.C.",
       rawResponse: true
-    })
-      .then((response: any) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain(
-          `address=${encodeURIComponent("1600 Pennsylvania Avenue")}`
-        );
-        expect(options.body).toContain(
-          `city=${encodeURIComponent("Washington D.C.")}`
-        );
-        expect(options.method).toBe("POST");
-        expect(response.status).toBe(200);
-        expect(response.ok).toBe(true);
-        expect(response.body.Readable).not.toBe(null);
-        response.json().then((raw: any) => {
-          expect(raw).toEqual(FindAddressCandidates);
-          done();
-        });
-        // this used to work with isomorphic-fetch
-        // expect(response instanceof Response).toBe(true);
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(
+      `address=${encodeURIComponent("1600 Pennsylvania Avenue")}`
+    );
+    expect(options.body).toContain(
+      `city=${encodeURIComponent("Washington D.C.")}`
+    );
+    expect(options.method).toBe("POST");
+    expect(response.status).toBe(200);
+    expect(response.ok).toBe(true);
+    expect(response.body.Readable).not.toBe(null);
+    const raw = await response.json();
+    expect(raw).toEqual(FindAddressCandidates);
+    // this used to work with isomorphic-fetch
+    // expect(response instanceof Response).toBe(true);
   });
 
-  it("should make a single geocoding request with a postal code as a string", (done) => {
+  test("should make a single geocoding request with a postal code as a string", async () => {
     fetchMock.once("*", FindAddressCandidates);
 
-    geocode({
+    const response = await geocode({
       params: {
         address: "1205 Williston Rd",
         postal: "05403"
       }
-    })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain(
-          `address=${encodeURIComponent("1205 Williston Rd")}`
-        );
-        expect(options.body).toContain("postal=05403");
+    });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(
+      `address=${encodeURIComponent("1205 Williston Rd")}`
+    );
+    expect(options.body).toContain("postal=05403");
 
-        expect(response.spatialReference.wkid).toEqual(4326);
-        expect(response.geoJson.features.length).toBeGreaterThan(0);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    expect(response.spatialReference.wkid).toEqual(4326);
+    expect(response.geoJson.features.length).toBeGreaterThan(0);
   });
 
-  it("should make a single geocoding request with a postal code as a number", (done) => {
+  test("should make a single geocoding request with a postal code as a number", async () => {
     fetchMock.once("*", FindAddressCandidates);
 
-    geocode({
+    const response = await geocode({
       params: {
         address: "380 New York St, Redlands, California",
         postal: 92373
       }
-    })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain(
-          `address=${encodeURIComponent(
-            "380 New York St, Redlands, California"
-          )}`
-        );
-        expect(options.body).toContain("postal=92373");
+    });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(
+      `address=${encodeURIComponent("380 New York St, Redlands, California")}`
+    );
+    expect(options.body).toContain("postal=92373");
 
-        expect(response.spatialReference.wkid).toEqual(4326);
-        expect(response.geoJson.features.length).toBeGreaterThan(0);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    expect(response.spatialReference.wkid).toEqual(4326);
+    expect(response.geoJson.features.length).toBeGreaterThan(0);
   });
 });

--- a/packages/arcgis-rest-geocoding/test/helpers.test.ts
+++ b/packages/arcgis-rest-geocoding/test/helpers.test.ts
@@ -1,6 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, test, afterEach, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { getGeocodeService } from "../src/helpers.js";
 import { SharingInfo } from "./mocks/responses.js";
@@ -12,75 +13,58 @@ describe("geocode", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("should retrieve metadata from the World Geocoding Service", (done) => {
+
+  test("should retrieve metadata from the World Geocoding Service", async () => {
     fetchMock.once("*", SharingInfo);
 
-    getGeocodeService()
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/?f=json"
-        );
-        expect(options.method).toBe("GET");
-        // expect(response).toEqual(SharingInfo); // need to fix something in order introspect the whole response
-        expect(response.currentVersion).toEqual(10.41);
-        expect(response.serviceDescription).toEqual(
-          "Sample geocoder for San Diego, California, USA"
-        );
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await getGeocodeService();
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/?f=json"
+    );
+    expect(options.method).toBe("GET");
+    // expect(response).toEqual(SharingInfo); // need to fix something in order introspect the whole response
+    expect(response.currentVersion).toEqual(10.41);
+    expect(response.serviceDescription).toEqual(
+      "Sample geocoder for San Diego, California, USA"
+    );
   });
 
-  it("should make POST request for metadata from the World Geocoding Service", (done) => {
+  test("should make POST request for metadata from the World Geocoding Service", async () => {
     fetchMock.once("*", SharingInfo);
 
-    getGeocodeService({ httpMethod: "POST" })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        // expect(paramsSpy).toHaveBeenCalledWith("f", "json");
-        // expect(response).toEqual(SharingInfo); // need to fix something in order introspect the whole response
-        expect(response.currentVersion).toEqual(10.41);
-        expect(response.serviceDescription).toEqual(
-          "Sample geocoder for San Diego, California, USA"
-        );
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await getGeocodeService({ httpMethod: "POST" });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    // expect(paramsSpy).toHaveBeenCalledWith("f", "json");
+    // expect(response).toEqual(SharingInfo); // need to fix something in order introspect the whole response
+    expect(response.currentVersion).toEqual(10.41);
+    expect(response.serviceDescription).toEqual(
+      "Sample geocoder for San Diego, California, USA"
+    );
   });
 
-  it("should retrieve metadata from custom geocoding services", (done) => {
+  test("should retrieve metadata from custom geocoding services", async () => {
     fetchMock.once("*", SharingInfo);
 
-    getGeocodeService({ endpoint: customGeocoderUrl })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/?f=json"
-        );
-        expect(options.method).toBe("GET");
-        // how to introspect the whole response?
-        // expect(response).toEqual(SharingInfo);
-        expect(response.currentVersion).toEqual(10.41);
-        expect(response.serviceDescription).toEqual(
-          "Sample geocoder for San Diego, California, USA"
-        );
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await getGeocodeService({ endpoint: customGeocoderUrl });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://foo.com/arcgis/rest/services/Custom/GeocodeServer/?f=json"
+    );
+    expect(options.method).toBe("GET");
+    // how to introspect the whole response?
+    // expect(response).toEqual(SharingInfo);
+    expect(response.currentVersion).toEqual(10.41);
+    expect(response.serviceDescription).toEqual(
+      "Sample geocoder for San Diego, California, USA"
+    );
   });
 });

--- a/packages/arcgis-rest-geocoding/test/reverse.test.ts
+++ b/packages/arcgis-rest-geocoding/test/reverse.test.ts
@@ -1,6 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, test, afterEach, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { reverseGeocode } from "../src/reverse.js";
 import { ReverseGeocode } from "./mocks/responses.js";
@@ -9,117 +10,89 @@ describe("geocode", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("should make a reverse geocoding request", (done) => {
+
+  test("should make a reverse geocoding request", async () => {
     fetchMock.once("*", ReverseGeocode);
 
-    reverseGeocode({ x: -118.409, y: 33.9425 })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain(
-          `location=${encodeURIComponent('{"x":-118.409,"y":33.9425}')}`
-        );
-        expect(response).toEqual(ReverseGeocode); // introspect the entire response
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await reverseGeocode({ x: -118.409, y: 33.9425 });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(
+      `location=${encodeURIComponent('{"x":-118.409,"y":33.9425}')}`
+    );
+    expect(response).toEqual(ReverseGeocode); // introspect the entire response
   });
 
-  it("should make a reverse geocoding GET request and pass through a spatial reference", (done) => {
+  test("should make a reverse geocoding GET request and pass through a spatial reference", async () => {
     fetchMock.once("*", ReverseGeocode);
 
-    reverseGeocode(
+    const response = await reverseGeocode(
       { x: -118.409, y: 33.9425, spatialReference: { wkid: 4326 } },
       { httpMethod: "GET" }
-    )
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?f=json&location=%7B%22x%22%3A-118.409%2C%22y%22%3A33.9425%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D"
-        );
-        expect(options.method).toBe("GET");
-        expect(response).toEqual(ReverseGeocode); // this introspects the entire response
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    );
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?f=json&location=%7B%22x%22%3A-118.409%2C%22y%22%3A33.9425%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D"
+    );
+    expect(options.method).toBe("GET");
+    expect(response).toEqual(ReverseGeocode); // this introspects the entire response
   });
 
-  it("should make a reverse geocoding request and translate lat/long JSON objects", (done) => {
+  test("should make a reverse geocoding request and translate lat/long JSON objects", async () => {
     fetchMock.once("*", ReverseGeocode);
 
-    reverseGeocode({ longitude: -118.409, latitude: 33.9425 })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain(
-          `location=${encodeURIComponent("-118.409,33.9425")}`
-        );
-        expect(response).toEqual(ReverseGeocode); // this introspects the entire response
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await reverseGeocode({
+      longitude: -118.409,
+      latitude: 33.9425
+    });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(
+      `location=${encodeURIComponent("-118.409,33.9425")}`
+    );
+    expect(response).toEqual(ReverseGeocode); // this introspects the entire response
   });
 
-  it("should make a reverse geocoding request and translate lat/long JSON abbreviated objects", (done) => {
+  test("should make a reverse geocoding request and translate lat/long JSON abbreviated objects", async () => {
     fetchMock.once("*", ReverseGeocode);
 
-    reverseGeocode({ lat: 33.9425, long: -118.409 })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain(
-          `location=${encodeURIComponent("-118.409,33.9425")}`
-        );
-        expect(response).toEqual(ReverseGeocode); // this introspects the entire response
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await reverseGeocode({ lat: 33.9425, long: -118.409 });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(
+      `location=${encodeURIComponent("-118.409,33.9425")}`
+    );
+    expect(response).toEqual(ReverseGeocode); // this introspects the entire response
   });
 
-  it("should make a reverse geocoding request and translate a raw long,lat array", (done) => {
+  test("should make a reverse geocoding request and translate a raw long,lat array", async () => {
     fetchMock.once("*", ReverseGeocode);
 
-    reverseGeocode([-118, 34])
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain(
-          `location=${encodeURIComponent("-118,34")}`
-        );
-        expect(response).toEqual(ReverseGeocode); // this introspects the entire response
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await reverseGeocode([-118, 34]);
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(`location=${encodeURIComponent("-118,34")}`);
+    expect(response).toEqual(ReverseGeocode); // this introspects the entire response
   });
 });

--- a/packages/arcgis-rest-geocoding/test/suggest.test.ts
+++ b/packages/arcgis-rest-geocoding/test/suggest.test.ts
@@ -1,6 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, afterEach, test, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { suggest } from "../src/suggest.js";
 import { Suggest } from "./mocks/responses.js";
@@ -9,46 +10,37 @@ describe("geocode", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("should make a request for suggestions", (done) => {
+
+  test("should make a request for suggestions", async () => {
     fetchMock.once("*", Suggest);
 
-    suggest("LAX")
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain("text=LAX");
-        expect(response).toEqual(Suggest); // this introspects the entire response
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await suggest("LAX");
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain("text=LAX");
+    expect(response).toEqual(Suggest); // this introspects the entire response
   });
 
-  it("should make a request for suggestions with other parameters", (done) => {
+  test("should make a request for suggestions with other parameters", async () => {
     fetchMock.once("*", Suggest);
 
-    suggest("LAX", { params: { category: "Address,Postal" } })
-      .then((response) => {
-        expect(fetchMock.called()).toEqual(true);
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest"
-        );
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain("text=LAX");
-        expect(options.body).toContain("category=Address%2CPostal");
-        expect(response).toEqual(Suggest); // this introspects the entire response
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await suggest("LAX", {
+      params: { category: "Address,Postal" }
+    });
+    expect(fetchMock.called()).toEqual(true);
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest"
+    );
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain("text=LAX");
+    expect(options.body).toContain("category=Address%2CPostal");
+    expect(response).toEqual(Suggest); // this introspects the entire response
   });
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,11 +3,15 @@ import { defineConfig } from "vite";
 export default defineConfig({
   test: {
     include: [
-      "packages/arcgis-rest-basemap-sessions/**/*.{test,spec}.?(c|m)[jt]s?(x)"
+      "packages/arcgis-rest-basemap-sessions/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "packages/arcgis-rest-geocoding/**/*.{test,spec}.?(c|m)[jt]s?(x)"
     ],
     coverage: {
       enabled: true,
-      include: ["packages/arcgis-rest-basemap-sessions/src/**/*.{ts,js}"],
+      include: [
+        "packages/arcgis-rest-basemap-sessions/src/**/*.{ts,js}",
+        "packages/arcgis-rest-geocoding/src/**/*.{ts,js}"
+      ],
       provider: "istanbul",
       reporter: ["json", "html", "cobertura"],
       reportsDirectory: "./coverage/vitest",


### PR DESCRIPTION
This PR migrates the demographics package tests to Vitest as part of https://github.com/Esri/arcgis-rest-js/issues/1251