### PR TITLE
chore: migrate arcgis-rest-feature-service package tests to Vitest

### DIFF
--- a/jasmine.json
+++ b/jasmine.json
@@ -2,7 +2,6 @@
   "spec_dir": "packages",
   "spec_files": [
     "arcgis-rest-developer-credentials/{src,test}/**/*.test.ts",
-    "arcgis-rest-feature-service/{src,test}/**/*.test.ts",
     "arcgis-rest-portal/{src,test}/**/*.test.ts",
     "arcgis-rest-routing/{src,test}/**/*.test.ts",
     "arcgis-rest-request/{src,test}/**/*.test.ts"

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -14,7 +14,6 @@ module.exports = function (config) {
     // list of files / patterns to load in the browser
     files: [
       "packages/arcgis-rest-developer-credentials/{src,test}/**/!(*.test.live).ts",
-      "packages/arcgis-rest-feature-service/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-portal/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-request/{src,test}/**/!(*.test.live).ts",
       "packages/arcgis-rest-routing/{src,test}/**/!(*.test.live).ts",

--- a/packages/arcgis-rest-feature-service/src/decodeValues.ts
+++ b/packages/arcgis-rest-feature-service/src/decodeValues.ts
@@ -83,7 +83,6 @@ export function decodeValues(
       (feature: IFeature) => {
         const decodedAttributes: { [index: string]: any } = {};
         for (const key in feature.attributes) {
-          /* istanbul ignore next */
           if (!Object.prototype.hasOwnProperty.call(feature.attributes, key))
             continue;
           const value = feature.attributes[key];

--- a/packages/arcgis-rest-feature-service/test/addToServiceDefinition.test.ts
+++ b/packages/arcgis-rest-feature-service/test/addToServiceDefinition.test.ts
@@ -2,21 +2,22 @@
  * Apache-2.0 */
 
 import fetchMock from "fetch-mock";
+import { describe, afterEach, test, expect } from "vitest";
 import { TOMORROW } from "../../../scripts/test-helpers.js";
+import { ILayer, ITable } from "../src/helpers.js";
 import {
   encodeParam,
   ErrorTypes,
   ArcGISIdentityManager
 } from "@esri/arcgis-rest-request";
-import { ILayer, ITable } from "../src/helpers.js";
 import { addToServiceDefinition } from "../src/addToServiceDefinition.js";
+import { layerDefinitionSid } from "./mocks/layerDefinition.js";
 import {
   AddToFeatureServiceSuccessResponseFredAndGinger,
   AddToFeatureServiceSuccessResponseFayardAndHarold,
   AddToFeatureServiceSuccessResponseCydAndGene,
   AddToFeatureServiceError
 } from "./mocks/service.js";
-import { layerDefinitionSid } from "./mocks/layerDefinition.js";
 
 describe("add to feature service", () => {
   afterEach(() => {
@@ -84,264 +85,209 @@ describe("add to feature service", () => {
       id: 0
     };
 
-    it("should add a pair of layers", (done) => {
+    test("should add a pair of layers", async () => {
       fetchMock.once("*", AddToFeatureServiceSuccessResponseFredAndGinger);
 
-      addToServiceDefinition(
+      const response = await addToServiceDefinition(
         "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
         {
           layers: [layerDescriptionFred, layerDescriptionGinger],
           ...MOCK_USER_REQOPTS
         }
-      )
-        .then(
-          (response) => {
-            // Check service call
-            expect(fetchMock.called()).toEqual(true);
-            const [url, options] = fetchMock.lastCall("*");
-
-            expect(url).toEqual(
-              "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
-            );
-            expect(options.method).toBe("POST");
-            expect(options.body).toContain("f=json");
-            expect(options.body).toContain(encodeParam("token", "fake-token"));
-            expect(options.body).toContain(
-              encodeParam(
-                "addToDefinition",
-                JSON.stringify({
-                  layers: [layerDescriptionFred, layerDescriptionGinger]
-                })
-              )
-            );
-
-            // Check response
-            expect(response).toEqual(
-              AddToFeatureServiceSuccessResponseFredAndGinger
-            );
-
-            done();
-          },
-          () => {
-            fail(); // call is supposed to succeed
-          }
+      );
+      // Check service call
+      expect(fetchMock.called()).toEqual(true);
+      const [url, options] = fetchMock.lastCall("*");
+      expect(url).toEqual(
+        "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
+      );
+      expect(options.method).toBe("POST");
+      expect(options.body).toContain("f=json");
+      expect(options.body).toContain(encodeParam("token", "fake-token"));
+      expect(options.body).toContain(
+        encodeParam(
+          "addToDefinition",
+          JSON.stringify({
+            layers: [layerDescriptionFred, layerDescriptionGinger]
+          })
         )
-        .catch((e) => {
-          fail(e);
-        });
+      );
+      // Check response
+      expect(response).toEqual(AddToFeatureServiceSuccessResponseFredAndGinger);
     });
 
-    it("should add a pair of tables", (done) => {
+    test("should add a pair of tables", async () => {
       fetchMock.once("*", AddToFeatureServiceSuccessResponseFayardAndHarold);
 
-      addToServiceDefinition(
+      const response = await addToServiceDefinition(
         "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
         {
           tables: [tableDescriptionFayard, tableDescriptionHarold],
           ...MOCK_USER_REQOPTS
         }
-      )
-        .then(
-          (response) => {
-            // Check service call
-            expect(fetchMock.called()).toEqual(true);
-            const [url, options] = fetchMock.lastCall("*");
-
-            expect(url).toEqual(
-              "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
-            );
-            expect(options.method).toBe("POST");
-            expect(options.body).toContain("f=json");
-            expect(options.body).toContain(encodeParam("token", "fake-token"));
-            expect(options.body).toContain(
-              encodeParam(
-                "addToDefinition",
-                JSON.stringify({
-                  tables: [tableDescriptionFayard, tableDescriptionHarold]
-                })
-              )
-            );
-
-            // Check response
-            expect(response).toEqual(
-              AddToFeatureServiceSuccessResponseFayardAndHarold
-            );
-
-            done();
-          },
-          () => {
-            fail(); // call is supposed to succeed
-          }
+      );
+      // Check service call
+      expect(fetchMock.called()).toEqual(true);
+      const [url, options] = fetchMock.lastCall("*");
+      expect(url).toEqual(
+        "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
+      );
+      expect(options.method).toBe("POST");
+      expect(options.body).toContain("f=json");
+      expect(options.body).toContain(encodeParam("token", "fake-token"));
+      expect(options.body).toContain(
+        encodeParam(
+          "addToDefinition",
+          JSON.stringify({
+            tables: [tableDescriptionFayard, tableDescriptionHarold]
+          })
         )
-        .catch((e) => {
-          fail(e);
-        });
+      );
+      // Check response
+      expect(response).toEqual(
+        AddToFeatureServiceSuccessResponseFayardAndHarold
+      );
     });
 
-    it("should add a layer and a table", (done) => {
+    test("should add a layer and a table", async () => {
       fetchMock.once("*", AddToFeatureServiceSuccessResponseCydAndGene);
 
-      addToServiceDefinition(
+      const response = await addToServiceDefinition(
         "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
         {
           layers: [layerDescriptionCyd],
           tables: [tableDescriptionGene],
           ...MOCK_USER_REQOPTS
         }
-      )
-        .then((response) => {
-          // Check service call
-          expect(fetchMock.called()).toEqual(true);
-          const [url, options] = fetchMock.lastCall("*");
+      );
+      // Check service call
+      expect(fetchMock.called()).toEqual(true);
+      const [url, options] = fetchMock.lastCall("*");
 
-          expect(url).toEqual(
-            "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
-          );
-          expect(options.method).toBe("POST");
-          expect(options.body).toContain("f=json");
-          expect(options.body).toContain(encodeParam("token", "fake-token"));
-          expect(options.body).toContain(
-            encodeParam(
-              "addToDefinition",
-              JSON.stringify({
-                layers: [layerDescriptionCyd],
-                tables: [tableDescriptionGene]
-              })
-            )
-          );
-
-          // Check response
-          expect(response).toEqual(
-            AddToFeatureServiceSuccessResponseCydAndGene
-          );
-          done();
-        })
-        .catch((e) => {
-          fail(e);
-        });
+      expect(url).toEqual(
+        "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
+      );
+      expect(options.method).toBe("POST");
+      expect(options.body).toContain("f=json");
+      expect(options.body).toContain(encodeParam("token", "fake-token"));
+      expect(options.body).toContain(
+        encodeParam(
+          "addToDefinition",
+          JSON.stringify({
+            layers: [layerDescriptionCyd],
+            tables: [tableDescriptionGene]
+          })
+        )
+      );
+      // Check response
+      expect(response).toEqual(AddToFeatureServiceSuccessResponseCydAndGene);
     });
 
-    it("should add a layer definition", (done) => {
+    test("should add a layer definition", async () => {
       fetchMock.once("*", AddToFeatureServiceSuccessResponseCydAndGene);
 
-      addToServiceDefinition(
+      const response = await addToServiceDefinition(
         "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
         {
           layers: [layerDefinitionSid],
           ...MOCK_USER_REQOPTS
         }
-      )
-        .then((response) => {
-          // Check service call
-          expect(fetchMock.called()).toEqual(true);
-          const [url, options] = fetchMock.lastCall("*");
+      );
+      // Check service call
+      expect(fetchMock.called()).toEqual(true);
+      const [url, options] = fetchMock.lastCall("*");
 
-          expect(url).toEqual(
-            "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
-          );
-          expect(options.method).toBe("POST");
-          expect(options.body).toContain("f=json");
-          expect(options.body).toContain(encodeParam("token", "fake-token"));
-          expect(options.body).toContain(
-            encodeParam(
-              "addToDefinition",
-              JSON.stringify({
-                layers: [layerDefinitionSid]
-              })
-            )
-          );
+      expect(url).toEqual(
+        "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
+      );
+      expect(options.method).toBe("POST");
+      expect(options.body).toContain("f=json");
+      expect(options.body).toContain(encodeParam("token", "fake-token"));
+      expect(options.body).toContain(
+        encodeParam(
+          "addToDefinition",
+          JSON.stringify({
+            layers: [layerDefinitionSid]
+          })
+        )
+      );
+      // Check response
+      expect(response).toEqual(AddToFeatureServiceSuccessResponseCydAndGene);
+    });
 
-          // Check response
-          expect(response).toEqual(
-            AddToFeatureServiceSuccessResponseCydAndGene
-          );
-          done();
+    test("should throw an error with expected information when attempting to add invalid layer", async () => {
+      fetchMock.once("*", AddToFeatureServiceError);
+
+      await expect(
+        addToServiceDefinition(
+          "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
+          {
+            layers: [layerDescriptionFail],
+            ...MOCK_USER_REQOPTS
+          }
+        )
+      ).rejects.toMatchObject({
+        name: ErrorTypes.ArcGISRequestError,
+        message: "400: Unable to add feature service definition.",
+        url: "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition",
+        options: expect.objectContaining({
+          params: expect.objectContaining({
+            addToDefinition: { layers: [layerDescriptionFail] }
+          }),
+          httpMethod: "POST"
         })
-        .catch((e) => {
-          fail(e);
-        });
-    });
-
-    it("should fail to add a bad layer", (done) => {
-      fetchMock.once("*", AddToFeatureServiceError);
-
-      addToServiceDefinition(
-        "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
-        {
-          layers: [layerDescriptionFail],
-          ...MOCK_USER_REQOPTS
-        }
-      ).catch((error) => {
-        expect(error.name).toBe(ErrorTypes.ArcGISRequestError);
-        expect(error.message).toBe(
-          "400: Unable to add feature service definition."
-        );
-        expect(error instanceof Error).toBeTruthy();
-        expect(error.url).toBe(
-          "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
-        );
-        // params added internally aren't surfaced in the error
-        expect(error.options.params.addToDefinition).toEqual({
-          layers: [layerDescriptionFail]
-        });
-        expect(error.options.httpMethod).toEqual("POST");
-        done();
       });
     });
 
-    it("should fail to add a bad table", (done) => {
+    test("should throw an error with expected information when attempting to add invalid table", async () => {
       fetchMock.once("*", AddToFeatureServiceError);
 
-      addToServiceDefinition(
-        "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
-        {
-          tables: [tableDescriptionFail],
-          ...MOCK_USER_REQOPTS
-        }
-      ).catch((error) => {
-        expect(error.name).toBe(ErrorTypes.ArcGISRequestError);
-        expect(error.message).toBe(
-          "400: Unable to add feature service definition."
-        );
-        expect(error instanceof Error).toBeTruthy();
-        expect(error.url).toBe(
-          "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
-        );
-        // params added internally aren't surfaced in the error
-        expect(error.options.params.addToDefinition).toEqual({
-          tables: [tableDescriptionFail]
-        });
-        expect(error.options.httpMethod).toEqual("POST");
-        done();
+      await expect(
+        addToServiceDefinition(
+          "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
+          {
+            tables: [tableDescriptionFail],
+            ...MOCK_USER_REQOPTS
+          }
+        )
+      ).rejects.toMatchObject({
+        name: ErrorTypes.ArcGISRequestError,
+        message: "400: Unable to add feature service definition.",
+        url: "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition",
+        options: expect.objectContaining({
+          params: expect.objectContaining({
+            addToDefinition: { tables: [tableDescriptionFail] }
+          }),
+          httpMethod: "POST"
+        })
       });
     });
 
-    it("should fail to add a bad layer and a bad table", (done) => {
+    test("should fail to add a bad layer and a bad table", async () => {
       fetchMock.once("*", AddToFeatureServiceError);
 
-      addToServiceDefinition(
-        "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
-        {
-          layers: [layerDescriptionFail],
-          tables: [tableDescriptionFail],
-          ...MOCK_USER_REQOPTS
-        }
-      ).catch((error) => {
-        expect(error.name).toBe(ErrorTypes.ArcGISRequestError);
-        expect(error.message).toBe(
-          "400: Unable to add feature service definition."
-        );
-        expect(error instanceof Error).toBeTruthy();
-        expect(error.url).toBe(
-          "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition"
-        );
-        // params added internally aren't surfaced in the error
-        expect(error.options.params.addToDefinition).toEqual({
-          tables: [tableDescriptionFail],
-          layers: [layerDescriptionFail]
-        });
-        expect(error.options.httpMethod).toEqual("POST");
-        done();
+      await expect(
+        addToServiceDefinition(
+          "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
+          {
+            layers: [layerDescriptionFail],
+            tables: [tableDescriptionFail],
+            ...MOCK_USER_REQOPTS
+          }
+        )
+      ).rejects.toMatchObject({
+        name: ErrorTypes.ArcGISRequestError,
+        message: "400: Unable to add feature service definition.",
+        url: "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/addToDefinition",
+        options: expect.objectContaining({
+          params: expect.objectContaining({
+            addToDefinition: {
+              tables: [tableDescriptionFail],
+              layers: [layerDescriptionFail]
+            }
+          }),
+          httpMethod: "POST"
+        })
       });
     });
   }); // auth requests

--- a/packages/arcgis-rest-feature-service/test/addToServiceDefinition.test.ts
+++ b/packages/arcgis-rest-feature-service/test/addToServiceDefinition.test.ts
@@ -263,7 +263,7 @@ describe("add to feature service", () => {
       });
     });
 
-    test("should fail to add a bad layer and a bad table", async () => {
+    test("should throw an error when attempting to add an invalid layer and an invalid table", async () => {
       fetchMock.once("*", AddToFeatureServiceError);
 
       await expect(

--- a/packages/arcgis-rest-feature-service/test/attachments.test.ts
+++ b/packages/arcgis-rest-feature-service/test/attachments.test.ts
@@ -1,6 +1,8 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { FormData } from "@esri/arcgis-rest-form-data";
+import { describe, afterEach, test, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { attachmentFile } from "../../../scripts/test-helpers.js";
 import {
@@ -13,7 +15,6 @@ import {
   deleteAttachments,
   IDeleteAttachmentsOptions
 } from "../src/index.js";
-
 import {
   getAttachmentsResponse,
   addAttachmentResponse,
@@ -21,7 +22,7 @@ import {
   deleteAttachmentsResponse,
   genericInvalidResponse
 } from "./mocks/feature.js";
-import { FormData } from "@esri/arcgis-rest-form-data";
+
 const serviceUrl =
   "https://services.arcgis.com/f8b/arcgis/rest/services/Custom/FeatureServer/0";
 
@@ -29,161 +30,114 @@ describe("attachment methods", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("should return an array of attachmentInfos for a feature by id", (done) => {
-    const requestOptions = {
+
+  test("should return an array of attachmentInfos for a feature by id", async () => {
+    const requestOptions: IGetAttachmentsOptions = {
       url: serviceUrl,
       featureId: 42,
-      params: {
-        gdbVersion: "SDE.DEFAULT"
-      }
-    } as IGetAttachmentsOptions;
+      params: { gdbVersion: "SDE.DEFAULT" }
+    };
     fetchMock.once("*", getAttachmentsResponse);
-    getAttachments(requestOptions)
-      .then(() => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          `${requestOptions.url}/${requestOptions.featureId}/attachments?f=json&gdbVersion=SDE.DEFAULT`
-        );
-        expect(options.method).toBe("GET");
-        expect(getAttachmentsResponse.attachmentInfos.length).toEqual(2);
-        expect(getAttachmentsResponse.attachmentInfos[0].id).toEqual(409);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await getAttachments(requestOptions);
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      `${requestOptions.url}/${requestOptions.featureId}/attachments?f=json&gdbVersion=SDE.DEFAULT`
+    );
+    expect(options.method).toBe("GET");
+    expect(response.attachmentInfos).toHaveLength(2);
+    expect(response.attachmentInfos[0].id).toBe(409);
   });
 
-  it("should return objectId of the added attachment and a truthy success", (done) => {
-    const requestOptions = {
+  test("should return objectId of the added attachment and a success state", async () => {
+    const requestOptions: IAddAttachmentOptions = {
       url: serviceUrl,
       featureId: 42,
       attachment: attachmentFile(),
-      params: {
-        returnEditMoment: true
-      }
-    } as IAddAttachmentOptions;
+      params: { returnEditMoment: true }
+    };
     fetchMock.once("*", addAttachmentResponse);
-    addAttachment(requestOptions)
-      .then(() => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          `${requestOptions.url}/${requestOptions.featureId}/addAttachment`
-        );
-        expect(options.method).toBe("POST");
+    const response = await addAttachment(requestOptions);
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      `${requestOptions.url}/${requestOptions.featureId}/addAttachment`
+    );
+    expect(options.method).toBe("POST");
 
-        const params = options.body as FormData;
-        expect(params instanceof FormData).toBeTruthy();
-        // we can introspect FormData in Chrome this way, but not Node.js
-        // more info: https://github.com/form-data/form-data/issues/124
-        if (params.get) {
-          expect(params.get("returnEditMoment")).toEqual("true");
-        }
-        expect(addAttachmentResponse.addAttachmentResult.objectId).toEqual(
-          1001
-        );
-        expect(addAttachmentResponse.addAttachmentResult.success).toEqual(true);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const params = options.body as FormData;
+    expect(params instanceof FormData).toBeTruthy();
+    // we can introspect FormData in Chrome this way, but not Node.js
+    // more info: https://github.com/form-data/form-data/issues/124
+    if (params.get) {
+      expect(params.get("returnEditMoment")).toEqual("true");
+    }
+    expect(response.addAttachmentResult.objectId).toBe(1001);
+    expect(response.addAttachmentResult.success).toBe(true);
   });
 
-  it("should return an error for a service/feature which does not have attachments", (done) => {
-    const requestOptions = {
+  test("should return an error for a service/feature which does not have attachments", async () => {
+    const requestOptions: IAddAttachmentOptions = {
       url: "https://services.arcgis.com/f8b/arcgis/rest/services/NoAttachments/FeatureServer/0",
       featureId: 654,
       attachment: attachmentFile(),
-      params: {
-        returnEditMoment: true
-      }
-    } as IAddAttachmentOptions;
+      params: { returnEditMoment: true }
+    };
     fetchMock.once("*", genericInvalidResponse);
-    addAttachment(requestOptions)
-      .then(() => {
-        // nothing to test here forcing error
-        fail();
+    await expect(addAttachment(requestOptions)).rejects.toMatchObject({
+      response: expect.objectContaining({
+        error: expect.objectContaining({
+          code: 400,
+          message: "Invalid or missing input parameters."
+        })
       })
-      .catch((error) => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          `${requestOptions.url}/${requestOptions.featureId}/addAttachment`
-        );
-        expect(options.method).toBe("POST");
-        expect(error.response.error.code).toEqual(400);
-        expect(error.response.error.message).toEqual(
-          "Invalid or missing input parameters."
-        );
-        done();
-      });
+    });
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      `${requestOptions.url}/${requestOptions.featureId}/addAttachment`
+    );
+    expect(options.method).toBe("POST");
   });
 
-  it("should return objectId of the updated attachment and a truthy success", (done) => {
-    const requestOptions = {
+  test("should return objectId of the updated attachment and a success state", async () => {
+    const requestOptions: IUpdateAttachmentOptions = {
       url: serviceUrl,
       featureId: 42,
       attachmentId: 1001,
       attachment: attachmentFile(),
-      params: {
-        returnEditMoment: true
-      }
-    } as IUpdateAttachmentOptions;
+      params: { returnEditMoment: true }
+    };
     fetchMock.once("*", updateAttachmentResponse);
-    updateAttachment(requestOptions)
-      .then(() => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          `${requestOptions.url}/${requestOptions.featureId}/updateAttachment`
-        );
-        expect(options.method).toBe("POST");
-        expect(
-          updateAttachmentResponse.updateAttachmentResult.objectId
-        ).toEqual(1001);
-        expect(updateAttachmentResponse.updateAttachmentResult.success).toEqual(
-          true
-        );
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await updateAttachment(requestOptions);
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      `${requestOptions.url}/${requestOptions.featureId}/updateAttachment`
+    );
+    expect(options.method).toBe("POST");
+    expect(response.updateAttachmentResult.objectId).toBe(1001);
+    expect(response.updateAttachmentResult.success).toBe(true);
   });
 
-  it("should return objectId of the deleted attachment and a truthy success", (done) => {
-    const requestOptions = {
+  test("should return objectId of the deleted attachment and a success state", async () => {
+    const requestOptions: IDeleteAttachmentsOptions = {
       url: serviceUrl,
       featureId: 42,
       attachmentIds: [1001],
-      params: {
-        returnEditMoment: true
-      }
-    } as IDeleteAttachmentsOptions;
+      params: { returnEditMoment: true }
+    };
     fetchMock.once("*", deleteAttachmentsResponse);
-    deleteAttachments(requestOptions)
-      .then(() => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          `${requestOptions.url}/${requestOptions.featureId}/deleteAttachments`
-        );
-        expect(options.body).toContain("attachmentIds=1001");
-        expect(options.body).toContain("returnEditMoment=true");
-        expect(options.method).toBe("POST");
-        expect(
-          deleteAttachmentsResponse.deleteAttachmentResults[0].objectId
-        ).toEqual(1001);
-        expect(
-          deleteAttachmentsResponse.deleteAttachmentResults[0].success
-        ).toEqual(true);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await deleteAttachments(requestOptions);
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      `${requestOptions.url}/${requestOptions.featureId}/deleteAttachments`
+    );
+    expect(options.body).toContain("attachmentIds=1001");
+    expect(options.body).toContain("returnEditMoment=true");
+    expect(options.method).toBe("POST");
+    expect(response.deleteAttachmentResults[0].objectId).toBe(1001);
+    expect(response.deleteAttachmentResults[0].success).toBe(true);
   });
 });

--- a/packages/arcgis-rest-feature-service/test/createFeatureService.test.ts
+++ b/packages/arcgis-rest-feature-service/test/createFeatureService.test.ts
@@ -1,6 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, test, expect, afterEach } from "vitest";
 import fetchMock from "fetch-mock";
 import { createFeatureService } from "../src/createFeatureService.js";
 import { FeatureServiceResponse } from "./mocks/service.js";
@@ -60,220 +61,151 @@ describe("create feature service", () => {
       }
     };
 
-    it("should create a feature service defaulting to the root folder", (done) => {
+    test("should create a feature service defaulting to the root folder", async () => {
       fetchMock.mock("end:createService", FeatureServiceResponse, {});
 
-      createFeatureService({
+      const response = await createFeatureService({
         item: serviceDescription,
         ...MOCK_USER_REQOPTS
-      })
-        .then(
-          (response) => {
-            expect(fetchMock.called("end:createService")).toEqual(true);
+      });
 
-            // Check create service call
-            const [urlCreate, optionsCreate] =
-              fetchMock.lastCall("end:createService");
-            expect(urlCreate).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
-            );
-            expect(optionsCreate.method).toBe("POST");
-            expect(optionsCreate.body).toContain("f=json");
-            expect(optionsCreate.body).toContain(
-              encodeParam(
-                "createParameters",
-                JSON.stringify(serviceDescription)
-              )
-            );
-            expect(optionsCreate.body).toContain("outputType=featureService");
-            expect(optionsCreate.body).toContain(
-              encodeParam("token", "fake-token")
-            );
+      expect(fetchMock.called("end:createService")).toBe(true);
 
-            // Check response
-            expect(response).toEqual(FeatureServiceResponse);
+      // Check create service call
+      const [urlCreate, optionsCreate] =
+        fetchMock.lastCall("end:createService");
+      expect(urlCreate).toBe(
+        "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
+      );
+      expect(optionsCreate.method).toBe("POST");
+      expect(optionsCreate.body).toContain("f=json");
+      expect(optionsCreate.body).toContain(
+        encodeParam("createParameters", JSON.stringify(serviceDescription))
+      );
+      expect(optionsCreate.body).toContain("outputType=featureService");
+      expect(optionsCreate.body).toContain(encodeParam("token", "fake-token"));
 
-            done();
-          },
-          () => {
-            fail(); // call is supposed to succeed
-          }
-        )
-        .catch((e) => {
-          fail(e);
-        });
+      // Check response
+      expect(response).toEqual(FeatureServiceResponse);
     });
 
-    it("should create a feature service specified for the root folder 1", (done) => {
+    test("should create a feature service specified for the root folder 1", async () => {
       fetchMock.mock("end:createService", FeatureServiceResponse, {});
       const folderId = "";
 
-      createFeatureService({
+      const response = await createFeatureService({
         item: serviceDescription,
         folderId,
         ...MOCK_USER_REQOPTS
-      })
-        .then(
-          (response) => {
-            expect(fetchMock.called("end:createService")).toEqual(true);
+      });
 
-            // Check create service call
-            const [urlCreate, optionsCreate] =
-              fetchMock.lastCall("end:createService");
-            expect(urlCreate).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
-            );
-            expect(optionsCreate.method).toBe("POST");
-            expect(optionsCreate.body).toContain("f=json");
-            expect(optionsCreate.body).toContain(
-              encodeParam(
-                "createParameters",
-                JSON.stringify(serviceDescription)
-              )
-            );
-            expect(optionsCreate.body).toContain("outputType=featureService");
-            expect(optionsCreate.body).toContain(
-              encodeParam("token", "fake-token")
-            );
+      expect(fetchMock.called("end:createService")).toBe(true);
 
-            // Check response
-            expect(response).toEqual(FeatureServiceResponse);
+      // Check create service call
+      const [urlCreate, optionsCreate] =
+        fetchMock.lastCall("end:createService");
+      expect(urlCreate).toBe(
+        "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
+      );
+      expect(optionsCreate.method).toBe("POST");
+      expect(optionsCreate.body).toContain("f=json");
+      expect(optionsCreate.body).toContain(
+        encodeParam("createParameters", JSON.stringify(serviceDescription))
+      );
+      expect(optionsCreate.body).toContain("outputType=featureService");
+      expect(optionsCreate.body).toContain(encodeParam("token", "fake-token"));
 
-            done();
-          },
-          () => {
-            fail(); // call is supposed to succeed
-          }
-        )
-        .catch((e) => {
-          fail(e);
-        });
+      // Check response
+      expect(response).toEqual(FeatureServiceResponse);
     });
 
-    it("should create a feature service specified for the root folder 2", (done) => {
+    test("should create a feature service specified for the root folder 2", async () => {
       fetchMock.mock("end:createService", FeatureServiceResponse, {});
       const folderId = "/";
 
-      createFeatureService({
+      const response = await createFeatureService({
         item: serviceDescription,
         folderId,
         ...MOCK_USER_REQOPTS
-      })
-        .then(
-          (response) => {
-            expect(fetchMock.called("end:createService")).toEqual(true);
+      });
 
-            // Check create service call
-            const [urlCreate, optionsCreate] =
-              fetchMock.lastCall("end:createService");
-            expect(urlCreate).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
-            );
-            expect(optionsCreate.method).toBe("POST");
-            expect(optionsCreate.body).toContain("f=json");
-            expect(optionsCreate.body).toContain(
-              encodeParam(
-                "createParameters",
-                JSON.stringify(serviceDescription)
-              )
-            );
-            expect(optionsCreate.body).toContain("outputType=featureService");
-            expect(optionsCreate.body).toContain(
-              encodeParam("token", "fake-token")
-            );
+      expect(fetchMock.called("end:createService")).toBe(true);
 
-            // Check response
-            expect(response).toEqual(FeatureServiceResponse);
+      // Check create service call
+      const [urlCreate, optionsCreate] =
+        fetchMock.lastCall("end:createService");
+      expect(urlCreate).toBe(
+        "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/createService"
+      );
+      expect(optionsCreate.method).toBe("POST");
+      expect(optionsCreate.body).toContain("f=json");
+      expect(optionsCreate.body).toContain(
+        encodeParam("createParameters", JSON.stringify(serviceDescription))
+      );
+      expect(optionsCreate.body).toContain("outputType=featureService");
+      expect(optionsCreate.body).toContain(encodeParam("token", "fake-token"));
 
-            done();
-          },
-          () => {
-            fail(); // call is supposed to succeed
-          }
-        )
-        .catch((e) => {
-          fail(e);
-        });
+      // Check response
+      expect(response).toEqual(FeatureServiceResponse);
     });
 
-    it("should create a feature service in a particular folder", (done) => {
+    test("should create a feature service in a particular folder", async () => {
       fetchMock.mock("end:createService", FeatureServiceResponse, {});
       const folderId = "83216cba44bf4357bf06687ec88a847b";
 
-      createFeatureService({
+      const response = await createFeatureService({
         item: serviceDescription,
         folderId,
         ...MOCK_USER_REQOPTS
-      })
-        .then(
-          (response) => {
-            expect(fetchMock.called("end:createService")).toEqual(true);
+      });
 
-            // Check create service call
-            const [urlCreate, optionsCreate] =
-              fetchMock.lastCall("end:createService");
-            expect(urlCreate).toEqual(
-              "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/83216cba44bf4357bf06687ec88a847b/createService"
-            );
-            expect(optionsCreate.method).toBe("POST");
-            expect(optionsCreate.body).toContain("f=json");
-            expect(optionsCreate.body).toContain(
-              encodeParam(
-                "createParameters",
-                JSON.stringify(serviceDescription)
-              )
-            );
-            expect(optionsCreate.body).toContain("outputType=featureService");
-            expect(optionsCreate.body).toContain(
-              encodeParam("token", "fake-token")
-            );
+      expect(fetchMock.called("end:createService")).toBe(true);
 
-            // Check response
-            expect(response).toEqual(FeatureServiceResponse);
+      // Check create service call
+      const [urlCreate, optionsCreate] =
+        fetchMock.lastCall("end:createService");
+      expect(urlCreate).toBe(
+        "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/83216cba44bf4357bf06687ec88a847b/createService"
+      );
+      expect(optionsCreate.method).toBe("POST");
+      expect(optionsCreate.body).toContain("f=json");
+      expect(optionsCreate.body).toContain(
+        encodeParam("createParameters", JSON.stringify(serviceDescription))
+      );
+      expect(optionsCreate.body).toContain("outputType=featureService");
+      expect(optionsCreate.body).toContain(encodeParam("token", "fake-token"));
 
-            done();
-          },
-          () => {
-            fail(); // call is supposed to succeed
-          }
-        )
-        .catch((e) => {
-          fail(e);
-        });
+      // Check response
+      expect(response).toEqual(FeatureServiceResponse);
     });
 
-    it("should fail to create a feature service destined for a particular folder with success=false", (done) => {
+    test("should fail to create a feature service destined for a particular folder with success=false", async () => {
       fetchMock.mock("end:createService", { success: false });
 
       const folderId = "83216cba44bf4357bf06687ec88a847b";
 
-      createFeatureService({
+      const response = await createFeatureService({
         item: serviceDescription,
         folderId,
         ...MOCK_USER_REQOPTS
-      })
-        .then((e) => {
-          expect(fetchMock.called("end:createService")).toEqual(true);
+      });
 
-          // Check create service call
-          const [urlCreate, optionsCreate] =
-            fetchMock.lastCall("end:createService");
-          expect(urlCreate).toEqual(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/83216cba44bf4357bf06687ec88a847b/createService"
-          );
-          expect(optionsCreate.method).toBe("POST");
-          expect(optionsCreate.body).toContain("f=json");
-          expect(optionsCreate.body).toContain(
-            encodeParam("createParameters", JSON.stringify(serviceDescription))
-          );
-          expect(optionsCreate.body).toContain("outputType=featureService");
-          expect(optionsCreate.body).toContain(
-            encodeParam("token", "fake-token")
-          );
-          expect(e.success).toBeFalsy();
-          done();
-        })
-        .catch(() => fail());
+      expect(fetchMock.called("end:createService")).toBe(true);
+
+      // Check create service call
+      const [urlCreate, optionsCreate] =
+        fetchMock.lastCall("end:createService");
+      expect(urlCreate).toBe(
+        "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/83216cba44bf4357bf06687ec88a847b/createService"
+      );
+      expect(optionsCreate.method).toBe("POST");
+      expect(optionsCreate.body).toContain("f=json");
+      expect(optionsCreate.body).toContain(
+        encodeParam("createParameters", JSON.stringify(serviceDescription))
+      );
+      expect(optionsCreate.body).toContain("outputType=featureService");
+      expect(optionsCreate.body).toContain(encodeParam("token", "fake-token"));
+      expect(response.success).toBeFalsy();
     });
   });
 });

--- a/packages/arcgis-rest-feature-service/test/crud.test.ts
+++ b/packages/arcgis-rest-feature-service/test/crud.test.ts
@@ -1,6 +1,7 @@
 /* Copyright (c) 2018-2019 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, afterEach, test, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import {
   addFeatures,
@@ -25,7 +26,8 @@ describe("feature", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("should return objectId of the added feature and a truthy success", (done) => {
+
+  test("should return objectId of the added feature and a truthy success", async () => {
     const requestOptions = {
       url: serviceUrl,
       features: [
@@ -46,29 +48,26 @@ describe("feature", () => {
         }
       ]
     };
+
     fetchMock.once("*", addFeaturesResponse);
-    addFeatures(requestOptions)
-      .then((response) => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(`${requestOptions.url}/addFeatures`);
-        expect(options.body).toContain(
-          "features=" +
-            encodeURIComponent(
-              '[{"geometry":{"x":-9177311.62541634,"y":4247151.205222242,"spatialReference":{"wkid":102100,"latestWkid":3857}},"attributes":{"Tree_ID":102,"Collected":1349395200000,"Crew":"Linden+ Forrest+ Johnny"}}]'
-            )
-        );
-        expect(options.method).toBe("POST");
-        expect(response.addResults[0].objectId).toEqual(1001);
-        expect(response.addResults[0].success).toEqual(true);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+
+    const response = await addFeatures(requestOptions);
+
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toBe(`${requestOptions.url}/addFeatures`);
+    expect(options.body).toContain(
+      "features=" +
+        encodeURIComponent(
+          '[{"geometry":{"x":-9177311.62541634,"y":4247151.205222242,"spatialReference":{"wkid":102100,"latestWkid":3857}},"attributes":{"Tree_ID":102,"Collected":1349395200000,"Crew":"Linden+ Forrest+ Johnny"}}]'
+        )
+    );
+    expect(options.method).toBe("POST");
+    expect(response.addResults[0].objectId).toBe(1001);
+    expect(response.addResults[0].success).toBe(true);
   });
 
-  it("should return objectId of the updated feature and a truthy success", (done) => {
+  test("should return objectId of the updated feature and a truthy success", async () => {
     const requestOptions = {
       url: serviceUrl,
       features: [
@@ -84,55 +83,43 @@ describe("feature", () => {
       trueCurveClient: false
     } as IUpdateFeaturesOptions;
     fetchMock.once("*", updateFeaturesResponse);
-    updateFeatures(requestOptions)
-      .then((response) => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(`${requestOptions.url}/updateFeatures`);
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain(
-          "features=" +
-            encodeURIComponent(
-              '[{"attributes":{"OBJECTID":1001,"Street":"NO","Native":"YES"}}]'
-            )
-        );
-        expect(options.body).toContain("rollbackOnFailure=false");
-        expect(options.body).toContain("trueCurveClient=false");
-        expect(response.updateResults[0].success).toEqual(true);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await updateFeatures(requestOptions);
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toBe(`${requestOptions.url}/updateFeatures`);
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain(
+      "features=" +
+        encodeURIComponent(
+          '[{"attributes":{"OBJECTID":1001,"Street":"NO","Native":"YES"}}]'
+        )
+    );
+    expect(options.body).toContain("rollbackOnFailure=false");
+    expect(options.body).toContain("trueCurveClient=false");
+    expect(response.updateResults[0].success).toBe(true);
   });
 
-  it("should return objectId of the deleted feature and a truthy success", (done) => {
+  test("should return objectId of the deleted feature and a truthy success", async () => {
     const requestOptions = {
       url: serviceUrl,
       objectIds: [1001],
       where: "1=1"
     } as IDeleteFeaturesOptions;
     fetchMock.once("*", deleteFeaturesResponse);
-    deleteFeatures(requestOptions)
-      .then((response) => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(`${requestOptions.url}/deleteFeatures`);
-        expect(options.body).toContain("objectIds=1001");
-        expect(options.body).toContain("where=1%3D1");
-        expect(options.method).toBe("POST");
-        expect(response.deleteResults[0].objectId).toEqual(
-          requestOptions.objectIds[0]
-        );
-        expect(response.deleteResults[0].success).toEqual(true);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await deleteFeatures(requestOptions);
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toBe(`${requestOptions.url}/deleteFeatures`);
+    expect(options.body).toContain("objectIds=1001");
+    expect(options.body).toContain("where=1%3D1");
+    expect(options.method).toBe("POST");
+    expect(response.deleteResults[0].objectId).toBe(
+      requestOptions.objectIds[0]
+    );
+    expect(response.deleteResults[0].success).toBe(true);
   });
 
-  it("should return objectId of the added, updated or deleted feature(s) and a truthy success", (done) => {
+  test("should return objectId of the added, updated or deleted feature(s) and a truthy success", async () => {
     const requestOptions = {
       url: serviceUrl,
       adds: [
@@ -163,35 +150,29 @@ describe("feature", () => {
       deletes: [455]
     };
     fetchMock.once("*", applyEditsResponse);
-    applyEdits(requestOptions)
-      .then((response) => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(`${requestOptions.url}/applyEdits`);
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain(
-          "adds=" +
-            encodeURIComponent(
-              '[{"geometry":{"x":-9177311.62541634,"y":4247151.205222242,"spatialReference":{"wkid":102100,"latestWkid":3857}},"attributes":{"Tree_ID":102,"Collected":1349395200000,"Crew":"Linden+ Forrest+ Johnny"}}]'
-            )
-        );
-        expect(options.body).toContain(
-          "updates=" +
-            encodeURIComponent(
-              '[{"attributes":{"OBJECTID":1001,"Crew":"Tom+ Patrick+ Dave"}}]'
-            )
-        );
-        expect(options.body).toContain("deletes=455");
-        expect(response.addResults[0].objectId).toEqual(2156);
-        expect(response.addResults[0].success).toEqual(true);
-        expect(response.updateResults[0].objectId).toEqual(1001);
-        expect(response.updateResults[0].success).toEqual(true);
-        expect(response.deleteResults[0].objectId).toEqual(455);
-        expect(response.deleteResults[0].success).toEqual(true);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await applyEdits(requestOptions);
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toBe(`${requestOptions.url}/applyEdits`);
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain(
+      "adds=" +
+        encodeURIComponent(
+          '[{"geometry":{"x":-9177311.62541634,"y":4247151.205222242,"spatialReference":{"wkid":102100,"latestWkid":3857}},"attributes":{"Tree_ID":102,"Collected":1349395200000,"Crew":"Linden+ Forrest+ Johnny"}}]'
+        )
+    );
+    expect(options.body).toContain(
+      "updates=" +
+        encodeURIComponent(
+          '[{"attributes":{"OBJECTID":1001,"Crew":"Tom+ Patrick+ Dave"}}]'
+        )
+    );
+    expect(options.body).toContain("deletes=455");
+    expect(response.addResults[0].objectId).toBe(2156);
+    expect(response.addResults[0].success).toBe(true);
+    expect(response.updateResults[0].objectId).toBe(1001);
+    expect(response.updateResults[0].success).toBe(true);
+    expect(response.deleteResults[0].objectId).toBe(455);
+    expect(response.deleteResults[0].success).toBe(true);
   });
 });

--- a/packages/arcgis-rest-feature-service/test/decodeValues.test.ts
+++ b/packages/arcgis-rest-feature-service/test/decodeValues.test.ts
@@ -49,4 +49,24 @@ describe("formatCodedValues()", () => {
 
     expect(response.features[0]).toEqual(cvdFeaturesFormatted[0]);
   });
+
+  test("should decode own properties using fetched metadata", async () => {
+    fetchMock.once("*", getFeatureServiceResponse);
+
+    // Create an object with an inherited property and own properties
+    const testAttributes = Object.create({ prototypeAttribute: "ignore" });
+
+    const response = await decodeValues({
+      url: serviceUrl,
+      queryResponse: {
+        ...cvdQueryResponse,
+        features: [...cvdQueryResponse.features, { attributes: testAttributes }]
+      }
+    });
+
+    expect(response.features[0]).toEqual(cvdFeaturesFormatted[0]);
+    expect(response.features[0].attributes).not.toHaveProperty(
+      "prototypeAttribute"
+    );
+  });
 });

--- a/packages/arcgis-rest-feature-service/test/decodeValues.test.ts
+++ b/packages/arcgis-rest-feature-service/test/decodeValues.test.ts
@@ -1,16 +1,16 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, afterEach, test, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { decodeValues } from "../src/decodeValues.js";
-
+import { cvdServiceFields, serviceFields } from "./mocks/fields.js";
+import { getFeatureServiceResponse } from "./mocks/service.js";
+import { queryResponse } from "./mocks/feature.js";
 import {
   cvdQueryResponse,
   cvdFeaturesFormatted
 } from "./mocks/cvdQueryResponse.js";
-import { cvdServiceFields, serviceFields } from "./mocks/fields.js";
-import { getFeatureServiceResponse } from "./mocks/service.js";
-import { queryResponse } from "./mocks/feature.js";
 
 const serviceUrl =
   "https://services.arcgis.com/f8b/arcgis/rest/services/Custom/FeatureServer/0";
@@ -19,49 +19,34 @@ describe("formatCodedValues()", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("should format the cvd codes in a raw response", (done) => {
-    decodeValues({
+  test("should format the cvd codes in a raw response", async () => {
+    const response = await decodeValues({
       url: serviceUrl,
       fields: cvdServiceFields,
       queryResponse: cvdQueryResponse
-    })
-      .then((response) => {
-        expect(response.features[0]).toEqual(cvdFeaturesFormatted[0]);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    });
+
+    expect(response.features[0]).toEqual(cvdFeaturesFormatted[0]);
   });
 
-  it("should return the original response if there are no coded value domains", (done) => {
-    decodeValues({
+  test("should return the original response if there are no coded value domains", async () => {
+    const response = await decodeValues({
       url: serviceUrl,
       fields: serviceFields,
       queryResponse
-    })
-      .then((response) => {
-        expect(response).toEqual(queryResponse);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    });
+
+    expect(response).toEqual(queryResponse);
   });
 
-  it("should fetch metadata and then format cvd codes in a raw response", (done) => {
+  test("should fetch metadata and then format cvd codes in a raw response", async () => {
     fetchMock.once("*", getFeatureServiceResponse);
 
-    decodeValues({
+    const response = await decodeValues({
       url: serviceUrl,
       queryResponse: cvdQueryResponse
-    })
-      .then((response) => {
-        expect(response.features[0]).toEqual(cvdFeaturesFormatted[0]);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    });
+
+    expect(response.features[0]).toEqual(cvdFeaturesFormatted[0]);
   });
 });

--- a/packages/arcgis-rest-feature-service/test/decodeValues.test.ts
+++ b/packages/arcgis-rest-feature-service/test/decodeValues.test.ts
@@ -50,23 +50,22 @@ describe("formatCodedValues()", () => {
     expect(response.features[0]).toEqual(cvdFeaturesFormatted[0]);
   });
 
-  test("should decode own properties using fetched metadata", async () => {
+  test("should fetch metadata then skip decoding if no cvd codes", async () => {
     fetchMock.once("*", getFeatureServiceResponse);
 
-    // Create an object with an inherited property and own properties
-    const testAttributes = Object.create({ prototypeAttribute: "ignore" });
+    const attributesToIgnore = Object.create({ prototypeAttribute: "ignore" });
 
     const response = await decodeValues({
       url: serviceUrl,
       queryResponse: {
         ...cvdQueryResponse,
-        features: [...cvdQueryResponse.features, { attributes: testAttributes }]
+        features: [
+          ...cvdQueryResponse.features,
+          { attributes: attributesToIgnore }
+        ]
       }
     });
 
     expect(response.features[0]).toEqual(cvdFeaturesFormatted[0]);
-    expect(response.features[0].attributes).not.toHaveProperty(
-      "prototypeAttribute"
-    );
   });
 });

--- a/packages/arcgis-rest-feature-service/test/getAllLayersAndTables.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getAllLayersAndTables.test.ts
@@ -1,6 +1,6 @@
+import { describe, test, afterEach, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { getAllLayersAndTables } from "../src/getAllLayersAndTables.js";
-
 import { allLayersAndTablesResponse } from "./mocks/allLayersAndTablesResponse.js";
 
 const layerUrlBase =
@@ -10,19 +10,15 @@ describe("getAllLayersAndTables()", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("should fetch all layers and table associated with the service", (done) => {
+  test("should fetch all layers and table associated with the service", async () => {
     fetchMock.once("*", allLayersAndTablesResponse);
-    getAllLayersAndTables({ url: layerUrlBase + "/0" })
-      .then((response) => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(layerUrlBase + "/layers");
-        expect(options.method).toBe("POST");
-        expect(response).toEqual(allLayersAndTablesResponse);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+
+    const response = await getAllLayersAndTables({ url: layerUrlBase + "/0" });
+
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toBe(layerUrlBase + "/layers");
+    expect(options.method).toBe("POST");
+    expect(response).toEqual(allLayersAndTablesResponse);
   });
 });

--- a/packages/arcgis-rest-feature-service/test/getLayer.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getLayer.test.ts
@@ -9,7 +9,7 @@ import { getFeatureServiceResponse } from "./mocks/service.js";
 const layerUrl =
   "https://services.arcgis.com/f8b/arcgis/rest/services/Custom/FeatureServer/0";
 
-describe("feature", () => {
+describe("feature service layer", () => {
   afterEach(() => {
     fetchMock.restore();
   });

--- a/packages/arcgis-rest-feature-service/test/getLayer.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getLayer.test.ts
@@ -1,9 +1,9 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, afterEach, test, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { getLayer } from "../src/getLayer.js";
-
 import { getFeatureServiceResponse } from "./mocks/service.js";
 
 const layerUrl =
@@ -13,19 +13,16 @@ describe("feature", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("should fetch service metadata", (done) => {
+
+  test("should fetch service metadata", async () => {
     fetchMock.once("*", getFeatureServiceResponse);
-    getLayer({ url: layerUrl })
-      .then((response) => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(layerUrl);
-        expect(options.method).toBe("POST");
-        expect(response).toEqual(getFeatureServiceResponse);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+
+    const response = await getLayer({ url: layerUrl });
+
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(layerUrl);
+    expect(options.method).toBe("POST");
+    expect(response).toEqual(getFeatureServiceResponse);
   });
 });

--- a/packages/arcgis-rest-feature-service/test/getService.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getService.test.ts
@@ -1,9 +1,9 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, afterEach, test, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { getService } from "../src/getService.js";
-
 import { getFeatureServerResponse } from "./mocks/service.js";
 
 const layerUrl =
@@ -13,19 +13,15 @@ describe("getServer()", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("should fetch feature service metadata", (done) => {
+  test("should fetch feature server metadata", async () => {
     fetchMock.once("*", getFeatureServerResponse);
-    getService({ url: layerUrl })
-      .then((response) => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(layerUrl);
-        expect(options.method).toBe("POST");
-        expect(response).toEqual(getFeatureServerResponse);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+
+    const response = await getService({ url: layerUrl });
+
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(layerUrl);
+    expect(options.method).toBe("POST");
+    expect(response).toEqual(getFeatureServerResponse);
   });
 });

--- a/packages/arcgis-rest-feature-service/test/getServiceAdminInfo.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getServiceAdminInfo.test.ts
@@ -1,6 +1,7 @@
 /* Copyright (c) 2018-2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, afterEach, test, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { getServiceAdminInfo } from "../src/getServiceAdminInfo.js";
 import { TOMORROW } from "../../../scripts/test-helpers.js";
@@ -22,20 +23,19 @@ describe("getServiceAdminInfo: ", () => {
     portal: "https://myorg.maps.arcgis.com/sharing/rest"
   });
 
-  it("makes request to the admin url", () => {
+  test("should return the api response when making a request to the admin url", async () => {
     fetchMock.once("*", { foo: "bar" }, { method: "POST" });
 
-    return getServiceAdminInfo(
+    const response = await getServiceAdminInfo(
       "https://servicesqa.arcgis.com/orgid/arcgis/rest/services/mysevice/FeatureServer",
       MOCK_USER_SESSION
-    ).then((result) => {
-      const [url] = fetchMock.lastCall("*");
+    );
 
-      expect(result.foo).toBe("bar", "should return the api response");
+    const [url] = fetchMock.lastCall("*");
 
-      expect(url).toBe(
-        "https://servicesqa.arcgis.com/orgid/arcgis/rest/admin/services/mysevice/FeatureServer"
-      );
-    });
+    expect(response.foo).toBe("bar");
+    expect(url).toBe(
+      "https://servicesqa.arcgis.com/orgid/arcgis/rest/admin/services/mysevice/FeatureServer"
+    );
   });
 });

--- a/packages/arcgis-rest-feature-service/test/getViewSources.test.ts
+++ b/packages/arcgis-rest-feature-service/test/getViewSources.test.ts
@@ -1,6 +1,7 @@
 /* Copyright (c) 2018-2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, test, expect, afterEach } from "vitest";
 import fetchMock from "fetch-mock";
 import { getViewSources } from "../src/getViewSources.js";
 import { ArcGISIdentityManager } from "@esri/arcgis-rest-request";
@@ -21,25 +22,22 @@ describe("get-view-sources: ", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("makes request to the admin url", () => {
+  test("makes request to the admin url", async () => {
     fetchMock.once("*", { currentVersion: 1234 }, { method: "POST" });
 
-    return getViewSources(
+    const response = await getViewSources(
       "https://servicesqa.arcgis.com/orgid/arcgis/rest/services/mysevice/FeatureServer",
       MOCK_USER_SESSION
-    ).then((result) => {
-      expect(result.currentVersion).toBe(
-        1234,
-        "should return the api response"
-      );
+    );
 
-      const [url] = fetchMock.lastCall("*");
+    expect(response.currentVersion).toBe(1234);
 
-      expect(fetchMock.called()).toEqual(true);
+    const [url] = fetchMock.lastCall("*");
 
-      expect(url).toContain(
-        "https://servicesqa.arcgis.com/orgid/arcgis/rest/services/mysevice/FeatureServer/sources"
-      );
-    });
+    expect(fetchMock.called()).toBe(true);
+
+    expect(url).toContain(
+      "https://servicesqa.arcgis.com/orgid/arcgis/rest/services/mysevice/FeatureServer/sources"
+    );
   });
 });

--- a/packages/arcgis-rest-feature-service/test/helpers.test.ts
+++ b/packages/arcgis-rest-feature-service/test/helpers.test.ts
@@ -1,27 +1,27 @@
+import { describe, test, expect } from "vitest";
 import { parseServiceUrl } from "../src/helpers.js";
 
 describe("parseServiceUrl", () => {
-  it("Trims service url to root", (done) => {
+  test("Trims service url to root", async () => {
     const input =
       "https://gis.tempe.gov/arcgis/rest/services/Covid_Cases/FeatureServer/layers?f=json";
     const expected =
       "https://gis.tempe.gov/arcgis/rest/services/Covid_Cases/FeatureServer";
     const actual = parseServiceUrl(input);
     expect(actual).toBe(expected);
-    done();
   });
-  it("Removes query string from non-standard service url", (done) => {
+
+  test("Removes query string from non-standard service url", async () => {
     const input = "https://gis.tempe.gov/arcgis/non/traditional/path?f=json";
     const expected = "https://gis.tempe.gov/arcgis/non/traditional/path";
     const actual = parseServiceUrl(input);
     expect(actual).toBe(expected);
-    done();
   });
-  it("Removes trailing slash from non-standard service url", (done) => {
+
+  test("Removes trailing slash from non-standard service url", async () => {
     const input = "https://gis.tempe.gov/arcgis/non/traditional/path/";
     const expected = "https://gis.tempe.gov/arcgis/non/traditional/path";
     const actual = parseServiceUrl(input);
     expect(actual).toBe(expected);
-    done();
   });
 });

--- a/packages/arcgis-rest-feature-service/test/query.test.ts
+++ b/packages/arcgis-rest-feature-service/test/query.test.ts
@@ -1,6 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, afterEach, test, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import {
   getFeature,
@@ -10,7 +11,6 @@ import {
   IQueryFeaturesOptions,
   IQueryRelatedOptions
 } from "../src/index.js";
-
 import {
   featureResponse,
   queryResponse,
@@ -24,75 +24,60 @@ describe("getFeature() and queryFeatures()", () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  it("should return a feature by id", (done) => {
+  test("should return a feature by id", async () => {
     const requestOptions = {
       url: serviceUrl,
       id: 42
     };
     fetchMock.once("*", featureResponse);
-    getFeature(requestOptions)
-      .then((response) => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(`${requestOptions.url}/42?f=json`);
-        expect(options.method).toBe("GET");
-        expect(response.attributes.FID).toEqual(42);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+
+    const response = await getFeature(requestOptions);
+
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toBe(`${requestOptions.url}/42?f=json`);
+    expect(options.method).toBe("GET");
+    expect(response.attributes.FID).toBe(42);
   });
 
-  it("return rawResponse when getting a feature", (done) => {
+  test("return rawResponse when getting a feature", async () => {
     const requestOptions = {
       url: serviceUrl,
       id: 42,
       rawResponse: true
     };
     fetchMock.once("*", featureResponse);
-    getFeature(requestOptions)
-      .then((response: any) => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(`${requestOptions.url}/42?f=json`);
-        expect(options.method).toBe("GET");
-        expect(response.status).toBe(200);
-        expect(response.ok).toBe(true);
-        expect(response.body.Readable).not.toBe(null);
-        response.json().then((raw: any) => {
-          expect(raw).toEqual(featureResponse);
-          done();
-        });
-        // this used to work with isomorphic-fetch
-        // expect(response instanceof Response).toBe(true);
-      })
-      .catch((e) => {
-        fail(e);
-      });
+
+    const response: any = await getFeature(requestOptions);
+
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toBe(`${requestOptions.url}/42?f=json`);
+    expect(options.method).toBe("GET");
+    expect(response.status).toBe(200);
+    expect(response.ok).toBe(true);
+    expect(response.body.Readable).not.toBe(null);
+
+    const raw = await response.json();
+    expect(raw).toEqual(featureResponse);
   });
 
-  it("should supply default query parameters", (done) => {
+  test("should supply default query parameters", async () => {
     const requestOptions: IQueryFeaturesOptions = {
       url: serviceUrl
     };
     fetchMock.once("*", queryResponse);
-    queryFeatures(requestOptions)
-      .then(() => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          `${requestOptions.url}/query?f=json&where=1%3D1&outFields=*`
-        );
-        expect(options.method).toBe("GET");
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await queryFeatures(requestOptions);
+
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      `${requestOptions.url}/query?f=json&where=1%3D1&outFields=*`
+    );
+    expect(options.method).toBe("GET");
   });
 
-  it("should use passed in query parameters", (done) => {
+  test("should use passed in query parameters", async () => {
     const requestOptions: IQueryFeaturesOptions = {
       url: serviceUrl,
       where: "Condition='Poor'",
@@ -102,43 +87,33 @@ describe("getFeature() and queryFeatures()", () => {
       geometryType: "esriGeometryPolygon"
     };
     fetchMock.once("*", queryResponse);
-    queryFeatures(requestOptions)
-      .then(() => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          `${requestOptions.url}/query?f=json&where=Condition%3D%27Poor%27&outFields=FID%2CTree_ID%2CCmn_Name%2CCondition&geometry=%7B%7D&geometryType=esriGeometryPolygon&orderByFields=test`
-        );
-        expect(options.method).toBe("GET");
-        // expect(response.attributes.FID).toEqual(42);
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await queryFeatures(requestOptions);
+
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      `${requestOptions.url}/query?f=json&where=Condition%3D%27Poor%27&outFields=FID%2CTree_ID%2CCmn_Name%2CCondition&geometry=%7B%7D&geometryType=esriGeometryPolygon&orderByFields=test`
+    );
+    expect(options.method).toBe("GET");
+    // expect(response.attributes.FID).toEqual(42);
   });
 
-  it("should supply default query related parameters", (done) => {
+  test("should supply default query related parameters", async () => {
     const requestOptions: IQueryRelatedOptions = {
       url: serviceUrl
     };
     fetchMock.once("*", queryRelatedResponse);
-    queryRelated(requestOptions)
-      .then(() => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(
-          `${requestOptions.url}/queryRelatedRecords?f=json&definitionExpression=1%3D1&outFields=*&relationshipId=0`
-        );
-        expect(options.method).toBe("GET");
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await queryRelated(requestOptions);
+
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(
+      `${requestOptions.url}/queryRelatedRecords?f=json&definitionExpression=1%3D1&outFields=*&relationshipId=0`
+    );
+    expect(options.method).toBe("GET");
   });
 
-  it("should use passed in query related parameters", (done) => {
+  test("should use passed in query related parameters", async () => {
     const requestOptions: IQueryRelatedOptions = {
       url: serviceUrl,
       relationshipId: 1,
@@ -147,23 +122,16 @@ describe("getFeature() and queryFeatures()", () => {
       httpMethod: "POST"
     };
     fetchMock.once("*", queryRelatedResponse);
-    queryRelated(requestOptions)
-      .then(() => {
-        expect(fetchMock.called()).toBeTruthy();
-        const [url, options] = fetchMock.lastCall("*");
-        expect(url).toEqual(`${requestOptions.url}/queryRelatedRecords`);
-        expect(options.method).toBe("POST");
-        expect(options.body).toContain("f=json");
-        expect(options.body).toContain("relationshipId=1");
-        expect(options.body).toContain(
-          "definitionExpression=APPROXACRE%3C10000"
-        );
-        expect(options.body).toContain("outFields=APPROXACRE%2CFIELD_NAME");
-        done();
-      })
-      .catch((e) => {
-        fail(e);
-      });
+    const response = await queryRelated(requestOptions);
+
+    expect(fetchMock.called()).toBeTruthy();
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toEqual(`${requestOptions.url}/queryRelatedRecords`);
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain("relationshipId=1");
+    expect(options.body).toContain("definitionExpression=APPROXACRE%3C10000");
+    expect(options.body).toContain("outFields=APPROXACRE%2CFIELD_NAME");
   });
 });
 
@@ -183,7 +151,7 @@ describe("queryAllFeatures", () => {
     fetchMock.restore();
   });
 
-  it("fetches multiple pages based on feature count", async () => {
+  test("fetches multiple pages based on feature count", async () => {
     fetchMock.mock(`${serviceUrl}?f=json`, {
       maxRecordCount: 2000
     });
@@ -213,7 +181,7 @@ describe("queryAllFeatures", () => {
     expect(result.features[pageSize].attributes.OBJECTID).toBe(2001);
   });
 
-  it("fetches only one page if total features are under page size", async () => {
+  test("fetches only one page if total features are under page size", async () => {
     fetchMock.getOnce(`${serviceUrl}?f=json`, {
       maxRecordCount: 2000
     });
@@ -235,7 +203,7 @@ describe("queryAllFeatures", () => {
     expect(result.features[0].attributes.OBJECTID).toBe(2001);
   });
 
-  it("uses user defined resultRecordCount if less than page size", async () => {
+  test("uses user defined resultRecordCount if less than page size", async () => {
     const customCount = 1000;
 
     fetchMock.getOnce(`${serviceUrl}?f=json`, {
@@ -261,7 +229,7 @@ describe("queryAllFeatures", () => {
     expect(result.features.length).toBe(customCount);
   });
 
-  it("fall back to service pageSize if user resultRecordCount exceeds it", async () => {
+  test("fall back to service pageSize if user resultRecordCount exceeds it", async () => {
     fetchMock.getOnce(`${serviceUrl}?f=json`, {
       maxRecordCount: 2000
     });
@@ -285,7 +253,7 @@ describe("queryAllFeatures", () => {
     expect(result.features.length).toBe(pageSize);
   });
 
-  it("fall back to a default size of 2000 if thes service does not return a page size", async () => {
+  test("fall back to a default size of 2000 if thes service does not return a page size", async () => {
     fetchMock.getOnce(`${serviceUrl}?f=json`, {});
 
     fetchMock.getOnce(
@@ -302,7 +270,7 @@ describe("queryAllFeatures", () => {
     expect(result.features.length).toBe(pageSize);
   });
 
-  it("paginates over services using f=geojson", async () => {
+  test("paginates over services using f=geojson", async () => {
     // first page with 2000 features
     const page1Features = Array.from({ length: pageSize }, (_, i) => ({
       id: i + 1,

--- a/packages/arcgis-rest-feature-service/test/updateServiceDefinition.test.ts
+++ b/packages/arcgis-rest-feature-service/test/updateServiceDefinition.test.ts
@@ -34,7 +34,7 @@ describe("update service definition", () => {
       capabilities: "Create,Update"
     };
 
-    test("should update feature service defintion", async () => {
+    test("should update feature service definition (direct option)", async () => {
       fetchMock.once("*", UpdateServiceDefinitionSuccess);
 
       const response = await updateServiceDefinition(
@@ -45,7 +45,7 @@ describe("update service definition", () => {
         }
       );
 
-      // Check service call
+      // Check service call for direct updateDefinition option
       expect(fetchMock.called()).toBe(true);
       const [url, options] = fetchMock.lastCall("*");
 
@@ -62,7 +62,8 @@ describe("update service definition", () => {
       // Check response
       expect(response).toEqual(UpdateServiceDefinitionSuccess);
     });
-    test("should update feature service defintion (params.updateDefinition)", async () => {
+
+    test("should update feature service definition (params object)", async () => {
       fetchMock.once("*", UpdateServiceDefinitionSuccess);
 
       const response = await updateServiceDefinition(
@@ -73,7 +74,7 @@ describe("update service definition", () => {
         }
       );
 
-      // Check service call
+      // Check service call for updateDefinition inside params object
       expect(fetchMock.called()).toEqual(true);
       const [url, options] = fetchMock.lastCall("*");
 

--- a/packages/arcgis-rest-feature-service/test/updateServiceDefinition.test.ts
+++ b/packages/arcgis-rest-feature-service/test/updateServiceDefinition.test.ts
@@ -1,6 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+import { describe, afterEach, test, expect } from "vitest";
 import fetchMock from "fetch-mock";
 import { TOMORROW } from "../../../scripts/test-helpers.js";
 import { ArcGISIdentityManager, encodeParam } from "@esri/arcgis-rest-request";
@@ -33,71 +34,61 @@ describe("update service definition", () => {
       capabilities: "Create,Update"
     };
 
-    it("should update feature service defintion", (done) => {
+    test("should update feature service defintion", async () => {
       fetchMock.once("*", UpdateServiceDefinitionSuccess);
 
-      updateServiceDefinition(
+      const response = await updateServiceDefinition(
         "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
         {
           updateDefinition,
           ...MOCK_USER_REQOPTS
         }
-      )
-        .then((response) => {
-          // Check service call
-          expect(fetchMock.called()).toEqual(true);
-          const [url, options] = fetchMock.lastCall("*");
+      );
 
-          expect(url).toEqual(
-            "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/updateDefinition"
-          );
-          expect(options.method).toBe("POST");
-          expect(options.body).toContain("f=json");
-          expect(options.body).toContain(encodeParam("token", "fake-token"));
-          expect(options.body).toContain(
-            encodeParam("updateDefinition", JSON.stringify(updateDefinition))
-          );
+      // Check service call
+      expect(fetchMock.called()).toBe(true);
+      const [url, options] = fetchMock.lastCall("*");
 
-          // Check response
-          expect(response).toEqual(UpdateServiceDefinitionSuccess);
-          done();
-        })
-        .catch((e) => {
-          fail(e);
-        });
+      expect(url).toBe(
+        "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/updateDefinition"
+      );
+      expect(options.method).toBe("POST");
+      expect(options.body).toContain("f=json");
+      expect(options.body).toContain(encodeParam("token", "fake-token"));
+      expect(options.body).toContain(
+        encodeParam("updateDefinition", JSON.stringify(updateDefinition))
+      );
+
+      // Check response
+      expect(response).toEqual(UpdateServiceDefinitionSuccess);
     });
-    it("should update feature service defintion (params.updateDefinition)", (done) => {
+    test("should update feature service defintion (params.updateDefinition)", async () => {
       fetchMock.once("*", UpdateServiceDefinitionSuccess);
 
-      updateServiceDefinition(
+      const response = await updateServiceDefinition(
         "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer",
         {
           params: { updateDefinition },
           ...MOCK_USER_REQOPTS
         }
-      )
-        .then((response) => {
-          // Check service call
-          expect(fetchMock.called()).toEqual(true);
-          const [url, options] = fetchMock.lastCall("*");
+      );
 
-          expect(url).toEqual(
-            "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/updateDefinition"
-          );
-          expect(options.method).toBe("POST");
-          expect(options.body).toContain("f=json");
-          expect(options.body).toContain(encodeParam("token", "fake-token"));
-          expect(options.body).toContain(
-            encodeParam("updateDefinition", JSON.stringify(updateDefinition))
-          );
+      // Check service call
+      expect(fetchMock.called()).toEqual(true);
+      const [url, options] = fetchMock.lastCall("*");
 
-          // Check response
-          expect(response).toEqual(UpdateServiceDefinitionSuccess);
-          done();
-        })
-        .catch((e) => {
-          fail(e);
-        });
+      expect(url).toEqual(
+        "https://services1.arcgis.com/ORG/arcgis/rest/admin/services/FEATURE_SERVICE/FeatureServer/updateDefinition"
+      );
+      expect(options.method).toBe("POST");
+      expect(options.body).toContain("f=json");
+      expect(options.body).toContain(encodeParam("token", "fake-token"));
+      expect(options.body).toContain(
+        encodeParam("updateDefinition", JSON.stringify(updateDefinition))
+      );
+
+      // Check response
+      expect(response).toEqual(UpdateServiceDefinitionSuccess);
     });
   }); // auth requests
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,7 +7,8 @@ export default defineConfig({
       "packages/arcgis-rest-elevation/**/*.{test,spec}.?(c|m)[jt]s?(x)",
       "packages/arcgis-rest-places/**/*.{test,spec}.?(c|m)[jt]s?(x)",
       "packages/arcgis-rest-demographics/**/*.{test,spec}.?(c|m)[jt]s?(x)",
-      "packages/arcgis-rest-geocoding/**/*.{test,spec}.?(c|m)[jt]s?(x)"
+      "packages/arcgis-rest-geocoding/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "packages/arcgis-rest-feature-service/**/*.{test,spec}.?(c|m)[jt]s?(x)"
     ],
     coverage: {
       enabled: true,
@@ -16,7 +17,8 @@ export default defineConfig({
         "packages/arcgis-rest-elevation/src/**/*.{ts,js}",
         "packages/arcgis-rest-places/src/**/*.{ts,js}",
         "packages/arcgis-rest-demographics/src/**/*.{ts,js}",
-        "packages/arcgis-rest-geocoding/src/**/*.{ts,js}"
+        "packages/arcgis-rest-geocoding/src/**/*.{ts,js}",
+        "packages/arcgis-rest-feature-service/src/**/*.{ts,js}"
       ],
       provider: "istanbul",
       reporter: ["json", "html", "cobertura"],


### PR DESCRIPTION
This PR migrates the routing package tests to Vitest as part of https://github.com/Esri/arcgis-rest-js/issues/1251