### PR TITLE
Allow token check for decorated thumbnail to fail

### DIFF
--- a/.changeset/icy-garlics-repair.md
+++ b/.changeset/icy-garlics-repair.md
@@ -1,0 +1,5 @@
+---
+"@esri/arcgis-rest-portal": patch
+---
+
+Fix a bug in `getItem()` when using LDAP or cookie based auth.

--- a/.changeset/icy-garlics-repair.md
+++ b/.changeset/icy-garlics-repair.md
@@ -2,4 +2,4 @@
 "@esri/arcgis-rest-portal": patch
 ---
 
-Fix a bug in `getItem()` when using LDAP or cookie based auth.
+Fix a bug in `getItem()` when using LDAP or cookie-based auth.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@vitest/browser-preview": "^4.0.5",
         "@vitest/coverage-istanbul": "^4.0.5",
         "@vitest/ui": "^4.0.5",
-        "arcgis-pbf-parser": "^0.0.4",
         "babel-preset-env": "^1.7.0",
         "browser-sync": "^2.27.9",
         "eslint": "^9.39.1",
@@ -3614,30 +3613,6 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/arcgis-pbf-parser": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/arcgis-pbf-parser/-/arcgis-pbf-parser-0.0.4.tgz",
-      "integrity": "sha512-ngieRsLNct1dPyH85DnASiierr+hYO+9ow3zC22lYvNcKtFxVrtd1jbfizwWs9Kp3NpKP4iNnPAONp3acCcceA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "pbf": "^3.2.1"
-      }
-    },
-    "node_modules/arcgis-pbf-parser/node_modules/pbf": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
-      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ieee754": "^1.1.12",
-        "resolve-protobuf-schema": "^2.1.0"
-      },
-      "bin": {
-        "pbf": "bin/pbf"
-      }
     },
     "node_modules/are-we-there-yet": {
       "version": "1.1.7",
@@ -8461,27 +8436,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -11952,7 +11906,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
       "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
@@ -12438,7 +12391,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
       "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ps-list": {
@@ -13075,7 +13027,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
@@ -16252,10 +16203,10 @@
     },
     "packages/arcgis-rest-auth": {
       "name": "@esri/arcgis-rest-auth",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-request": "^4.8.0",
+        "@esri/arcgis-rest-request": "^4.10.1",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -16270,14 +16221,14 @@
     },
     "packages/arcgis-rest-basemap-sessions": {
       "name": "@esri/arcgis-rest-basemap-sessions",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "^4.8.0"
+        "@esri/arcgis-rest-request": "^4.10.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -16298,13 +16249,13 @@
     },
     "packages/arcgis-rest-demographics": {
       "name": "@esri/arcgis-rest-demographics",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "^4.8.0"
+        "@esri/arcgis-rest-request": "^4.10.1"
       },
       "engines": {
         "node": ">=12.20.0"
@@ -16321,15 +16272,15 @@
     },
     "packages/arcgis-rest-developer-credentials": {
       "name": "@esri/arcgis-rest-developer-credentials",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-portal": "^4.8.0",
-        "@esri/arcgis-rest-request": "^4.8.0"
+        "@esri/arcgis-rest-portal": "^4.10.1",
+        "@esri/arcgis-rest-request": "^4.10.1"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-portal": "^4.8.0",
-        "@esri/arcgis-rest-request": "^4.8.0"
+        "@esri/arcgis-rest-portal": "^4.10.1",
+        "@esri/arcgis-rest-request": "^4.10.1"
       },
       "engines": {
         "node": ">=12.20.0"
@@ -16337,13 +16288,13 @@
     },
     "packages/arcgis-rest-elevation": {
       "name": "@esri/arcgis-rest-elevation",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "^4.8.0"
+        "@esri/arcgis-rest-request": "^4.10.1"
       },
       "engines": {
         "node": ">=12.20.0"
@@ -16360,14 +16311,15 @@
     },
     "packages/arcgis-rest-feature-service": {
       "name": "@esri/arcgis-rest-feature-service",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "pbf": "^4.0.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-portal": "^4.8.0",
-        "@esri/arcgis-rest-request": "^4.8.0"
+        "@esri/arcgis-rest-portal": "^4.10.1",
+        "@esri/arcgis-rest-request": "^4.10.1"
       },
       "engines": {
         "node": ">=12.20.0"
@@ -16385,7 +16337,7 @@
     },
     "packages/arcgis-rest-fetch": {
       "name": "@esri/arcgis-rest-fetch",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "node-fetch": "^3.2.10"
@@ -16393,7 +16345,7 @@
     },
     "packages/arcgis-rest-form-data": {
       "name": "@esri/arcgis-rest-form-data",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "formdata-node": "^4.1.0"
@@ -16401,7 +16353,7 @@
     },
     "packages/arcgis-rest-geocoding": {
       "name": "@esri/arcgis-rest-geocoding",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@terraformer/arcgis": "^2.0.7",
@@ -16409,7 +16361,7 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "^4.8.0"
+        "@esri/arcgis-rest-request": "^4.10.1"
       },
       "engines": {
         "node": ">=12.20.0"
@@ -16426,13 +16378,13 @@
     },
     "packages/arcgis-rest-places": {
       "name": "@esri/arcgis-rest-places",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "^4.8.0"
+        "@esri/arcgis-rest-request": "^4.10.1"
       },
       "engines": {
         "node": ">=12.20.0"
@@ -16449,13 +16401,13 @@
     },
     "packages/arcgis-rest-portal": {
       "name": "@esri/arcgis-rest-portal",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "^4.8.0"
+        "@esri/arcgis-rest-request": "^4.10.1"
       },
       "engines": {
         "node": ">=12.20.0"
@@ -16472,11 +16424,11 @@
     },
     "packages/arcgis-rest-request": {
       "name": "@esri/arcgis-rest-request",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@esri/arcgis-rest-fetch": "^4.8.0",
-        "@esri/arcgis-rest-form-data": "^4.8.0",
+        "@esri/arcgis-rest-fetch": "^4.10.1",
+        "@esri/arcgis-rest-form-data": "^4.10.1",
         "mitt": "^3.0.0",
         "tslib": "^2.3.1"
       },
@@ -16499,7 +16451,7 @@
     },
     "packages/arcgis-rest-routing": {
       "name": "@esri/arcgis-rest-routing",
-      "version": "4.8.0",
+      "version": "4.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@terraformer/arcgis": "^2.0.7",
@@ -16507,7 +16459,7 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@esri/arcgis-rest-request": "^4.8.0"
+        "@esri/arcgis-rest-request": "^4.10.1"
       },
       "engines": {
         "node": ">=12.20.0"

--- a/packages/arcgis-rest-portal/src/items/get.ts
+++ b/packages/arcgis-rest-portal/src/items/get.ts
@@ -61,9 +61,7 @@ export function getItem(
       try {
         token = await requestOptions.authentication.getToken(url);
       } catch (e) {
-        // do nothing, `getToken()` will fail in some cases like LDAP or PKI auth,
-        // but we still want to return the item info if possible the thumbnail will
-        //  still work if the browser manages the auth with a cookie
+        // Ignore token acquisition errors because `getToken()` can fail for some authentication types, but we still want to return the item info when possible since the browser may still provide thumbnail access via an auth cookie.
       }
     }
 

--- a/packages/arcgis-rest-portal/src/items/get.ts
+++ b/packages/arcgis-rest-portal/src/items/get.ts
@@ -58,7 +58,13 @@ export function getItem(
       typeof requestOptions.authentication !== "string" &&
       item.access !== "public"
     ) {
-      token = await requestOptions.authentication.getToken(url);
+      try {
+        token = await requestOptions.authentication.getToken(url);
+      } catch (e) {
+        // do nothing, `getToken()` will fail in some cases like LDAP or PKI auth,
+        // but we still want to return the item info if possible the thumbnail will
+        //  still work if the browser manages the auth with a cookie
+      }
     }
 
     return decorateThumbnail(item, portal, token);

--- a/packages/arcgis-rest-portal/test/items/get.test.ts
+++ b/packages/arcgis-rest-portal/test/items/get.test.ts
@@ -246,6 +246,21 @@ describe("get", () => {
         "https://www.arcgis.com/sharing/rest/content/items/3ef/info/thumb.png"
       );
     });
+
+    test("should not decorate with an item thumbnail if there is an error getting a token", async () => {
+      fetchMock.once("*", MOCK_ITEM);
+      const fakeAuthManager = {
+        getToken: (_url: string) => Promise.reject(new Error("error")),
+        portal: "https://www.arcgis.com/sharing/rest",
+        federatedServers: []
+      } as IAuthenticationManager;
+      const item = await getItem("3ef", {
+        authentication: fakeAuthManager
+      });
+      expect(item.thumbnailUrl).toBe(
+        "https://www.arcgis.com/sharing/rest/content/items/3ef/info/thumb.png"
+      );
+    });
   });
 
   describe("Authenticated methods", () => {


### PR DESCRIPTION
This fixes a bug reported internally where `getItem()` will throw an error because it cannot get a token when using LDAP auth since the browser manages auth by sending cookies with the requests rather then storing a token.