### PR TITLE
Fix thumbnail token query parameter

### DIFF
--- a/packages/arcgis-rest-portal/src/items/helpers.ts
+++ b/packages/arcgis-rest-portal/src/items/helpers.ts
@@ -315,7 +315,7 @@ export function decorateThumbnail(
   if (typeof item.thumbnail === "string") {
     thumbnailUrl = `${portal}/content/items/${item.id}/info/${item.thumbnail}`;
     if (thumbnailUrl && item.access !== "public" && token) {
-      thumbnailUrl += `?${token}`;
+      thumbnailUrl += `?token=${token}`;
     }
   }
 

--- a/packages/arcgis-rest-portal/test/items/get.test.ts
+++ b/packages/arcgis-rest-portal/test/items/get.test.ts
@@ -231,7 +231,7 @@ describe("get", () => {
       } as IAuthenticationManager;
       const item = await getItem("3ef", { authentication: fakeAuthManager });
       expect(item.thumbnailUrl).toBe(
-        "https://www.arcgis.com/sharing/rest/content/items/3ef/info/thumb.png?fake-token"
+        "https://www.arcgis.com/sharing/rest/content/items/3ef/info/thumb.png?token=fake-token"
       );
     });
 

--- a/packages/arcgis-rest-portal/test/items/helpers.test.ts
+++ b/packages/arcgis-rest-portal/test/items/helpers.test.ts
@@ -40,4 +40,36 @@ describe("decorateThumbnail()", () => {
       decorateThumbnail(undefined as any, "https://portal.com")
     ).toBeUndefined();
   });
+
+  test("should decorate private item thumbnail with token parameter", () => {
+    const item = decorateThumbnail(
+      {
+        id: "3ef",
+        access: "private",
+        thumbnail: "thumb.png"
+      } as any,
+      "https://portal.com",
+      "fake-token"
+    );
+
+    expect(item.thumbnailUrl).toBe(
+      "https://portal.com/content/items/3ef/info/thumb.png?token=fake-token"
+    );
+  });
+
+  test("should not append token parameter for public item thumbnail", () => {
+    const item = decorateThumbnail(
+      {
+        id: "3ef",
+        access: "public",
+        thumbnail: "thumb.png"
+      } as any,
+      "https://portal.com",
+      "fake-token"
+    );
+
+    expect(item.thumbnailUrl).toBe(
+      "https://portal.com/content/items/3ef/info/thumb.png"
+    );
+  });
 });


### PR DESCRIPTION
Fixes: #1314

Private item thumbnail URLs were appending the raw token as the query string, producing unauthorized requests. ArcGIS expects the token under the `token` query parameter.

- **Thumbnail URL decoration**
  - Changed private thumbnail URLs from `?${token}` to `?token=${token}`.
  - Preserved public thumbnail behavior with no token appended.

- **Test coverage**
  - Added direct `decorateThumbnail()` coverage for private and public thumbnail URLs.
  - Updated authenticated `getItem()` thumbnail expectations.

```ts
thumbnailUrl += `?token=${token}`;
```