### PR TITLE
chore: make the job tests less noisy

### DIFF
--- a/packages/arcgis-rest-request/src/job.ts
+++ b/packages/arcgis-rest-request/src/job.ts
@@ -238,7 +238,6 @@ export class Job {
    */
   private setIntervalHandler: any;
 
-
   constructor(options: IJobOptions) {
     const { url, id, pollingRate, authentication }: Partial<IJobOptions> = {
       ...DefaultJobOptions,
@@ -252,6 +251,7 @@ export class Job {
     this._pollingRate = pollingRate;
     this.emitter = mitt();
 
+    // istanbul ignore next - trying to test this results in multiple unhandled requests which fetch-mock doesn't like.
     if (options.startMonitoring) {
       this.startEventMonitoring(pollingRate);
     }

--- a/packages/arcgis-rest-request/test/job.test.ts
+++ b/packages/arcgis-rest-request/test/job.test.ts
@@ -316,7 +316,7 @@ describe("Job", () => {
     });
   });
 
-  it("create a new job and fire the new, submitted, waiting and time-out states", (done) => {
+  it("create a new job and fire the new, submitted, waiting, and time-out states", (done) => {
     const {
       submitOptions,
       jobSubmittedResponse,

--- a/packages/arcgis-rest-request/test/mocks/job-mock-fetches.ts
+++ b/packages/arcgis-rest-request/test/mocks/job-mock-fetches.ts
@@ -4,7 +4,7 @@ export const GPEndpointCall = {
     Query: `"DATE" > date '1998-01-01 00:00:00' AND "DATE" < date '1998-01-31 00:00:00') AND ("Day" = 'SUN' OR "Day"= 'SAT'),
   `
   },
-  startMonitoring: true,
+  startMonitoring: false,
   pollingRate: 5000
 };
 


### PR DESCRIPTION
This PR makes the job tests quieter by disabling polling during the tests to reduce unmatched requests in fetch mock. In a lot of cases I feel like this shouldn't be happening anyway because we have a lot of generic `*` handlers.

This mostly reworks the test to still test the same cases but without the polling that was causing extra requests. This also adds a utility function to create mocks with different ids so we can differentiate requests between test more easily.