### PR TITLE
fix(arcgis-rest-feature-service): add support for authenticated layers to queryAllFeatures()

### DIFF
--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -285,7 +285,8 @@ export async function queryAllFeatures(
 
   // retrieve the maxRecordCount for the service
   const pageSizeResponse = await request(requestOptions.url, {
-    httpMethod: "GET"
+    httpMethod: "GET",
+    authentication: requestOptions.authentication
   });
   // default the pageSize to 2000 if it is not provided
   const pageSize = pageSizeResponse.maxRecordCount || 2000;
@@ -366,7 +367,6 @@ export async function queryAllFeatures(
     }
 
     const returnedCount = response.features.length;
-
 
     // check if the response has exceededTransferLimit handles both the standard json and geojson responses
     const exceededTransferLimit =


### PR DESCRIPTION
Fixes #1261 by passing through the authentication object.