### PR TITLE
Request deprecation messages should honor suppressWarnings

### DIFF
--- a/.changeset/late-singers-taste.md
+++ b/.changeset/late-singers-taste.md
@@ -1,0 +1,5 @@
+---
+"@esri/arcgis-rest-request": patch
+---
+
+setDefaultRequestOptions and requests with rawResponse will honor suppressWarnings requestOptions

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -45,9 +45,11 @@ export function setDefaultRequestOptions(
   options: IRequestOptions,
   hideWarnings?: boolean
 ) {
-  console.warn(
-    `setDefaultRequestOptions() is deprecated. This will be removed in ArcGIS REST JS v5.0.`
-  );
+  if (!options.suppressWarnings) {
+    console.warn(
+      `setDefaultRequestOptions() is deprecated. This will be removed in ArcGIS REST JS v5.0.`
+    );
+  }
   if (options.authentication && !hideWarnings) {
     warn(
       "You should not set `authentication` as a default in a shared environment such as a web server which will process multiple users requests. You can call `setDefaultRequestOptions` with `true` as a second argument to disable this warning."

--- a/packages/arcgis-rest-request/src/request.ts
+++ b/packages/arcgis-rest-request/src/request.ts
@@ -45,7 +45,9 @@ export function setDefaultRequestOptions(
   options: IRequestOptions,
   hideWarnings?: boolean
 ) {
-  console.warn(`setDefaultRequestOptions() is deprecated. This will be removed in ArcGIS REST JS v5.0.`);
+  console.warn(
+    `setDefaultRequestOptions() is deprecated. This will be removed in ArcGIS REST JS v5.0.`
+  );
   if (options.authentication && !hideWarnings) {
     warn(
       "You should not set `authentication` as a default in a shared environment such as a web server which will process multiple users requests. You can call `setDefaultRequestOptions` with `true` as a second argument to disable this warning."
@@ -505,7 +507,11 @@ export function internalRequest(
           });
       }
       if (rawResponse) {
-        console.warn(`rawResponse option is deprecated and will be removed in ArcGIS REST JS v5.0.`);
+        if (!options.suppressWarnings) {
+          console.warn(
+            `rawResponse option is deprecated and will be removed in ArcGIS REST JS v5.0.`
+          );
+        }
         return response;
       }
       switch (params.f) {

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -366,6 +366,51 @@ describe("request()", () => {
     expect(raw).toEqual(GeoJSONFeatureCollection);
   });
 
+  test("should warn when rawResponse is used without suppressWarnings", async () => {
+    const oldWarn = console.warn;
+    const warnSpy = vi.fn();
+    console.warn = warnSpy;
+
+    fetchMock.once("*", GeoJSONFeatureCollection);
+
+    await request(
+      "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer/0/query",
+      {
+        httpMethod: "GET",
+        params: { where: "1=1", f: "geojson" },
+        rawResponse: true
+      }
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "rawResponse option is deprecated and will be removed in ArcGIS REST JS v5.0."
+    );
+
+    console.warn = oldWarn;
+  });
+
+  test("should not warn when rawResponse is used with suppressWarnings", async () => {
+    const oldWarn = console.warn;
+    const warnSpy = vi.fn();
+    console.warn = warnSpy;
+
+    fetchMock.once("*", GeoJSONFeatureCollection);
+
+    await request(
+      "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer/0/query",
+      {
+        httpMethod: "GET",
+        params: { where: "1=1", f: "geojson" },
+        rawResponse: true,
+        suppressWarnings: true
+      }
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    console.warn = oldWarn;
+  });
+
   test("should allow setting defaults for all requests", async () => {
     fetchMock.once("*", SharingRestInfo);
 

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -438,6 +438,34 @@ describe("request()", () => {
     });
   });
 
+  test("should warn when setDefaultRequestOptions is used without suppressWarnings", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    setDefaultRequestOptions({
+      headers: {
+        "Test-Header": "Test"
+      }
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "setDefaultRequestOptions() is deprecated. This will be removed in ArcGIS REST JS v5.0."
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  test("should not warn when setDefaultRequestOptions is used with suppressWarnings", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    setDefaultRequestOptions({
+      headers: {
+        "Test-Header": "Test"
+      },
+      suppressWarnings: true
+    });
+    warnSpy.mockRestore();
+  });
+
   test("should warn users when attempting to set default auth", () => {
     const oldWarn = console.warn;
     const warnSpy = vi.fn();

--- a/packages/arcgis-rest-request/test/request.test.ts
+++ b/packages/arcgis-rest-request/test/request.test.ts
@@ -367,48 +367,48 @@ describe("request()", () => {
   });
 
   test("should warn when rawResponse is used without suppressWarnings", async () => {
-    const oldWarn = console.warn;
-    const warnSpy = vi.fn();
-    console.warn = warnSpy;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     fetchMock.once("*", GeoJSONFeatureCollection);
 
-    await request(
-      "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer/0/query",
-      {
-        httpMethod: "GET",
-        params: { where: "1=1", f: "geojson" },
-        rawResponse: true
-      }
-    );
+    try {
+      await request(
+        "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer/0/query",
+        {
+          httpMethod: "GET",
+          params: { where: "1=1", f: "geojson" },
+          rawResponse: true
+        }
+      );
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      "rawResponse option is deprecated and will be removed in ArcGIS REST JS v5.0."
-    );
-
-    console.warn = oldWarn;
+      expect(warnSpy).toHaveBeenCalledWith(
+        "rawResponse option is deprecated and will be removed in ArcGIS REST JS v5.0."
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   test("should not warn when rawResponse is used with suppressWarnings", async () => {
-    const oldWarn = console.warn;
-    const warnSpy = vi.fn();
-    console.warn = warnSpy;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     fetchMock.once("*", GeoJSONFeatureCollection);
 
-    await request(
-      "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer/0/query",
-      {
-        httpMethod: "GET",
-        params: { where: "1=1", f: "geojson" },
-        rawResponse: true,
-        suppressWarnings: true
-      }
-    );
+    try {
+      await request(
+        "https://services1.arcgis.com/ORG/arcgis/rest/services/FEATURE_SERVICE/FeatureServer/0/query",
+        {
+          httpMethod: "GET",
+          params: { where: "1=1", f: "geojson" },
+          rawResponse: true,
+          suppressWarnings: true
+        }
+      );
 
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    console.warn = oldWarn;
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   test("should allow setting defaults for all requests", async () => {


### PR DESCRIPTION
Deprecation messages should not warn when suppressWarnings option is true.