### PR TITLE
Add `processOptions()` method

### DIFF
--- a/.changeset/soft-brooms-smile.md
+++ b/.changeset/soft-brooms-smile.md
@@ -1,0 +1,9 @@
+---
+"@esri/arcgis-rest-request": minor
+---
+
+Added `processOptions` to `@esri/arcgis-rest-request` and published it in exports.
+
+Replaced `appendCustomParams` with `processOptions` across REST JS.
+
+Deprecated `appendCustomParams` for removal in a future release.

--- a/.changeset/soft-brooms-smile.md
+++ b/.changeset/soft-brooms-smile.md
@@ -7,3 +7,5 @@ Added `processOptions` to `@esri/arcgis-rest-request` and published it in export
 Replaced `appendCustomParams` with `processOptions` across REST JS.
 
 Deprecated `appendCustomParams` for removal in a future release.
+
+Fixed issue witn `findElevationAtManyPoints` where coordinates were not being passed consistently.

--- a/packages/arcgis-rest-demographics/src/getAvailableCountries.ts
+++ b/packages/arcgis-rest-demographics/src/getAvailableCountries.ts
@@ -4,7 +4,7 @@
 import {
   request,
   cleanUrl,
-  appendCustomParams,
+  processOptions,
   IExtent
 } from "@esri/arcgis-rest-request";
 
@@ -89,26 +89,24 @@ export interface IApportionmentThreshold {
 export function getAvailableCountries(
   requestOptions?: IGetAvailableCountriesOptions
 ): Promise<IGetAvailableCountriesResponse> {
+  let url = `${ARCGIS_ONLINE_GEOENRICHMENT_URL}/countries`;
   let options: IEndpointOptions = {};
-  let endpoint = `${ARCGIS_ONLINE_GEOENRICHMENT_URL}/countries`;
-  if (!requestOptions) {
-    options.params = {};
-  } else {
+  if (requestOptions) {
     if (requestOptions.endpoint) {
-      endpoint = `${requestOptions.endpoint}/countries`;
+      url = `${requestOptions.endpoint}/countries`;
     }
-
-    options = appendCustomParams<IGetAvailableCountriesOptions>(
-      requestOptions,
-      [],
-      { params: { ...requestOptions.params } }
-    );
     if (requestOptions.countryCode) {
-      endpoint = `${endpoint}/${requestOptions.countryCode}`;
+      url = `${url}/${requestOptions.countryCode}`;
     }
-  }
 
-  return request(cleanUrl(endpoint), options).then((response: any) => {
+    const { requestOptions: processedOptions } =
+      processOptions<IGetAvailableCountriesOptions>(requestOptions, {
+        paramKeys: [],
+        extractKeys: []
+      });
+    options = processedOptions;
+  }
+  return request(cleanUrl(url), options).then((response: any) => {
     return response;
   });
 }

--- a/packages/arcgis-rest-demographics/src/getAvailableDataCollections.ts
+++ b/packages/arcgis-rest-demographics/src/getAvailableDataCollections.ts
@@ -1,11 +1,7 @@
 /* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import {
-  request,
-  cleanUrl,
-  appendCustomParams
-} from "@esri/arcgis-rest-request";
+import { request, cleanUrl, processOptions } from "@esri/arcgis-rest-request";
 
 import {
   ARCGIS_ONLINE_GEOENRICHMENT_URL,
@@ -130,19 +126,20 @@ export function getAvailableDataCollections(
   let options: IGetAvailableDataCollectionsOptions = {};
   let endpoint = `${ARCGIS_ONLINE_GEOENRICHMENT_URL}/dataCollections`;
 
-  if (!requestOptions) {
-    options.params = {};
-  } else {
+  if (requestOptions) {
     if (requestOptions.endpoint) {
       endpoint = `${requestOptions.endpoint}/dataCollections`;
     }
-    options = appendCustomParams<IGetAvailableDataCollectionsOptions>(
+    const { requestOptions: processedOptions } = processOptions(
       requestOptions,
-      ["addDerivativeVariables", "suppressNullValues"],
-      { params: { ...requestOptions.params } }
+      {
+        paramKeys: ["addDerivativeVariables", "suppressNullValues"],
+        extractKeys: []
+      }
     );
+    options = processedOptions as IGetAvailableDataCollectionsOptions;
 
-    if (options.params.addDerivativeVariables) {
+    if (options.params?.addDerivativeVariables) {
       options.params.addDerivativeVariables = JSON.stringify(
         options.params.addDerivativeVariables
       );

--- a/packages/arcgis-rest-demographics/src/getAvailableGeographyLevels.ts
+++ b/packages/arcgis-rest-demographics/src/getAvailableGeographyLevels.ts
@@ -1,11 +1,7 @@
 /* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import {
-  request,
-  cleanUrl,
-  appendCustomParams
-} from "@esri/arcgis-rest-request";
+import { request, cleanUrl, processOptions } from "@esri/arcgis-rest-request";
 
 import {
   ARCGIS_ONLINE_GEOENRICHMENT_URL,
@@ -71,15 +67,18 @@ export function getAvailableGeographyLevels(
   let options: IEndpointOptions = {};
   let endpoint = `${ARCGIS_ONLINE_GEOENRICHMENT_URL}/StandardGeographyLevels`;
 
-  if (!requestOptions) {
-    options.params = {};
-  } else {
+  if (requestOptions) {
     if (requestOptions.endpoint) {
       endpoint = `${requestOptions.endpoint}/StandardGeographyLevels`;
     }
-    options = appendCustomParams<IEndpointOptions>(requestOptions, [], {
-      params: { ...requestOptions.params }
-    });
+    const { requestOptions: processedOptions } = processOptions(
+      requestOptions,
+      {
+        paramKeys: [],
+        extractKeys: []
+      }
+    );
+    options = processedOptions;
   }
 
   return request(`${cleanUrl(endpoint)}`, options).then((response: any) => {

--- a/packages/arcgis-rest-demographics/src/getGeography.ts
+++ b/packages/arcgis-rest-demographics/src/getGeography.ts
@@ -1,11 +1,7 @@
 /* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import {
-  request,
-  cleanUrl,
-  appendCustomParams
-} from "@esri/arcgis-rest-request";
+import { request, cleanUrl, processOptions } from "@esri/arcgis-rest-request";
 
 import {
   ARCGIS_ONLINE_STANDARD_GEOGRAPHY_QUERY_URL,
@@ -106,13 +102,19 @@ export interface IGetGeographyResponse {
 export function getGeography(
   requestOptions?: IGetGeographyOptions
 ): Promise<IGetGeographyResponse> {
+  // the SAAS service does not support anonymous requests
+  if (!requestOptions.authentication) {
+    return Promise.reject(
+      "Geoenrichment using the ArcGIS service requires authentication"
+    );
+  }
+
   const endpoint = `${
     requestOptions.endpoint || ARCGIS_ONLINE_STANDARD_GEOGRAPHY_QUERY_URL
   }/execute`;
 
-  const options = appendCustomParams<IGetGeographyOptions>(
-    requestOptions,
-    [
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
       "sourceCountry",
       "optionalCountryDataset",
       "geographyLayers",
@@ -130,15 +132,8 @@ export function getGeography(
       "featureOffset",
       "langCode"
     ],
-    { params: { ...requestOptions.params } }
-  );
-
-  // the SAAS service does not support anonymous requests
-  if (!requestOptions.authentication) {
-    return Promise.reject(
-      "Geoenrichment using the ArcGIS service requires authentication"
-    );
-  }
+    extractKeys: []
+  });
 
   // These parameters are passed as JSON-style strings:
   ["geographyLayers", "geographyIDs"].forEach((parameter) => {

--- a/packages/arcgis-rest-demographics/src/queryDemographicData.ts
+++ b/packages/arcgis-rest-demographics/src/queryDemographicData.ts
@@ -1,11 +1,7 @@
 /* Copyright (c) 2020 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import {
-  request,
-  cleanUrl,
-  appendCustomParams
-} from "@esri/arcgis-rest-request";
+import { request, cleanUrl, processOptions } from "@esri/arcgis-rest-request";
 import {
   ARCGIS_ONLINE_GEOENRICHMENT_URL,
   IGeoenrichmentResult,
@@ -69,9 +65,15 @@ export interface IQueryDemographicDataResponse {
 export function queryDemographicData(
   requestOptions?: IQueryDemographicDataOptions
 ): Promise<IQueryDemographicDataResponse> {
-  const options = appendCustomParams<IQueryDemographicDataOptions>(
-    requestOptions,
-    [
+  // the SAAS service does not support anonymous requests
+  if (!requestOptions.authentication) {
+    return Promise.reject(
+      "Geoenrichment using the ArcGIS service requires authentication"
+    );
+  }
+
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
       "studyAreas",
       "dataCollections",
       "analysisVariables",
@@ -80,15 +82,8 @@ export function queryDemographicData(
       "inSR",
       "outSR"
     ],
-    { params: { ...requestOptions.params } }
-  );
-
-  // the SAAS service does not support anonymous requests
-  if (!requestOptions.authentication) {
-    return Promise.reject(
-      "Geoenrichment using the ArcGIS service requires authentication"
-    );
-  }
+    extractKeys: []
+  });
 
   // These parameters are passed as JSON-style strings:
   ["dataCollections", "analysisVariables"].forEach((parameter) => {

--- a/packages/arcgis-rest-developer-credentials/src/shared/registerApp.ts
+++ b/packages/arcgis-rest-developer-credentials/src/shared/registerApp.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2023 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, appendCustomParams } from "@esri/arcgis-rest-request";
+import { request, processOptions } from "@esri/arcgis-rest-request";
 import { getPortalUrl } from "@esri/arcgis-rest-portal";
 import {
   IApp,
@@ -50,19 +50,25 @@ export async function registerApp(
   requestOptions: IRegisterAppOptions
 ): Promise<IApp> {
   // build params
-  const options = appendCustomParams(requestOptions, [
-    "itemId",
-    "appType",
-    "redirect_uris",
-    "httpReferrers",
-    "privileges"
-  ]);
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
+      "itemId",
+      "appType",
+      "redirect_uris",
+      "httpReferrers",
+      "privileges"
+    ],
+    extractKeys: [],
+    defaultOptions: {
+      fetchOptions: {
+        method: "POST"
+      }
+    }
+  });
   // encode special params value (e.g. array type...) in advance in order to make encodeQueryString() works correctly
   stringifyArrays(options);
 
   const url = getPortalUrl(options) + "/oauth2/registerApp";
-  options.fetchOptions.method = "POST";
-  options.params.f = "json";
 
   const registeredAppResponse: IRegisteredAppResponse = await request(
     url,

--- a/packages/arcgis-rest-developer-credentials/src/shared/registerApp.ts
+++ b/packages/arcgis-rest-developer-credentials/src/shared/registerApp.ts
@@ -60,6 +60,9 @@ export async function registerApp(
     ],
     extractKeys: [],
     defaultOptions: {
+      params: {
+        f: "json"
+      },
       fetchOptions: {
         method: "POST"
       }

--- a/packages/arcgis-rest-developer-credentials/src/updateApiKey.ts
+++ b/packages/arcgis-rest-developer-credentials/src/updateApiKey.ts
@@ -16,7 +16,7 @@ import {
   buildExpirationDateParams
 } from "./shared/helpers.js";
 import { getItem, getPortalUrl, updateItem } from "@esri/arcgis-rest-portal";
-import { appendCustomParams, request } from "@esri/arcgis-rest-request";
+import { processOptions, request } from "@esri/arcgis-rest-request";
 import {
   IApp,
   IGetAppInfoOptions,
@@ -98,11 +98,15 @@ export async function updateApiKey(
     };
     const appResponse = await getRegisteredAppInfo(getAppOption);
     const clientId = appResponse.client_id;
-    const options = appendCustomParams(
-      { ...appResponse, ...requestOptions }, // object with the custom params to look in
-      ["privileges", "httpReferrers"] // keys you want copied to the params object
-    );
-    options.params.f = "json";
+
+    const mergedOptions = {
+      ...appResponse,
+      ...requestOptions
+    };
+    const { requestOptions: options } = processOptions(mergedOptions, {
+      paramKeys: ["privileges", "httpReferrers"],
+      extractKeys: []
+    });
 
     // encode special params value (e.g. array type...) in advance in order to make encodeQueryString() works correctly
     stringifyArrays(options);

--- a/packages/arcgis-rest-developer-credentials/src/updateOAuthApp.ts
+++ b/packages/arcgis-rest-developer-credentials/src/updateOAuthApp.ts
@@ -8,7 +8,7 @@ import {
   appToOAuthAppProperties
 } from "./shared/helpers.js";
 import { getItem, getPortalUrl } from "@esri/arcgis-rest-portal";
-import { appendCustomParams, request } from "@esri/arcgis-rest-request";
+import { processOptions, request } from "@esri/arcgis-rest-request";
 import {
   IApp,
   IGetAppInfoOptions,
@@ -70,10 +70,13 @@ export async function updateOAuthApp(
   }
 
   const clientId = appResponse.client_id;
-  const options = appendCustomParams({ ...appResponse, ...requestOptions }, [
-    "redirect_uris"
-  ]);
-  options.params.f = "json";
+  const { requestOptions: options } = processOptions(
+    { ...appResponse, ...requestOptions },
+    {
+      paramKeys: ["redirect_uris"],
+      extractKeys: []
+    }
+  );
   options.params.appType = "multiple";
 
   // encode special params value (e.g. array type...) in advance in order to make encodeQueryString() works correctly

--- a/packages/arcgis-rest-developer-credentials/test/shared/registerApp.test.ts
+++ b/packages/arcgis-rest-developer-credentials/test/shared/registerApp.test.ts
@@ -169,8 +169,7 @@ describe("registerApp()", () => {
       redirect_uris: [],
       httpReferrers: ["https://www.esri.com/en-us/home"],
       privileges: [],
-      authentication: authOnline,
-      fetchOptions: { method: "GET" }
+      authentication: authOnline
     };
 
     const appResponse = await registerApp(requestOptions);

--- a/packages/arcgis-rest-elevation/src/findElevationAtManyPoints.ts
+++ b/packages/arcgis-rest-elevation/src/findElevationAtManyPoints.ts
@@ -1,6 +1,6 @@
 import {
   request,
-  appendCustomParams,
+  processOptions,
   IRequestOptions
 } from "@esri/arcgis-rest-request";
 
@@ -8,7 +8,7 @@ import { operations } from "./openapi-types.js";
 import { baseUrl } from "./utils.js";
 
 // determine the list of allowed params we want to allow as options
-// this should match the array given to appendCustomParams below
+// this should match the array given to processOptions below
 type queryParams = Pick<
   operations["ElevationAtManyPointsPost"]["requestBody"]["content"]["application/json"],
   "coordinates" | "relativeTo"
@@ -72,15 +72,14 @@ export interface IFindElevationAtManyPointsOptions
 export function findElevationAtManyPoints(
   requestOptions: IFindElevationAtManyPointsOptions
 ): Promise<IFindElevationAtManyPointsResponse> {
-  const options: any = appendCustomParams<IFindElevationAtManyPointsOptions>(
-    requestOptions,
-    ["relativeTo"],
-    {
-      ...requestOptions
-    }
-  );
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: ["relativeTo"],
+    extractKeys: []
+  });
 
-  options.params.coordinates = JSON.stringify(requestOptions.coordinates);
+  if (options.params?.coordinates) {
+    options.params.coordinates = JSON.stringify(requestOptions.coordinates);
+  }
 
   return (
     request(`${baseUrl}/elevation/at-many-points`, {

--- a/packages/arcgis-rest-elevation/src/findElevationAtManyPoints.ts
+++ b/packages/arcgis-rest-elevation/src/findElevationAtManyPoints.ts
@@ -69,27 +69,20 @@ export interface IFindElevationAtManyPointsOptions
  * console.log(results)
  * ```
  */
-export function findElevationAtManyPoints(
+export async function findElevationAtManyPoints(
   requestOptions: IFindElevationAtManyPointsOptions
 ): Promise<IFindElevationAtManyPointsResponse> {
   const { requestOptions: options } = processOptions(requestOptions, {
-    paramKeys: ["relativeTo"],
+    paramKeys: ["relativeTo", "coordinates"],
     extractKeys: []
   });
 
+  // if coordinates were provided, we need to stringify them for the request body
   if (options.params?.coordinates) {
-    options.params.coordinates = JSON.stringify(requestOptions.coordinates);
+    options.params.coordinates = JSON.stringify(options.params.coordinates);
   }
 
-  return (
-    request(`${baseUrl}/elevation/at-many-points`, {
-      ...options
-    }) as Promise<successResponse>
-  ).then((response) => {
-    const r: IFindElevationAtManyPointsResponse = {
-      ...response
-    };
-
-    return r;
+  return request(`${baseUrl}/elevation/at-many-points`, {
+    ...options
   });
 }

--- a/packages/arcgis-rest-elevation/src/findElevationAtPoint.ts
+++ b/packages/arcgis-rest-elevation/src/findElevationAtPoint.ts
@@ -1,6 +1,6 @@
 import {
   request,
-  appendCustomParams,
+  processOptions,
   IRequestOptions
 } from "@esri/arcgis-rest-request";
 
@@ -8,7 +8,7 @@ import { operations } from "./openapi-types.js";
 import { baseUrl } from "./utils.js";
 
 // determine the list of allowed params we want to allow as options
-// this should match the array given to appendCustomParams below
+// this should match the array given to processOptions below
 type queryParams = Pick<
   operations["ElevationAtPointGet"]["parameters"]["query"],
   "lon" | "lat" | "relativeTo"
@@ -64,13 +64,10 @@ export interface IFindElevationAtPointOptions
 export function findElevationAtPoint(
   requestOptions: IFindElevationAtPointOptions
 ): Promise<IFindElevationAtPointResponse> {
-  const options = appendCustomParams<IFindElevationAtPointOptions>(
-    requestOptions,
-    ["lon", "lat", "relativeTo"],
-    {
-      ...requestOptions
-    }
-  );
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: ["lon", "lat", "relativeTo"],
+    extractKeys: []
+  });
 
   return (
     request(`${baseUrl}/elevation/at-point`, {

--- a/packages/arcgis-rest-elevation/test/findElevationAtManyPoints.test.ts
+++ b/packages/arcgis-rest-elevation/test/findElevationAtManyPoints.test.ts
@@ -21,7 +21,6 @@ describe("findElevationAtManyPoints()", () => {
     });
 
     const [url, options] = fetchMock.lastCall("*");
-    console.log("options.body", options.body);
     expect(url).toContain("/elevation/at-many-points");
     expect(options.method).toBe("POST");
     expect(options.body).toContain("f=json");
@@ -51,5 +50,33 @@ describe("findElevationAtManyPoints()", () => {
     expect(options.body).toContain(
       "coordinates=%5B%5B1.2%2C3.4%5D%2C%5B1.23%2C3.45%5D%5D"
     );
+  });
+
+  test("will stringify-encode empty coordinates", async () => {
+    fetchMock.mock("*", atManyPointsDefaultResult);
+    const response = await findElevationAtManyPoints({
+      coordinates: [],
+      authentication: ApiKeyManager.fromKey("MOCK_KEY")
+    });
+
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toContain("/elevation/at-many-points");
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain("coordinates=%5B%5D");
+  });
+
+  test("will not query coordinates when they are undefined", async () => {
+    fetchMock.mock("*", atManyPointsDefaultResult);
+    const response = await findElevationAtManyPoints({
+      coordinates: undefined,
+      authentication: ApiKeyManager.fromKey("MOCK_KEY")
+    });
+
+    const [url, options] = fetchMock.lastCall("*");
+    expect(url).toContain("/elevation/at-many-points");
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).not.toContain("coordinates");
   });
 });

--- a/packages/arcgis-rest-elevation/test/findElevationAtManyPoints.test.ts
+++ b/packages/arcgis-rest-elevation/test/findElevationAtManyPoints.test.ts
@@ -42,4 +42,26 @@ describe("findElevationAtManyPoints()", () => {
 
     expect(response.result).toEqual(atManyPointsEllipsoidResult.result);
   });
+
+  test("Outbound Smoke Test to verify current code but this method needs to be reviewed", async () => {
+    fetchMock.mock("*", atManyPointsDefaultResult);
+
+    const coordinates: Array<[number, number]> = [
+      [1.2, 3.4],
+      [1.23, 3.45]
+    ];
+
+    await findElevationAtManyPoints({
+      coordinates,
+      // This forces the branch where processOptions keeps params.coordinates.
+      params: { coordinates: "placeholder" },
+      authentication: ApiKeyManager.fromKey("MOCK_KEY")
+    } as any);
+
+    const [url, options] = fetchMock.lastCall("*");
+    const body = String(options?.body || "");
+    const params = new URLSearchParams(body);
+
+    expect(params.get("coordinates")).toEqual(JSON.stringify(coordinates));
+  });
 });

--- a/packages/arcgis-rest-elevation/test/findElevationAtManyPoints.test.ts
+++ b/packages/arcgis-rest-elevation/test/findElevationAtManyPoints.test.ts
@@ -12,7 +12,6 @@ describe("findElevationAtManyPoints()", () => {
 
   test("should return elevation at points with mean sea level as the reference", async () => {
     fetchMock.mock("*", atManyPointsDefaultResult);
-
     const response = await findElevationAtManyPoints({
       coordinates: [
         [1.2, 3.4],
@@ -22,46 +21,35 @@ describe("findElevationAtManyPoints()", () => {
     });
 
     const [url, options] = fetchMock.lastCall("*");
-
-    expect(response.result).toEqual(atManyPointsDefaultResult.result);
+    console.log("options.body", options.body);
+    expect(url).toContain("/elevation/at-many-points");
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(
+      "coordinates=%5B%5B1.2%2C3.4%5D%2C%5B1.23%2C3.45%5D%5D"
+    );
   });
 
   test("should return elevation at points with ellipsoid as the reference", async () => {
     fetchMock.mock("*", atManyPointsEllipsoidResult);
 
+    const coordinates = [
+      [1.2, 3.4],
+      [1.23, 3.45]
+    ];
+
     const response = await findElevationAtManyPoints({
-      coordinates: [
-        [1.2, 3.4],
-        [1.23, 3.45]
-      ],
+      coordinates,
       relativeTo: "ellipsoid",
       authentication: ApiKeyManager.fromKey("MOCK_KEY")
     });
 
     const [url, options] = fetchMock.lastCall("*");
-
-    expect(response.result).toEqual(atManyPointsEllipsoidResult.result);
-  });
-
-  test("Outbound Smoke Test to verify current code but this method needs to be reviewed", async () => {
-    fetchMock.mock("*", atManyPointsDefaultResult);
-
-    const coordinates: Array<[number, number]> = [
-      [1.2, 3.4],
-      [1.23, 3.45]
-    ];
-
-    await findElevationAtManyPoints({
-      coordinates,
-      // This forces the branch where processOptions keeps params.coordinates.
-      params: { coordinates: "placeholder" },
-      authentication: ApiKeyManager.fromKey("MOCK_KEY")
-    } as any);
-
-    const [url, options] = fetchMock.lastCall("*");
-    const body = String(options?.body || "");
-    const params = new URLSearchParams(body);
-
-    expect(params.get("coordinates")).toEqual(JSON.stringify(coordinates));
+    expect(url).toContain("/elevation/at-many-points");
+    expect(options.method).toBe("POST");
+    expect(options.body).toContain("f=json");
+    expect(options.body).toContain(
+      "coordinates=%5B%5B1.2%2C3.4%5D%2C%5B1.23%2C3.45%5D%5D"
+    );
   });
 });

--- a/packages/arcgis-rest-feature-service/src/add.ts
+++ b/packages/arcgis-rest-feature-service/src/add.ts
@@ -4,7 +4,7 @@
 import {
   request,
   cleanUrl,
-  appendCustomParams,
+  processOptions,
   IFeature
 } from "@esri/arcgis-rest-request";
 
@@ -46,11 +46,15 @@ export function addFeatures(
   const url = `${cleanUrl(requestOptions.url)}/addFeatures`;
 
   // edit operations are POST only
-  const options = appendCustomParams<IAddFeaturesOptions>(
-    requestOptions,
-    ["features", "gdbVersion", "returnEditMoment", "rollbackOnFailure"],
-    { params: { ...requestOptions.params } }
-  );
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
+      "features",
+      "gdbVersion",
+      "returnEditMoment",
+      "rollbackOnFailure"
+    ],
+    extractKeys: []
+  });
 
   return request(url, options);
 }

--- a/packages/arcgis-rest-feature-service/src/applyEdits.ts
+++ b/packages/arcgis-rest-feature-service/src/applyEdits.ts
@@ -4,7 +4,7 @@
 import {
   request,
   cleanUrl,
-  appendCustomParams,
+  processOptions,
   IFeature
 } from "@esri/arcgis-rest-request";
 
@@ -80,9 +80,8 @@ export function applyEdits(
   const url = `${cleanUrl(requestOptions.url)}/applyEdits`;
 
   // edit operations are POST only
-  const options = appendCustomParams<IApplyEditsOptions>(
-    requestOptions,
-    [
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
       "adds",
       "updates",
       "deletes",
@@ -93,8 +92,8 @@ export function applyEdits(
       "rollbackOnFailure",
       "trueCurveClient"
     ],
-    { params: { ...requestOptions.params } }
-  );
+    extractKeys: []
+  });
 
   return request(url, options);
 }

--- a/packages/arcgis-rest-feature-service/src/delete.ts
+++ b/packages/arcgis-rest-feature-service/src/delete.ts
@@ -1,11 +1,7 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import {
-  request,
-  cleanUrl,
-  appendCustomParams
-} from "@esri/arcgis-rest-request";
+import { request, cleanUrl, processOptions } from "@esri/arcgis-rest-request";
 
 import {
   ISharedEditOptions,
@@ -47,17 +43,16 @@ export function deleteFeatures(
   const url = `${cleanUrl(requestOptions.url)}/deleteFeatures`;
 
   // edit operations POST only
-  const options = appendCustomParams<IDeleteFeaturesOptions>(
-    requestOptions,
-    [
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
       "where",
       "objectIds",
       "gdbVersion",
       "returnEditMoment",
       "rollbackOnFailure"
     ],
-    { params: { ...requestOptions.params } }
-  );
+    extractKeys: []
+  });
 
   return request(url, options);
 }

--- a/packages/arcgis-rest-feature-service/src/query.ts
+++ b/packages/arcgis-rest-feature-service/src/query.ts
@@ -4,7 +4,7 @@
 import {
   request,
   cleanUrl,
-  appendCustomParams,
+  processOptions,
   ISpatialReference,
   IFeatureSet,
   IFeature,
@@ -167,9 +167,8 @@ export interface IQueryFeaturesRawOptions
 function prepareQueryFeaturesOptions(
   requestOptions: IQueryFeaturesRawOptions | IQueryFeaturesOptions
 ): IRequestOptions {
-  const queryOptions = appendCustomParams<IQueryFeaturesRawOptions>(
-    requestOptions,
-    [
+  const { requestOptions: queryOptions } = processOptions(requestOptions, {
+    paramKeys: [
       "where",
       "objectIds",
       "relationParam",
@@ -207,20 +206,18 @@ function prepareQueryFeaturesOptions(
       "returnExceededLimitFeatures",
       "f"
     ],
-    {
+    extractKeys: [],
+    defaultOptions: {
+      fetchOptions: {
+        method: "GET"
+      },
       params: {
         // set default query parameters
         where: "1=1",
-        outFields: "*",
-        ...requestOptions.params
+        outFields: "*"
       }
     }
-  );
-
-  queryOptions.fetchOptions = {
-    method: "GET",
-    ...queryOptions.fetchOptions
-  };
+  });
 
   return queryOptions;
 }
@@ -230,7 +227,7 @@ function prepareQueryFeaturesOptions(
  * Handles both f=pbf-as-geojson and f=pbf-as-arcgis format query params and handles errors.
  *
  * @param url - A feature service url
- * @param queryOptions - Options for the request that has been passed through appendCustomParams
+ * @param queryOptions - Options for the request that has been passed through processOptions
  * @returns A Promise that will resolve with the query response.
  */
 
@@ -462,9 +459,8 @@ export async function queryAllFeatures(
       }
     };
 
-    const queryOptions = appendCustomParams<IQueryAllFeaturesOptions>(
-      pagedOptions,
-      [
+    const { requestOptions: queryOptions } = processOptions(pagedOptions, {
+      paramKeys: [
         "where",
         "objectIds",
         "relationParam",
@@ -497,20 +493,18 @@ export async function queryAllFeatures(
         "sqlFormat",
         "f"
       ],
-      {
+      extractKeys: [],
+      defaultOptions: {
+        fetchOptions: {
+          method: "GET"
+        },
         params: {
+          // set default query parameters
           where: "1=1",
-          outFields: "*",
-          returnExceededLimitFeatures: true,
-          ...pagedOptions.params
+          outFields: "*"
         }
       }
-    );
-
-    queryOptions.fetchOptions = {
-      method: "GET",
-      ...queryOptions.fetchOptions
-    };
+    });
 
     let response: IQueryAllFeaturesResponse;
     if (

--- a/packages/arcgis-rest-feature-service/src/queryRelated.ts
+++ b/packages/arcgis-rest-feature-service/src/queryRelated.ts
@@ -4,7 +4,7 @@
 import {
   request,
   cleanUrl,
-  appendCustomParams,
+  processOptions,
   ISpatialReference,
   IFeature,
   IHasZM,
@@ -64,24 +64,26 @@ export interface IQueryRelatedResponse extends IHasZM {
 export function queryRelated(
   requestOptions: IQueryRelatedOptions
 ): Promise<IQueryRelatedResponse> {
-  const options = appendCustomParams<IQueryRelatedOptions>(
-    requestOptions,
-    ["objectIds", "relationshipId", "definitionExpression", "outFields"],
-    {
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
+      "objectIds",
+      "relationshipId",
+      "definitionExpression",
+      "outFields"
+    ],
+    extractKeys: [],
+    defaultOptions: {
+      fetchOptions: {
+        method: "GET"
+      },
       params: {
         // set default query parameters
         definitionExpression: "1=1",
         outFields: "*",
-        relationshipId: 0,
-        ...requestOptions.params
+        relationshipId: 0
       }
     }
-  );
-
-  options.fetchOptions = {
-    method: "GET",
-    ...options.fetchOptions
-  };
+  });
 
   return request(
     `${cleanUrl(requestOptions.url)}/queryRelatedRecords`,

--- a/packages/arcgis-rest-feature-service/src/update.ts
+++ b/packages/arcgis-rest-feature-service/src/update.ts
@@ -4,7 +4,7 @@
 import {
   request,
   cleanUrl,
-  appendCustomParams,
+  processOptions,
   IFeature
 } from "@esri/arcgis-rest-request";
 
@@ -49,17 +49,16 @@ export function updateFeatures(
   const url = `${cleanUrl(requestOptions.url)}/updateFeatures`;
 
   // edit operations are POST only
-  const options = appendCustomParams<IUpdateFeaturesOptions>(
-    requestOptions,
-    [
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
       "features",
       "gdbVersion",
       "returnEditMoment",
       "rollbackOnFailure",
       "trueCurveClient"
     ],
-    { params: { ...requestOptions.params } }
-  );
+    extractKeys: []
+  });
 
   return request(url, options);
 }

--- a/packages/arcgis-rest-geocoding/src/geocode.ts
+++ b/packages/arcgis-rest-geocoding/src/geocode.ts
@@ -4,7 +4,7 @@
 import {
   request,
   cleanUrl,
-  appendCustomParams,
+  processOptions,
   IExtent,
   ISpatialReference,
   IPoint,
@@ -107,9 +107,8 @@ export async function geocode(
     endpoint = ARCGIS_ONLINE_GEOCODING_URL;
   } else {
     endpoint = address.endpoint || ARCGIS_ONLINE_GEOCODING_URL;
-    options = appendCustomParams<IGeocodeOptions>(
-      address,
-      [
+    const { requestOptions: processedOptions } = processOptions(address, {
+      paramKeys: [
         "singleLine",
         "address",
         "address2",
@@ -124,10 +123,11 @@ export async function geocode(
         "outFields",
         "magicKey"
       ],
-      { params: { ...address.params } }
-    );
+      extractKeys: []
+    });
+    options = processedOptions;
 
-    if (options.params.postal && typeof options.params.postal === "number") {
+    if (options.params?.postal && typeof options.params.postal !== "string") {
       warn(
         "The postal code should be a string. " +
           "Issues can arise when using it as a number, especially if they start with zero."

--- a/packages/arcgis-rest-places/src/findPlacesNearPoint.ts
+++ b/packages/arcgis-rest-places/src/findPlacesNearPoint.ts
@@ -1,6 +1,6 @@
 import {
   request,
-  appendCustomParams,
+  processOptions,
   IRequestOptions
 } from "@esri/arcgis-rest-request";
 
@@ -9,7 +9,7 @@ import { baseUrl, hasNextPage, getNextPageParams } from "./utils.js";
 import { IconOptions } from "./iconOptions.js";
 
 // determine the list of allowed params we want to allow as options
-// this should match the array given to appendCustomParams below
+// this should match the array given to processOptions below
 type queryParams = Pick<
   operations["nearPointGet"]["parameters"]["query"],
   "x" | "y" | "radius" | "categoryIds" | "pageSize" | "offset" | "searchText"
@@ -86,9 +86,8 @@ export interface IFindPlacesNearPointOptions
 export function findPlacesNearPoint(
   requestOptions: IFindPlacesNearPointOptions
 ): Promise<IFindPlacesNearPointResponse> {
-  const options = appendCustomParams<IFindPlacesNearPointOptions>(
-    requestOptions,
-    [
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
       "x",
       "y",
       "radius",
@@ -98,10 +97,8 @@ export function findPlacesNearPoint(
       "searchText",
       "icon"
     ],
-    {
-      ...requestOptions
-    }
-  );
+    extractKeys: []
+  });
 
   return (
     request(requestOptions.endpoint || `${baseUrl}/places/near-point`, {

--- a/packages/arcgis-rest-places/src/findPlacesWithinExtent.ts
+++ b/packages/arcgis-rest-places/src/findPlacesWithinExtent.ts
@@ -1,6 +1,6 @@
 import {
   request,
-  appendCustomParams,
+  processOptions,
   IRequestOptions
 } from "@esri/arcgis-rest-request";
 
@@ -9,7 +9,7 @@ import { baseUrl, hasNextPage, getNextPageParams } from "./utils.js";
 import { IconOptions } from "./iconOptions.js";
 
 // determine the list of allowed params we want to allow as options
-// this should match the array given to appendCustomParams below
+// this should match the array given to processOptions below
 type queryParams = Pick<
   operations["withinExtentGet"]["parameters"]["query"],
   | "xmin"
@@ -94,9 +94,8 @@ export interface IFindPlaceWithinExtentOptions
 export function findPlacesWithinExtent(
   requestOptions: IFindPlaceWithinExtentOptions
 ): Promise<IFindPlacesWithinExtentResponse> {
-  const options = appendCustomParams<IFindPlaceWithinExtentOptions>(
-    requestOptions,
-    [
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
       "xmin",
       "ymin",
       "xmax",
@@ -107,10 +106,8 @@ export function findPlacesWithinExtent(
       "searchText",
       "icon"
     ],
-    {
-      ...requestOptions
-    }
-  );
+    extractKeys: []
+  });
 
   return (
     request(requestOptions.endpoint || `${baseUrl}/places/within-extent`, {

--- a/packages/arcgis-rest-places/src/getCategories.ts
+++ b/packages/arcgis-rest-places/src/getCategories.ts
@@ -1,6 +1,6 @@
 import {
   request,
-  appendCustomParams,
+  processOptions,
   IRequestOptions
 } from "@esri/arcgis-rest-request";
 
@@ -9,7 +9,7 @@ import { baseUrl } from "./utils.js";
 import { IconOptions } from "./iconOptions.js";
 
 // determine the list of allowed params we want to allow as options
-// this should match the array given to appendCustomParams below
+// this should match the array given to processOptions below
 type queryParams = Pick<
   operations["categoriesGet"]["parameters"]["query"],
   "filter"
@@ -70,13 +70,10 @@ export interface IGetCategoriesOptions
 export function getCategories(
   requestOptions: IGetCategoriesOptions
 ): Promise<IGetCategoriesResponse> {
-  const options = appendCustomParams<IGetCategoriesOptions>(
-    requestOptions,
-    ["filter", "icon"],
-    {
-      ...requestOptions
-    }
-  );
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: ["filter", "icon"],
+    extractKeys: []
+  });
 
   return request(requestOptions.endpoint || `${baseUrl}/categories`, {
     ...options,

--- a/packages/arcgis-rest-places/src/getCategory.ts
+++ b/packages/arcgis-rest-places/src/getCategory.ts
@@ -1,6 +1,6 @@
 import {
   request,
-  appendCustomParams,
+  processOptions,
   IRequestOptions
 } from "@esri/arcgis-rest-request";
 
@@ -9,7 +9,7 @@ import { baseUrl } from "./utils.js";
 import { IconOptions } from "./iconOptions.js";
 
 // determine the list of allowed params we want to allow as options
-// this should match the array given to appendCustomParams below
+// this should match the array given to processOptions below
 type queryParams = operations["categoriesCategoryIdGet"]["parameters"]["query"];
 
 // get the correct type of the response format
@@ -63,13 +63,10 @@ export function getCategory(
 ): Promise<IGetCategoryResponse> {
   const { categoryId } = requestOptions;
 
-  const options = appendCustomParams<IGetCategoryOptions>(
-    requestOptions,
-    ["icon"],
-    {
-      ...requestOptions
-    }
-  );
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: ["icon"],
+    extractKeys: []
+  });
 
   return request(
     requestOptions.endpoint || `${baseUrl}/categories/${categoryId}`,

--- a/packages/arcgis-rest-places/src/getPlaceDetails.ts
+++ b/packages/arcgis-rest-places/src/getPlaceDetails.ts
@@ -1,6 +1,6 @@
 import {
   request,
-  appendCustomParams,
+  processOptions,
   IRequestOptions
 } from "@esri/arcgis-rest-request";
 
@@ -9,7 +9,7 @@ import { baseUrl } from "./utils.js";
 import { IconOptions } from "./iconOptions.js";
 
 // determine the list of allowed params we want to allow as options
-// this should match the array given to appendCustomParams below
+// this should match the array given to processOptions below
 type queryParams = Pick<
   operations["placeIdGet"]["parameters"]["query"],
   "requestedFields"
@@ -79,13 +79,10 @@ export function getPlaceDetails(
 ): Promise<IGetPlaceResponse> {
   const { placeId } = requestOptions;
 
-  const options = appendCustomParams<IGetPlaceOptions>(
-    requestOptions,
-    ["requestedFields", "icon"],
-    {
-      ...requestOptions
-    }
-  );
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: ["requestedFields", "icon"],
+    extractKeys: []
+  });
 
   return request(requestOptions.endpoint || `${baseUrl}/places/${placeId}`, {
     ...options,

--- a/packages/arcgis-rest-places/test/findPlacesNearPoint.test.ts
+++ b/packages/arcgis-rest-places/test/findPlacesNearPoint.test.ts
@@ -60,8 +60,7 @@ describe("findPlacesNearPoint()", () => {
     fetchMock.mock("*", placeNearPointMockNoMoreResults);
 
     if (!firstPageResponse.nextPage) {
-      fail("Expected next page function");
-      return;
+      throw new Error("Expected next page function");
     }
 
     const nextPage = await firstPageResponse.nextPage();
@@ -109,5 +108,94 @@ describe("findPlacesNearPoint()", () => {
 
     const [url, options] = fetchMock.lastCall("*") as MockCall;
     expect(url).toContain("&icon=cim");
+  });
+
+  test("verify abort signal is passed through to request", async () => {
+    fetchMock.mock("*", placeNearPointMockNoMoreResults);
+
+    // legacy case: abort signal is a top-level option
+    const legacyAbortController = new AbortController();
+    await findPlacesNearPoint({
+      x: -73.735152,
+      y: 40.9384275,
+      radius: 1600 * 5, // 5 miles in meters
+      categoryIds: ["4d4b7105d754a06372d81259"], // Schools
+      authentication: MOCK_AUTH,
+      signal: legacyAbortController.signal
+    });
+
+    const [, legacyOptions] = fetchMock.lastCall("*") as MockCall;
+    expect((legacyOptions as RequestInit).signal).toBe(
+      legacyAbortController.signal
+    );
+
+    // default case uses fetchOptions.signal
+    const abortController = new AbortController();
+    await findPlacesNearPoint({
+      x: -73.735152,
+      y: 40.9384275,
+      radius: 1600 * 5, // 5 miles in meters
+      categoryIds: ["4d4b7105d754a06372d81259"], // Schools
+      authentication: MOCK_AUTH,
+      fetchOptions: {
+        signal: abortController.signal
+      }
+    });
+
+    const [, options] = fetchMock.lastCall("*") as MockCall;
+    expect((options as RequestInit).signal).toBe(abortController.signal);
+  });
+
+  test("verify abort signal should reject with AbortError when request is aborted", async () => {
+    fetchMock.mock("*", (_url, options) => {
+      return new Promise((_resolve, reject) => {
+        const signal = (options as RequestInit)?.signal as
+          | AbortSignal
+          | undefined;
+        if (!signal) {
+          reject(new Error("Missing AbortSignal in request options"));
+          return;
+        }
+        signal.addEventListener(
+          "abort",
+          () => {
+            reject(signal.reason);
+          },
+          { once: true }
+        );
+      });
+    });
+
+    const legacyAbortController = new AbortController();
+    const legacyPromise = findPlacesNearPoint({
+      x: -73.735152,
+      y: 40.9384275,
+      radius: 1600 * 5,
+      categoryIds: ["4d4b7105d754a06372d81259"],
+      authentication: MOCK_AUTH,
+      signal: legacyAbortController.signal
+    });
+
+    legacyAbortController.abort("help, I was aborted");
+    await expect(legacyPromise).rejects.toMatchObject({
+      name: "AbortError"
+    });
+
+    const fetchOptionsAbortController = new AbortController();
+    const fetchOptionsPromise = findPlacesNearPoint({
+      x: -73.735152,
+      y: 40.9384275,
+      radius: 1600 * 5,
+      categoryIds: ["4d4b7105d754a06372d81259"],
+      authentication: MOCK_AUTH,
+      fetchOptions: {
+        signal: fetchOptionsAbortController.signal
+      }
+    });
+
+    fetchOptionsAbortController.abort("I should have been aborted");
+    await expect(fetchOptionsPromise).rejects.toMatchObject({
+      name: "AbortError"
+    });
   });
 });

--- a/packages/arcgis-rest-places/test/findPlacesNearPoint.test.ts
+++ b/packages/arcgis-rest-places/test/findPlacesNearPoint.test.ts
@@ -166,6 +166,8 @@ describe("findPlacesNearPoint()", () => {
       });
     });
 
+    // test legacy top level option
+
     const legacyAbortController = new AbortController();
     const legacyPromise = findPlacesNearPoint({
       x: -73.735152,
@@ -180,6 +182,8 @@ describe("findPlacesNearPoint()", () => {
     await expect(legacyPromise).rejects.toMatchObject({
       name: "AbortError"
     });
+
+    // test signal in fetchOptions
 
     const fetchOptionsAbortController = new AbortController();
     const fetchOptionsPromise = findPlacesNearPoint({

--- a/packages/arcgis-rest-places/test/findPlacesNearPoint.test.ts
+++ b/packages/arcgis-rest-places/test/findPlacesNearPoint.test.ts
@@ -1,6 +1,6 @@
 import { ApiKeyManager } from "@esri/arcgis-rest-request";
 import { findPlacesNearPoint, IconOptions } from "../src/index.js";
-import { describe, test, expect, afterEach } from "vitest";
+import { describe, test, expect, afterEach, vi } from "vitest";
 import fetchMock, { MockCall } from "fetch-mock";
 import {
   placeNearPointMockNoMoreResults,
@@ -197,5 +197,29 @@ describe("findPlacesNearPoint()", () => {
     await expect(fetchOptionsPromise).rejects.toMatchObject({
       name: "AbortError"
     });
+  });
+
+  test("should console log a warning about deprecated options when using legacy top-level request options", async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+
+    fetchMock.mock("*", placeNearPointMockNoMoreResults);
+
+    await findPlacesNearPoint({
+      x: -3.1883,
+      y: 55.9533,
+      radius: 10,
+      authentication: MOCK_AUTH,
+      credentials: "include"
+    });
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "credentials is deprecated as a top-level request option"
+      )
+    );
+
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/packages/arcgis-rest-portal/src/groups/get.ts
+++ b/packages/arcgis-rest-portal/src/groups/get.ts
@@ -4,7 +4,7 @@
 import {
   request,
   IRequestOptions,
-  appendCustomParams,
+  processOptions,
   IGroup,
   IUser
 } from "@esri/arcgis-rest-request";
@@ -190,13 +190,25 @@ export function searchGroupUsers(
   searchOptions?: ISearchGroupUsersOptions
 ): Promise<ISearchGroupUsersResult> {
   const url = `${getPortalUrl(searchOptions)}/community/groups/${id}/userlist`;
-  const options = appendCustomParams<ISearchGroupUsersOptions>(
+  const { requestOptions: options } = processOptions<ISearchGroupUsersOptions>(
     searchOptions || {},
-    ["name", "num", "start", "sortField", "sortOrder", "joined", "memberType"]
+    {
+      paramKeys: [
+        "name",
+        "num",
+        "start",
+        "sortField",
+        "sortOrder",
+        "joined",
+        "memberType"
+      ],
+      extractKeys: [],
+      defaultOptions: {
+        fetchOptions: {
+          method: "GET"
+        }
+      }
+    }
   );
-  options.fetchOptions = {
-    method: "GET",
-    ...options.fetchOptions
-  };
   return request(url, options);
 }

--- a/packages/arcgis-rest-portal/src/items/add.ts
+++ b/packages/arcgis-rest-portal/src/items/add.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, appendCustomParams } from "@esri/arcgis-rest-request";
+import { request, processOptions } from "@esri/arcgis-rest-request";
 import { getPortalUrl } from "../util/get-portal-url.js";
 import {
   IUserItemOptions,
@@ -86,11 +86,11 @@ export function addItemRelationship(
       requestOptions
     )}/content/users/${owner}/addRelationship`;
 
-    const options = appendCustomParams<IManageItemRelationshipOptions>(
-      requestOptions,
-      ["originItemId", "destinationItemId", "relationshipType"],
-      { params: { ...requestOptions.params } }
-    );
+    const { requestOptions: options } =
+      processOptions<IManageItemRelationshipOptions>(requestOptions, {
+        paramKeys: ["originItemId", "destinationItemId", "relationshipType"],
+        extractKeys: []
+      });
     return request(url, options);
   });
 }

--- a/packages/arcgis-rest-portal/src/items/create.ts
+++ b/packages/arcgis-rest-portal/src/items/create.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, appendCustomParams } from "@esri/arcgis-rest-request";
+import { request, processOptions } from "@esri/arcgis-rest-request";
 import { IItemAdd } from "../helpers.js";
 
 import { getPortalUrl } from "../util/get-portal-url.js";
@@ -110,21 +110,21 @@ export function createItemInFolder(
     }
 
     // serialize the item into something Portal will accept
-    const options = appendCustomParams<ICreateItemOptions>(
+    const { requestOptions: options } = processOptions<ICreateItemOptions>(
       requestOptions,
-      [
-        "owner",
-        "folderId",
-        "file",
-        "dataUrl",
-        "text",
-        "async",
-        "multipart",
-        "filename",
-        "overwrite"
-      ],
       {
-        params: { ...requestOptions.params }
+        paramKeys: [
+          "owner",
+          "folderId",
+          "file",
+          "dataUrl",
+          "text",
+          "async",
+          "multipart",
+          "filename",
+          "overwrite"
+        ],
+        extractKeys: []
       }
     );
     return request(url, options);

--- a/packages/arcgis-rest-portal/src/items/get.ts
+++ b/packages/arcgis-rest-portal/src/items/get.ts
@@ -4,7 +4,7 @@
 import {
   request,
   IRequestOptions,
-  appendCustomParams,
+  processOptions,
   IGroup,
   rawRequest
 } from "@esri/arcgis-rest-request";
@@ -379,10 +379,12 @@ export function getItemStatus(
       requestOptions.id
     }/status`;
 
-    const options = appendCustomParams<IItemStatusOptions>(
+    const { requestOptions: options } = processOptions<IItemStatusOptions>(
       requestOptions,
-      ["jobId", "jobType"],
-      { params: { ...requestOptions.params } }
+      {
+        paramKeys: ["jobId", "jobType"],
+        extractKeys: []
+      }
     );
 
     return request(url, options);

--- a/packages/arcgis-rest-portal/src/items/remove.ts
+++ b/packages/arcgis-rest-portal/src/items/remove.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, appendCustomParams } from "@esri/arcgis-rest-request";
+import { request, processOptions } from "@esri/arcgis-rest-request";
 
 import { getPortalUrl } from "../util/get-portal-url.js";
 import {
@@ -64,11 +64,10 @@ export function removeItemRelationship(
       requestOptions
     )}/content/users/${owner}/deleteRelationship`;
 
-    const options = appendCustomParams<IManageItemRelationshipOptions>(
-      requestOptions,
-      ["originItemId", "destinationItemId", "relationshipType"],
-      { params: { ...requestOptions.params } }
-    );
+    const { requestOptions: options } = processOptions(requestOptions, {
+      paramKeys: ["originItemId", "destinationItemId", "relationshipType"],
+      extractKeys: []
+    });
 
     return request(url, options);
   });

--- a/packages/arcgis-rest-portal/src/items/upload.ts
+++ b/packages/arcgis-rest-portal/src/items/upload.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2017-2019 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-import { request, appendCustomParams } from "@esri/arcgis-rest-request";
+import { request, processOptions } from "@esri/arcgis-rest-request";
 import { IItemAdd } from "../helpers.js";
 
 import { getPortalUrl } from "../util/get-portal-url.js";
@@ -53,11 +53,10 @@ export function addItemPart(
       requestOptions.id
     }/addPart?partNum=${partNum}`;
 
-    const options = appendCustomParams<IItemPartOptions>(
-      requestOptions,
-      ["file"],
-      { params: { ...requestOptions.params } }
-    );
+    const { requestOptions: options } = processOptions(requestOptions, {
+      paramKeys: ["file"],
+      extractKeys: []
+    });
 
     return request(url, options);
   });
@@ -87,12 +86,20 @@ export function commitItemUpload(
       requestOptions.id
     }/commit`;
 
-    const options = appendCustomParams<ICommitItemOptions>(requestOptions, [], {
-      params: {
-        ...requestOptions.params,
-        ...requestOptions.item
+    const { requestOptions: options } = processOptions<ICommitItemOptions>(
+      requestOptions,
+      {
+        paramKeys: [],
+        extractKeys: []
       }
-    });
+    );
+
+    // Preserve prior helper behavior: item fields were only merged when params was not provided.
+    if (!requestOptions.params) {
+      options.params = {
+        ...requestOptions.item
+      };
+    }
 
     return request(url, options);
   });

--- a/packages/arcgis-rest-portal/src/util/generic-search.ts
+++ b/packages/arcgis-rest-portal/src/util/generic-search.ts
@@ -4,7 +4,7 @@
 import {
   request,
   IRequestOptions,
-  appendCustomParams,
+  processOptions,
   IGroup,
   IUser
 } from "@esri/arcgis-rest-request";
@@ -36,9 +36,8 @@ export function genericSearch<T extends IItem | IGroup | IUser>(
     };
   } else {
     // searchUserAccess has one (known) valid value: "groupMember"
-    options = appendCustomParams<ISearchOptions>(
-      search,
-      [
+    const { requestOptions } = processOptions(search, {
+      paramKeys: [
         "q",
         "num",
         "start",
@@ -52,16 +51,13 @@ export function genericSearch<T extends IItem | IGroup | IUser>(
         "categories",
         "categoryFilters"
       ],
-      {
+      extractKeys: [],
+      defaultOptions: {
         fetchOptions: { method: "GET" }
       }
-    );
+    });
+    options = requestOptions;
   }
-
-  options.fetchOptions = {
-    method: "GET",
-    ...options.fetchOptions
-  };
 
   let path;
   switch (searchType) {

--- a/packages/arcgis-rest-portal/test/items/upload.test.ts
+++ b/packages/arcgis-rest-portal/test/items/upload.test.ts
@@ -77,6 +77,35 @@ describe("search", () => {
       expect(options.body).toContain("token=fake-token");
     });
 
+    test("should commit upload using provided params without auto-merging item fields", async () => {
+      fetchMock.once("*", ItemSuccessResponse);
+
+      await commitItemUpload({
+        id: "3ef",
+        item: {
+          title: "test",
+          type: "PDF"
+        },
+        params: {
+          someonePutAParamInHere: true
+        },
+        ...MOCK_USER_REQOPTS
+      });
+
+      expect(fetchMock.called()).toEqual(true);
+      const [url, options] = fetchMock.lastCall("*");
+      expect(url).toEqual(
+        "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/3ef/commit"
+      );
+      expect(options.method).toBe("POST");
+      expect(options.body).toContain("f=json");
+      expect(options.body).toContain("someonePutAParamInHere=true");
+      expect(options.body).toContain("token=fake-token");
+      // should not contain item data, since providing params precludes auto-merging item fields
+      expect(options.body).not.toContain("title=test");
+      expect(options.body).not.toContain("type=PDF");
+    });
+
     test("should cancel the item upload", async () => {
       fetchMock.once("*", ItemSuccessResponse);
 

--- a/packages/arcgis-rest-request/src/index.ts
+++ b/packages/arcgis-rest-request/src/index.ts
@@ -22,6 +22,7 @@ export * from "./utils/IParamBuilder.js";
 export * from "./utils/IParamsBuilder.js";
 export * from "./utils/IRequestOptions.js";
 export * from "./utils/ITokenRequestOptions.js";
+export * from "./utils/process-options.js";
 export * from "./utils/process-params.js";
 export * from "./utils/ResponseFormats.js";
 export * from "./utils/retryAuthError.js";

--- a/packages/arcgis-rest-request/src/utils/append-custom-params.ts
+++ b/packages/arcgis-rest-request/src/utils/append-custom-params.ts
@@ -3,9 +3,14 @@
 
 import { IRequestOptions } from "./IRequestOptions.js";
 import { normalizeDeprecatedRequestOptions } from "./normalize-deprecated-request-options.js";
+import { warn } from "./warn.js";
+
+let hasWarnedAboutAppendCustomParams = false;
 
 /**
  * Appends selected custom option keys into `params` while preserving request options.
+ *
+ * @deprecated Use `processOptions()` instead. This helper will be removed in a future major release.
  *
  * @param customOptions Endpoint-specific options supplied by the caller.
  * @param keys Keys from `customOptions` that should be appended to `params`.
@@ -17,6 +22,17 @@ export function appendCustomParams<T extends IRequestOptions>(
   keys: Array<keyof T>,
   baseOptions?: Partial<T>
 ): IRequestOptions {
+  const suppressWarnings =
+    customOptions?.requestFlags?.suppressWarnings ??
+    customOptions?.suppressWarnings ??
+    false;
+  if (!hasWarnedAboutAppendCustomParams && !suppressWarnings) {
+    warn(
+      "appendCustomParams() is deprecated and will be removed in a future major release. Use processOptions() instead."
+    );
+    hasWarnedAboutAppendCustomParams = true;
+  }
+
   // NOTE: this must be kept in sync with the keys in IRequestOptions
   const requestOptionsKeys = [
     // request options

--- a/packages/arcgis-rest-request/src/utils/process-options.ts
+++ b/packages/arcgis-rest-request/src/utils/process-options.ts
@@ -1,0 +1,105 @@
+/* Copyright (c) 2026 Environmental Systems Research Institute, Inc. */
+
+import { ILegacyRequestOptions, IRequestOptions } from "./IRequestOptions.js";
+
+type PureRequestOptions = Omit<IRequestOptions, keyof ILegacyRequestOptions>;
+
+type PureRequestOptionsKeys = Array<keyof PureRequestOptions>;
+
+const ALLOWED_TOP_LEVEL_KEYS: PureRequestOptionsKeys = [
+  "authentication",
+  "portal",
+  "fetchOptions",
+  "requestFlags",
+  "params"
+];
+
+const REQUEST_OPTION_KEYS = new Set<string>(ALLOWED_TOP_LEVEL_KEYS);
+
+type ProcessOptionsResult<T extends IRequestOptions> = {
+  requestOptions: IRequestOptions;
+} & Partial<Omit<T, keyof IRequestOptions>>;
+
+interface ProcessOptionsConfig<T extends IRequestOptions> {
+  paramKeys: Array<Exclude<keyof T, keyof IRequestOptions>>;
+  extractKeys: Array<keyof T>;
+  overwriteOptions?: Partial<Omit<IRequestOptions, "params">>;
+}
+
+export function processOptions<T extends IRequestOptions>(
+  options: T,
+  optionsConfig: ProcessOptionsConfig<T>
+): ProcessOptionsResult<T> {
+  const { paramKeys, extractKeys, overwriteOptions } = optionsConfig;
+
+  // internally redefine types as Record type for parsing and merging
+  const originalOptions = options as Record<string, any>;
+  const requestOptionsOut: Record<string, any> = {};
+  const overwriteOptionsAs = (overwriteOptions ?? {}) as Record<string, any>;
+  const toParams: Record<string, any> = {};
+  const toExtract: Record<string, any> = {};
+
+  const existsIn = (obj: Record<string, any>, key: string) =>
+    Object.prototype.hasOwnProperty.call(obj, key);
+
+  // 1) move non-request-option param keys into params bucket
+  paramKeys.forEach((key) => {
+    const keyName = key as string;
+    if (
+      existsIn(originalOptions, keyName) &&
+      !REQUEST_OPTION_KEYS.has(keyName)
+    ) {
+      toParams[keyName] = originalOptions[keyName];
+    }
+  });
+
+  // 2) extract requested top-level keys
+  extractKeys.forEach((key) => {
+    const keyName = key as string;
+    if (existsIn(originalOptions, keyName)) {
+      toExtract[keyName] = originalOptions[keyName];
+    }
+  });
+
+  // 3) build requestOptions with presence-based inclusion
+  const OVERWRITEABLE_KEYS: Array<"authentication" | "portal"> = [
+    "authentication",
+    "portal"
+  ];
+  const MERGEABLE_KEYS: Array<"fetchOptions" | "requestFlags"> = [
+    "fetchOptions",
+    "requestFlags"
+    // no params here because params is handled separately
+  ];
+
+  OVERWRITEABLE_KEYS.forEach((key) => {
+    if (existsIn(originalOptions, key)) {
+      requestOptionsOut[key] = originalOptions[key];
+    }
+    if (existsIn(overwriteOptionsAs, key)) {
+      requestOptionsOut[key] = overwriteOptionsAs[key];
+    }
+  });
+
+  MERGEABLE_KEYS.forEach((key) => {
+    if (existsIn(originalOptions, key) || existsIn(overwriteOptionsAs, key)) {
+      requestOptionsOut[key] = {
+        ...(originalOptions[key] ?? {}),
+        ...(overwriteOptionsAs[key] ?? {})
+      };
+    }
+  });
+
+  // if options has a params object or if any top-level options keys were delegated to become params, merge them into requestOptions.params
+  if (existsIn(originalOptions, "params") || Object.keys(toParams).length > 0) {
+    requestOptionsOut.params = {
+      ...(originalOptions.params ?? {}),
+      ...toParams
+    };
+  }
+
+  return {
+    ...(toExtract as Partial<Omit<T, keyof IRequestOptions>>),
+    requestOptions: requestOptionsOut as IRequestOptions
+  };
+}

--- a/packages/arcgis-rest-request/src/utils/process-options.ts
+++ b/packages/arcgis-rest-request/src/utils/process-options.ts
@@ -2,28 +2,28 @@
 
 import { ILegacyRequestOptions, IRequestOptions } from "./IRequestOptions.js";
 
+// using PureRequestOptions to explicitly only support v5 requestOptions until legacy requestOptions are removed from IRequestOptions
 type PureRequestOptions = Omit<IRequestOptions, keyof ILegacyRequestOptions>;
+type RequestOptionsKeys = keyof PureRequestOptions;
 
-type PureRequestOptionsKeys = Array<keyof PureRequestOptions>;
-
-const ALLOWED_TOP_LEVEL_KEYS: PureRequestOptionsKeys = [
-  "authentication",
-  "portal",
-  "fetchOptions",
-  "requestFlags",
-  "params"
-];
-
-const REQUEST_OPTION_KEYS = new Set<string>(ALLOWED_TOP_LEVEL_KEYS);
+// using ExtractableKey to explicitly define that only non IRequestOptions keys can be extracted to help avoid duplicate exports in props
+type ExtractableKey<T extends IRequestOptions> = Exclude<
+  keyof T,
+  keyof IRequestOptions
+>;
+type OverwriteableOptions = Pick<
+  PureRequestOptions,
+  "authentication" | "portal" | "fetchOptions" | "requestFlags"
+>;
 
 type ProcessOptionsResult<T extends IRequestOptions> = {
-  requestOptions: IRequestOptions;
-} & Partial<Omit<T, keyof IRequestOptions>>;
+  requestOptions: Partial<PureRequestOptions>;
+} & Partial<Pick<T, ExtractableKey<T>>>;
 
 interface ProcessOptionsConfig<T extends IRequestOptions> {
-  paramKeys: Array<Exclude<keyof T, keyof IRequestOptions>>;
-  extractKeys: Array<keyof T>;
-  overwriteOptions?: Partial<Omit<IRequestOptions, "params">>;
+  paramKeys: Array<ExtractableKey<T>>;
+  extractKeys: Array<ExtractableKey<T>>;
+  overwriteOptions?: Partial<OverwriteableOptions>;
 }
 
 export function processOptions<T extends IRequestOptions>(
@@ -42,18 +42,27 @@ export function processOptions<T extends IRequestOptions>(
   const existsIn = (obj: Record<string, any>, key: string) =>
     Object.prototype.hasOwnProperty.call(obj, key);
 
-  // 1) move non-request-option param keys into params bucket
+  const REQUEST_OPTION_KEYS = new Set<RequestOptionsKeys>([
+    "authentication",
+    "portal",
+    "fetchOptions",
+    "requestFlags",
+    "params"
+  ]);
+
+  // 1) move non-request-option paramkeys into params bucket
   paramKeys.forEach((key) => {
     const keyName = key as string;
     if (
       existsIn(originalOptions, keyName) &&
-      !REQUEST_OPTION_KEYS.has(keyName)
+      // requestOptions keys should not be able to be added to paramKeys, enforce here
+      !REQUEST_OPTION_KEYS.has(keyName as RequestOptionsKeys)
     ) {
       toParams[keyName] = originalOptions[keyName];
     }
   });
 
-  // 2) extract requested top-level keys
+  // 2) extract requested top-level keys into bucket
   extractKeys.forEach((key) => {
     const keyName = key as string;
     if (existsIn(originalOptions, keyName)) {
@@ -61,27 +70,15 @@ export function processOptions<T extends IRequestOptions>(
     }
   });
 
-  // 3) build requestOptions with presence-based inclusion
-  const OVERWRITEABLE_KEYS: Array<"authentication" | "portal"> = [
-    "authentication",
-    "portal"
-  ];
-  const MERGEABLE_KEYS: Array<"fetchOptions" | "requestFlags"> = [
-    "fetchOptions",
-    "requestFlags"
-    // no params here because params is handled separately
-  ];
-
-  OVERWRITEABLE_KEYS.forEach((key) => {
-    if (existsIn(originalOptions, key)) {
+  // 3) build requestOptions by merging overwriteOptions over originalOptions
+  (["authentication", "portal"] as const).forEach((key) => {
+    if (existsIn(originalOptions, key))
       requestOptionsOut[key] = originalOptions[key];
-    }
-    if (existsIn(overwriteOptionsAs, key)) {
+    if (existsIn(overwriteOptionsAs, key))
       requestOptionsOut[key] = overwriteOptionsAs[key];
-    }
   });
 
-  MERGEABLE_KEYS.forEach((key) => {
+  (["fetchOptions", "requestFlags"] as const).forEach((key) => {
     if (existsIn(originalOptions, key) || existsIn(overwriteOptionsAs, key)) {
       requestOptionsOut[key] = {
         ...(originalOptions[key] ?? {}),
@@ -90,7 +87,11 @@ export function processOptions<T extends IRequestOptions>(
     }
   });
 
-  // if options has a params object or if any top-level options keys were delegated to become params, merge them into requestOptions.params
+  /**
+   * if original options has a params object,
+   * or if any top-level options keys were delegated to become params,
+   * merge them all into requestOptions.params.
+   */
   if (existsIn(originalOptions, "params") || Object.keys(toParams).length > 0) {
     requestOptionsOut.params = {
       ...(originalOptions.params ?? {}),
@@ -99,7 +100,7 @@ export function processOptions<T extends IRequestOptions>(
   }
 
   return {
-    ...(toExtract as Partial<Omit<T, keyof IRequestOptions>>),
-    requestOptions: requestOptionsOut as IRequestOptions
+    ...(toExtract as Partial<Pick<T, ExtractableKey<T>>>),
+    requestOptions: requestOptionsOut as Partial<PureRequestOptions>
   };
 }

--- a/packages/arcgis-rest-request/src/utils/process-options.ts
+++ b/packages/arcgis-rest-request/src/utils/process-options.ts
@@ -24,13 +24,15 @@ interface ProcessOptionsConfig<T extends IRequestOptions> {
   paramKeys: Array<ExtractableKey<T>>;
   extractKeys: Array<ExtractableKey<T>>;
   overwriteOptions?: Partial<OverwriteableOptions>;
+  moveRemainingToParams?: boolean;
 }
 
 export function processOptions<T extends IRequestOptions>(
   options: T,
   optionsConfig: ProcessOptionsConfig<T>
 ): ProcessOptionsResult<T> {
-  const { paramKeys, extractKeys, overwriteOptions } = optionsConfig;
+  const { paramKeys, extractKeys, overwriteOptions, moveRemainingToParams } =
+    optionsConfig;
 
   // internally redefine types as Record type for parsing and merging
   const originalOptions = options as Record<string, any>;
@@ -69,6 +71,22 @@ export function processOptions<T extends IRequestOptions>(
       toExtract[keyName] = originalOptions[keyName];
     }
   });
+
+  // 2b) optionally move all remaining non-request-option, non-extracted keys to params
+  if (moveRemainingToParams) {
+    const extractedKeySet = new Set<string>(extractKeys as string[]);
+    const explicitParamKeySet = new Set<string>(paramKeys as string[]);
+
+    Object.keys(originalOptions).forEach((keyName) => {
+      if (
+        !REQUEST_OPTION_KEYS.has(keyName as RequestOptionsKeys) &&
+        !extractedKeySet.has(keyName) &&
+        !explicitParamKeySet.has(keyName)
+      ) {
+        toParams[keyName] = originalOptions[keyName];
+      }
+    });
+  }
 
   // 3) build requestOptions by merging overwriteOptions over originalOptions
   (["authentication", "portal"] as const).forEach((key) => {

--- a/packages/arcgis-rest-request/src/utils/process-options.ts
+++ b/packages/arcgis-rest-request/src/utils/process-options.ts
@@ -11,7 +11,7 @@ type ExtractableKey<T extends IRequestOptions> = Exclude<
   keyof T,
   keyof IRequestOptions
 >;
-type OverwriteableOptions = Pick<
+type DefaultableOptions = Pick<
   PureRequestOptions,
   "authentication" | "portal" | "fetchOptions" | "requestFlags"
 >;
@@ -23,19 +23,20 @@ type ProcessOptionsResult<T extends IRequestOptions> = {
 interface ProcessOptionsConfig<T extends IRequestOptions> {
   paramKeys: Array<ExtractableKey<T>>;
   extractKeys: Array<ExtractableKey<T>>;
-  overwriteOptions?: Partial<OverwriteableOptions>;
+  // Fallback values used only when the corresponding value is not provided in options.
+  defaultOptions?: Partial<DefaultableOptions>;
 }
 
 export function processOptions<T extends IRequestOptions>(
   options: T,
   optionsConfig: ProcessOptionsConfig<T>
 ): ProcessOptionsResult<T> {
-  const { paramKeys, extractKeys, overwriteOptions } = optionsConfig;
+  const { paramKeys, extractKeys, defaultOptions } = optionsConfig;
 
   // internally redefine types as Record type for parsing and merging
   const originalOptions = options as Record<string, any>;
   const requestOptionsOut: Record<string, any> = {};
-  const overwriteOptionsAs = (overwriteOptions ?? {}) as Record<string, any>;
+  const defaultOptionsAs = (defaultOptions ?? {}) as Record<string, any>;
   const toParams: Record<string, any> = {};
   const toExtract: Record<string, any> = {};
 
@@ -70,19 +71,20 @@ export function processOptions<T extends IRequestOptions>(
     }
   });
 
-  // 3) build requestOptions by merging overwriteOptions over originalOptions
+  // 3) build requestOptions by applying defaults first, then explicit option values.
+  // This ensures explicit caller-supplied values are preferred over defaults.
   (["authentication", "portal"] as const).forEach((key) => {
+    if (existsIn(defaultOptionsAs, key))
+      requestOptionsOut[key] = defaultOptionsAs[key];
     if (existsIn(originalOptions, key))
       requestOptionsOut[key] = originalOptions[key];
-    if (existsIn(overwriteOptionsAs, key))
-      requestOptionsOut[key] = overwriteOptionsAs[key];
   });
 
   (["fetchOptions", "requestFlags"] as const).forEach((key) => {
-    if (existsIn(originalOptions, key) || existsIn(overwriteOptionsAs, key)) {
+    if (existsIn(originalOptions, key) || existsIn(defaultOptionsAs, key)) {
       requestOptionsOut[key] = {
-        ...(originalOptions[key] ?? {}),
-        ...(overwriteOptionsAs[key] ?? {})
+        ...(defaultOptionsAs[key] ?? {}),
+        ...(originalOptions[key] ?? {})
       };
     }
   });

--- a/packages/arcgis-rest-request/src/utils/process-options.ts
+++ b/packages/arcgis-rest-request/src/utils/process-options.ts
@@ -4,7 +4,7 @@ import { ILegacyRequestOptions, IRequestOptions } from "./IRequestOptions.js";
 
 // using PureRequestOptions to explicitly only support v5 requestOptions until legacy requestOptions are removed from IRequestOptions
 type PureRequestOptions = Omit<IRequestOptions, keyof ILegacyRequestOptions>;
-type RequestOptionsKeys = keyof PureRequestOptions;
+type RequestOptionsKeys = keyof IRequestOptions;
 
 // using ExtractableKey to explicitly define that only non IRequestOptions keys can be extracted to help avoid duplicate exports in props
 type ExtractableKey<T extends IRequestOptions> = Exclude<
@@ -13,7 +13,7 @@ type ExtractableKey<T extends IRequestOptions> = Exclude<
 >;
 
 type ProcessOptionsResult<T extends IRequestOptions> = {
-  requestOptions: Partial<PureRequestOptions>;
+  requestOptions: Partial<IRequestOptions>;
 } & Partial<Pick<T, ExtractableKey<T>>>;
 
 interface ProcessOptionsConfig<T extends IRequestOptions> {
@@ -44,10 +44,20 @@ export function processOptions<T extends IRequestOptions>(
     "portal",
     "fetchOptions",
     "requestFlags",
-    "params"
+    "params",
+    // legacy request options are passed through to request() where warnings
+    // and v5 normalization are handled centrally.
+    "httpMethod",
+    "credentials",
+    "headers",
+    "signal",
+    "hideToken",
+    "suppressWarnings",
+    "maxUrlLength",
+    "rawResponse"
   ]);
 
-  // 1) move non-request-option paramkeys into params bucket
+  // a) move non-request-option paramkeys into params bucket
   paramKeys.forEach((key) => {
     const keyName = key as string;
     if (
@@ -59,7 +69,7 @@ export function processOptions<T extends IRequestOptions>(
     }
   });
 
-  // 2) extract requested top-level keys into bucket
+  // b) move all keys to extract into extract bucket
   extractKeys.forEach((key) => {
     const keyName = key as string;
     if (existsIn(originalOptions, keyName)) {
@@ -67,8 +77,8 @@ export function processOptions<T extends IRequestOptions>(
     }
   });
 
-  // 3) build requestOptions by applying defaults first, then explicit option values.
-  // This ensures explicit caller-supplied values are preferred over defaults.
+  // 1) build requestOptions by applying default options first, then override with any existing option values.
+  // start with top-level keys, then fetchOptions and requestFlags objects.
   (["authentication", "portal"] as const).forEach((key) => {
     if (existsIn(defaultOptionsAs, key))
       requestOptionsOut[key] = defaultOptionsAs[key];
@@ -82,6 +92,28 @@ export function processOptions<T extends IRequestOptions>(
         ...(defaultOptionsAs[key] ?? {}),
         ...(originalOptions[key] ?? {})
       };
+    }
+  });
+
+  // 2) pass through any legacy top-level request options from original options.
+  // request() can emit warnings and convert them to v5 shape in one place.
+  // Legacy defaults are intentionally not allowed in defaultOptions.
+  (
+    [
+      "httpMethod",
+      "credentials",
+      "headers",
+      "signal",
+      "hideToken",
+      "suppressWarnings",
+      "maxUrlLength",
+      "rawResponse"
+    ] as const
+  ).forEach((key) => {
+    // this will only pass through legacy request options from the original options.
+    // default options will not allow legacy request options to be introduced
+    if (existsIn(originalOptions, key)) {
+      requestOptionsOut[key] = originalOptions[key];
     }
   });
 
@@ -104,6 +136,6 @@ export function processOptions<T extends IRequestOptions>(
 
   return {
     ...(toExtract as Partial<Pick<T, ExtractableKey<T>>>),
-    requestOptions: requestOptionsOut as Partial<PureRequestOptions>
+    requestOptions: requestOptionsOut as Partial<IRequestOptions>
   };
 }

--- a/packages/arcgis-rest-request/src/utils/process-options.ts
+++ b/packages/arcgis-rest-request/src/utils/process-options.ts
@@ -11,10 +11,6 @@ type ExtractableKey<T extends IRequestOptions> = Exclude<
   keyof T,
   keyof IRequestOptions
 >;
-type DefaultableOptions = Pick<
-  PureRequestOptions,
-  "authentication" | "portal" | "fetchOptions" | "requestFlags"
->;
 
 type ProcessOptionsResult<T extends IRequestOptions> = {
   requestOptions: Partial<PureRequestOptions>;
@@ -24,7 +20,7 @@ interface ProcessOptionsConfig<T extends IRequestOptions> {
   paramKeys: Array<ExtractableKey<T>>;
   extractKeys: Array<ExtractableKey<T>>;
   // Fallback values used only when the corresponding value is not provided in options.
-  defaultOptions?: Partial<DefaultableOptions>;
+  defaultOptions?: Partial<PureRequestOptions>;
 }
 
 export function processOptions<T extends IRequestOptions>(
@@ -94,8 +90,13 @@ export function processOptions<T extends IRequestOptions>(
    * or if any top-level options keys were delegated to become params,
    * merge them all into requestOptions.params.
    */
-  if (existsIn(originalOptions, "params") || Object.keys(toParams).length > 0) {
+  if (
+    existsIn(defaultOptionsAs, "params") ||
+    existsIn(originalOptions, "params") ||
+    Object.keys(toParams).length > 0
+  ) {
     requestOptionsOut.params = {
+      ...(defaultOptionsAs.params ?? {}),
       ...(originalOptions.params ?? {}),
       ...toParams
     };

--- a/packages/arcgis-rest-request/src/utils/process-options.ts
+++ b/packages/arcgis-rest-request/src/utils/process-options.ts
@@ -24,15 +24,13 @@ interface ProcessOptionsConfig<T extends IRequestOptions> {
   paramKeys: Array<ExtractableKey<T>>;
   extractKeys: Array<ExtractableKey<T>>;
   overwriteOptions?: Partial<OverwriteableOptions>;
-  moveRemainingToParams?: boolean;
 }
 
 export function processOptions<T extends IRequestOptions>(
   options: T,
   optionsConfig: ProcessOptionsConfig<T>
 ): ProcessOptionsResult<T> {
-  const { paramKeys, extractKeys, overwriteOptions, moveRemainingToParams } =
-    optionsConfig;
+  const { paramKeys, extractKeys, overwriteOptions } = optionsConfig;
 
   // internally redefine types as Record type for parsing and merging
   const originalOptions = options as Record<string, any>;
@@ -71,22 +69,6 @@ export function processOptions<T extends IRequestOptions>(
       toExtract[keyName] = originalOptions[keyName];
     }
   });
-
-  // 2b) optionally move all remaining non-request-option, non-extracted keys to params
-  if (moveRemainingToParams) {
-    const extractedKeySet = new Set<string>(extractKeys as string[]);
-    const explicitParamKeySet = new Set<string>(paramKeys as string[]);
-
-    Object.keys(originalOptions).forEach((keyName) => {
-      if (
-        !REQUEST_OPTION_KEYS.has(keyName as RequestOptionsKeys) &&
-        !extractedKeySet.has(keyName) &&
-        !explicitParamKeySet.has(keyName)
-      ) {
-        toParams[keyName] = originalOptions[keyName];
-      }
-    });
-  }
 
   // 3) build requestOptions by merging overwriteOptions over originalOptions
   (["authentication", "portal"] as const).forEach((key) => {

--- a/packages/arcgis-rest-request/test/utils/append-custom-params.test.ts
+++ b/packages/arcgis-rest-request/test/utils/append-custom-params.test.ts
@@ -5,9 +5,24 @@
  */
 
 import { appendCustomParams } from "../../src/index.js";
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 
 describe("appendCustomParams", () => {
+  test("warns once that appendCustomParams is deprecated", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // no-op
+    });
+
+    appendCustomParams({ params: {}, f: "json" } as any, ["f"]);
+    appendCustomParams({ params: {}, f: "json" } as any, ["f"]);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("appendCustomParams()");
+    expect(warnSpy.mock.calls[0][0]).toContain("deprecated");
+
+    warnSpy.mockRestore();
+  });
+
   test("merges custom options and base options, handles all value types, omits invalid keys, and normalizes legacy request options", () => {
     // this test should cover:
     // - omit keys not in keys
@@ -71,5 +86,41 @@ describe("appendCustomParams", () => {
         "portal"
       ]).toContain(key);
     });
+  });
+
+  test("does not warn when suppressWarnings is true", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // no-op
+    });
+
+    appendCustomParams(
+      {
+        params: {},
+        f: "json",
+        suppressWarnings: true
+      } as any,
+      ["f"]
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test("does not warn when requestFlags.suppressWarnings is true", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // no-op
+    });
+
+    appendCustomParams(
+      {
+        params: {},
+        f: "json",
+        requestFlags: { suppressWarnings: true }
+      } as any,
+      ["f"]
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/packages/arcgis-rest-request/test/utils/process-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-options.test.ts
@@ -27,6 +27,7 @@ describe("processOptions", () => {
       // param keys
       f: "json",
       token: "abc123",
+      // params.a should appear as "a:"" in params
       params: { a: 1 },
       // extra keys that should be ignored
       extra: "should be ignored",
@@ -267,5 +268,115 @@ describe("processOptions", () => {
       f: "json"
     });
     expect(result.requestOptions.params).not.toHaveProperty("authentication");
+  });
+
+  test("should ignore extractKeys that are not present on options", () => {
+    const result = processOptions(
+      {
+        f: "json",
+        params: {
+          outSR: 3857
+        }
+      },
+      {
+        paramKeys: ["f"],
+        extractKeys: ["id", "routeType"] as any
+      }
+    );
+
+    expect(result).not.toHaveProperty("id");
+    expect(result).not.toHaveProperty("routeType");
+    expect(result.requestOptions.params).toEqual({
+      outSR: 3857,
+      f: "json"
+    });
+  });
+
+  test("should build mergeable request options from overwriteOptions when original options are absent", () => {
+    const result = processOptions(
+      {
+        fetchOptions: {
+          credentials: "include"
+        },
+        requestFlags: {
+          hideToken: true
+        }
+      },
+      {
+        paramKeys: [],
+        extractKeys: [],
+        overwriteOptions: {
+          fetchOptions: {
+            method: "POST"
+          },
+          requestFlags: {
+            suppressWarnings: true
+          }
+        }
+      }
+    );
+
+    expect(result.requestOptions).toEqual({
+      fetchOptions: {
+        credentials: "include",
+        method: "POST"
+      },
+      requestFlags: {
+        hideToken: true,
+        suppressWarnings: true
+      }
+    });
+  });
+
+  test("should build mergeable request options from overwriteOptions when original mergeable keys are missing", () => {
+    const result = processOptions(
+      {
+        authentication: "auth-from-options",
+        portal: "https://example.com/sharing/rest"
+      },
+      {
+        paramKeys: [],
+        extractKeys: [],
+        overwriteOptions: {
+          fetchOptions: {
+            method: "POST",
+            credentials: "omit"
+          },
+          requestFlags: {
+            suppressWarnings: true
+          }
+        }
+      }
+    );
+
+    expect(result.requestOptions).toEqual({
+      authentication: "auth-from-options",
+      portal: "https://example.com/sharing/rest",
+      fetchOptions: {
+        method: "POST",
+        credentials: "omit"
+      },
+      requestFlags: {
+        suppressWarnings: true
+      }
+    });
+  });
+
+  test("should create params when original options has no params object", () => {
+    const result = processOptions(
+      {
+        f: "json",
+        token: "abc123"
+      },
+      {
+        paramKeys: ["f", "token"],
+        extractKeys: []
+      }
+    );
+
+    expect(result.requestOptions.params).toEqual({
+      f: "json",
+      token: "abc123"
+    });
   });
 });

--- a/packages/arcgis-rest-request/test/utils/process-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-options.test.ts
@@ -567,12 +567,61 @@ describe("processOptions", () => {
     });
   });
 
+  test("should hande case where optional keys are missing from options but included in paramKeys", () => {
+    type TestOptionalsWithNoneDefined = IRequestOptions & {
+      f?: "json";
+      token?: "abc123";
+    };
+    const options: TestOptionalsWithNoneDefined = {
+      authentication: "auth-from-options"
+      // f and token are missing from options, but included in paramKeys
+    };
+
+    const result = processOptions(options, {
+      paramKeys: ["f", "token"],
+      extractKeys: []
+    });
+
+    expect(result.requestOptions.params).toBeUndefined();
+    // assert shape
+    expect(result.requestOptions.authentication).toBe("auth-from-options");
+    expect(result.requestOptions).toEqual({
+      authentication: "auth-from-options"
+    });
+
+    type TestOptionalsWithOneDefined = IRequestOptions & {
+      f?: "json";
+      token?: "abc123";
+    };
+
+    const optionsWithOneDefined: TestOptionalsWithOneDefined = {
+      authentication: "auth-from-options",
+      f: "json"
+      // token is missing from options, but included in paramKeys
+    };
+
+    const resultWithOneDefined = processOptions(optionsWithOneDefined, {
+      paramKeys: ["f", "token"],
+      extractKeys: []
+    });
+
+    expect(resultWithOneDefined.requestOptions).toEqual({
+      authentication: "auth-from-options",
+      params: {
+        f: "json"
+      }
+    });
+  });
+
   test("should return empty requestOptions when options is an empty object", () => {
     const result = processOptions({} as IRequestOptions, {
       paramKeys: [],
       extractKeys: []
     });
 
+    expect(result).toEqual({
+      requestOptions: {}
+    });
     expect(result.requestOptions).toEqual({});
   });
 

--- a/packages/arcgis-rest-request/test/utils/process-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-options.test.ts
@@ -363,7 +363,11 @@ describe("processOptions", () => {
   });
 
   test("should create params when original options has no params object", () => {
-    const result = processOptions(
+    type TestOptions = IRequestOptions & {
+      f: "json";
+      token: "abc123";
+    };
+    const result = processOptions<TestOptions>(
       {
         f: "json",
         token: "abc123"

--- a/packages/arcgis-rest-request/test/utils/process-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-options.test.ts
@@ -32,11 +32,12 @@ describe("processOptions", () => {
       // extra keys that should be ignored
       extra: "should be ignored",
       // legacy request options keys that should be ignored altogether, as processOptions is not intended to support legacy request options at all
+      // (Typescript will complain if you try to use them), but if you force them as any, they will be moved to params instead
       httpMethod: "POST",
       credentials: "include",
       headers: { "X-Custom-Header": "value" },
       hideToken: true,
-      // requestOptions that should be in the final requestOptions object, but overridden by options if present
+      // requestOptions fetch options that will come through the final requestOptions object, unless overridden by overwriteOptions
       fetchOptions: {
         method: "POST",
         credentials: "omit",
@@ -72,7 +73,7 @@ describe("processOptions", () => {
       })
     );
     // requestOptions should be a pure IRequestOptions object with no extra keys or legacy keys
-    // requestOptions should reflect overriden values from options, if any
+    // requestOptions should reflect overridden values from overwriteOptions, if any
     expect(requestOptions).toEqual({
       authentication: "none",
       fetchOptions: {
@@ -88,6 +89,74 @@ describe("processOptions", () => {
         f: "json",
         token: "abc123"
       }
+    });
+  });
+
+  test("should include abort controller signal in fetchOptions when provided", () => {
+    const abortController = new AbortController();
+    const abortControllerTopLevel = new AbortController();
+    const requestOptions: IRequestOptions = {
+      authentication: "fake-token",
+      fetchOptions: {
+        signal: abortController.signal
+      }
+    };
+    const options = {
+      x: -73,
+      y: 40,
+      radius: 1600, // 5 miles in meters
+      categoryIds: ["123456789987654321"],
+      // if signal is provided at top-level and included in paramKeys, it will be moved to params
+      signal: abortControllerTopLevel.signal,
+      // structure abort controller in requestOptions.fetchOptions instead of at top-level
+      ...requestOptions
+    };
+
+    const processed = processOptions(options, {
+      // typescript will complain about signal because it is a legacy top-level requestOption
+      // and is excluded from ExtractableKey<T> type and should be included in requestOptions.fetchOptions,
+      // but will be moved into params if you force it.
+      paramKeys: ["x", "y", "radius", "categoryIds", "signal" as any],
+      extractKeys: []
+    });
+
+    expect(processed.requestOptions.fetchOptions?.signal).toBe(
+      abortController.signal
+    );
+    expect(processed.requestOptions).not.toHaveProperty("signal");
+    expect(processed.requestOptions.params).toEqual({
+      x: -73,
+      y: 40,
+      radius: 1600,
+      categoryIds: ["123456789987654321"],
+      signal: abortControllerTopLevel.signal
+    });
+  });
+
+  test("should not chain merge params under params if user tries to include params", () => {
+    const someUserBugThingShapeSearch = {
+      q: "my awesome query here",
+      start: 1,
+      num: 100,
+      params: {
+        categories: "/Categories/Trending"
+      }
+    };
+
+    const processed = processOptions(someUserBugThingShapeSearch, {
+      // typescript will complain about params because it is already a requestOption key
+      // but will not chain nest it if included in paramKeys.
+      paramKeys: ["q", "start", "num", "params" as any],
+      extractKeys: []
+    });
+
+    // processOptions should merge in { q, start, and num } from paramKeys since they are non requestOptions keys
+    // and should pull in all params by default, since params is a requestOptions key.
+    expect(processed.requestOptions.params).toEqual({
+      q: "my awesome query here",
+      start: 1,
+      num: 100,
+      categories: "/Categories/Trending"
     });
   });
 
@@ -153,13 +222,15 @@ describe("processOptions", () => {
     );
 
     expect(result.requestOptions.params).toEqual({
+      // top level token was moved to params and overwrote the existing params.token value,
+      // to preserve 'params-token', use extractKeys to extract top level keys instead of moving them into params.
       token: "top-level-token",
       culture: "en-US",
       f: "json"
     });
   });
 
-  test("should return extracted keys and exclude extracted and unsupported keys from requestOptions", () => {
+  test("should return extracted keys and only keys included in toParams and toExtract", () => {
     const result = processOptions(
       {
         id: "route-id",
@@ -168,6 +239,7 @@ describe("processOptions", () => {
         params: {
           outSR: 4326
         },
+        // should ignore all keys below
         extra: "ignore-me",
         httpMethod: "POST",
         credentials: "include",
@@ -184,7 +256,6 @@ describe("processOptions", () => {
 
     expect(result.id).toBe("route-id");
     expect(result.routeType).toBe("fastest");
-
     expect(result.requestOptions).toEqual({
       params: {
         outSR: 4326,
@@ -192,46 +263,40 @@ describe("processOptions", () => {
       }
     });
 
-    expect(result.requestOptions).not.toHaveProperty("id");
-    expect(result.requestOptions).not.toHaveProperty("routeType");
-    expect(result.requestOptions).not.toHaveProperty("extra");
-    expect(result.requestOptions).not.toHaveProperty("httpMethod");
-    expect(result.requestOptions).not.toHaveProperty("credentials");
-    expect(result.requestOptions).not.toHaveProperty("headers");
-    expect(result.requestOptions).not.toHaveProperty("hideToken");
+    expect(result).not.toHaveProperty("extra");
+    expect(result).not.toHaveProperty("httpMethod");
+    expect(result).not.toHaveProperty("credentials");
+    expect(result).not.toHaveProperty("headers");
+    expect(result).not.toHaveProperty("hideToken");
   });
 
   test("should build requestOptions correctly when overwriteOptions is omitted", () => {
-    const result = processOptions(
-      {
-        id: "abc123",
-        portal: "https://example.com/sharing/rest",
-        f: "json",
-        token: "token-from-options",
-        params: {
-          outSR: 3857
-        },
-        fetchOptions: {
-          method: "POST",
-          credentials: "include"
-        },
-        requestFlags: {
-          hideToken: true
-        }
+    const options = {
+      id: "abc123",
+      f: "json",
+      token: "token-from-options",
+      portal: "https://example.com/sharing/rest",
+      params: {
+        outSR: 3857
       },
-      {
-        paramKeys: ["f", "token"],
-        extractKeys: ["id"]
+      fetchOptions: {
+        method: "POST"
+      },
+      requestFlags: {
+        hideToken: true
       }
-    );
+    };
+
+    const result = processOptions(options, {
+      paramKeys: ["f", "token"],
+      extractKeys: ["id"]
+    });
 
     expect(result.id).toBe("abc123");
-
     expect(result.requestOptions).toEqual({
       portal: "https://example.com/sharing/rest",
       fetchOptions: {
-        method: "POST",
-        credentials: "include"
+        method: "POST"
       },
       requestFlags: {
         hideToken: true
@@ -242,8 +307,6 @@ describe("processOptions", () => {
         token: "token-from-options"
       }
     });
-
-    expect(result.requestOptions).not.toHaveProperty("id");
   });
 
   test("should ignore reserved IRequestOptions keys forced into paramKeys", () => {
@@ -257,7 +320,7 @@ describe("processOptions", () => {
       },
       {
         // Simulate a JS caller bypassing TypeScript constraints.
-        paramKeys: ["f", "authentication"] as any,
+        paramKeys: ["f", "authentication" as any] as any,
         extractKeys: []
       }
     );
@@ -293,28 +356,27 @@ describe("processOptions", () => {
   });
 
   test("should build mergeable request options from overwriteOptions when original options are absent", () => {
-    const result = processOptions(
-      {
+    const options = {
+      fetchOptions: {
+        credentials: "include" as RequestCredentials
+      },
+      requestFlags: {
+        hideToken: true
+      }
+    };
+
+    const result = processOptions(options, {
+      paramKeys: [],
+      extractKeys: [],
+      overwriteOptions: {
         fetchOptions: {
-          credentials: "include"
+          method: "POST"
         },
         requestFlags: {
-          hideToken: true
-        }
-      },
-      {
-        paramKeys: [],
-        extractKeys: [],
-        overwriteOptions: {
-          fetchOptions: {
-            method: "POST"
-          },
-          requestFlags: {
-            suppressWarnings: true
-          }
+          suppressWarnings: true
         }
       }
-    );
+    });
 
     expect(result.requestOptions).toEqual({
       fetchOptions: {
@@ -363,6 +425,7 @@ describe("processOptions", () => {
   });
 
   test("should create params when original options has no params object", () => {
+    // define custom object type
     type TestOptions = IRequestOptions & {
       f: "json";
       token: "abc123";
@@ -377,6 +440,67 @@ describe("processOptions", () => {
         extractKeys: []
       }
     );
+
+    expect(result.requestOptions.params).toEqual({
+      f: "json",
+      token: "abc123"
+    });
+  });
+
+  test("should not include undefined or null values in params", () => {
+    const options = {
+      f: "json",
+      token: undefined,
+      extra: null,
+      params: {
+        a: 1,
+        b: undefined,
+        c: null
+      }
+    };
+
+    const result = processOptions(options, {
+      paramKeys: ["f", "token", "extra"],
+      extractKeys: []
+    });
+
+    expect(result.requestOptions.params).toEqual({
+      f: "json",
+      a: 1
+    });
+  });
+
+  test("should handle empty paramKeys and extractKeys gracefully", () => {
+    const options = {
+      f: "json",
+      token: "abc123",
+      params: {
+        a: 1
+      }
+    };
+
+    const result = processOptions(options, {
+      paramKeys: [],
+      extractKeys: []
+    });
+
+    expect(result.requestOptions.params).toEqual({
+      f: "json",
+      token: "abc123",
+      a: 1
+    });
+  });
+
+  test("should handle missing params object gracefully", () => {
+    const options = {
+      f: "json",
+      token: "abc123"
+    };
+
+    const result = processOptions(options as any, {
+      paramKeys: ["f", "token"],
+      extractKeys: []
+    });
 
     expect(result.requestOptions.params).toEqual({
       f: "json",

--- a/packages/arcgis-rest-request/test/utils/process-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-options.test.ts
@@ -37,7 +37,7 @@ describe("processOptions", () => {
       credentials: "include",
       headers: { "X-Custom-Header": "value" },
       hideToken: true,
-      // requestOptions fetch options that will come through the final requestOptions object, unless overridden by overwriteOptions
+      // requestOptions fetch options that will come through the final requestOptions object, unless absent and filled by defaultOptions
       fetchOptions: {
         method: "POST",
         credentials: "omit",
@@ -51,7 +51,7 @@ describe("processOptions", () => {
     const { id, requestOptions } = processOptions(options, {
       paramKeys: ["f", "token", "bogus-or-misspelled-key" as any],
       extractKeys: ["id"],
-      overwriteOptions: {
+      defaultOptions: {
         authentication: "none",
         fetchOptions: {
           method: "GET"
@@ -73,16 +73,16 @@ describe("processOptions", () => {
       })
     );
     // requestOptions should be a pure IRequestOptions object with no extra keys or legacy keys
-    // requestOptions should reflect overridden values from overwriteOptions, if any
+    // requestOptions should prefer explicit options values over defaultOptions values
     expect(requestOptions).toEqual({
       authentication: "none",
       fetchOptions: {
-        method: "GET",
+        method: "POST",
         credentials: "omit",
         signal: expect.anything()
       },
       requestFlags: {
-        suppressWarnings: false
+        suppressWarnings: true
       },
       params: {
         a: 1,
@@ -160,7 +160,7 @@ describe("processOptions", () => {
     });
   });
 
-  test("should apply overwriteOptions precedence for top-level and nested request options", () => {
+  test("should apply defaultOptions and prefer explicit option values for top-level and nested request options", () => {
     const options: IRequestOptions = {
       authentication: "from-options",
       portal: "https://from-options.example.com/sharing/rest",
@@ -178,9 +178,9 @@ describe("processOptions", () => {
     const result = processOptions(options, {
       paramKeys: [],
       extractKeys: [],
-      overwriteOptions: {
-        authentication: "from-overwrite",
-        portal: "https://from-overwrite.example.com/sharing/rest",
+      defaultOptions: {
+        authentication: "from-default",
+        portal: "https://from-default.example.com/sharing/rest",
         fetchOptions: {
           method: "GET"
         },
@@ -191,16 +191,16 @@ describe("processOptions", () => {
     });
 
     expect(result.requestOptions).toEqual({
-      authentication: "from-overwrite",
-      portal: "https://from-overwrite.example.com/sharing/rest",
+      authentication: "from-options",
+      portal: "https://from-options.example.com/sharing/rest",
       fetchOptions: {
-        method: "GET",
+        method: "POST",
         credentials: "include",
         signal: expect.anything()
       },
       requestFlags: {
         hideToken: true,
-        suppressWarnings: false
+        suppressWarnings: true
       }
     });
   });
@@ -270,7 +270,7 @@ describe("processOptions", () => {
     expect(result).not.toHaveProperty("hideToken");
   });
 
-  test("should build requestOptions correctly when overwriteOptions is omitted", () => {
+  test("should build requestOptions correctly when defaultOptions is omitted", () => {
     const options = {
       id: "abc123",
       f: "json",
@@ -355,7 +355,7 @@ describe("processOptions", () => {
     });
   });
 
-  test("should build mergeable request options from overwriteOptions when original options are absent", () => {
+  test("should build mergeable request options from defaultOptions when original options are absent", () => {
     const options = {
       fetchOptions: {
         credentials: "include" as RequestCredentials
@@ -368,7 +368,7 @@ describe("processOptions", () => {
     const result = processOptions(options, {
       paramKeys: [],
       extractKeys: [],
-      overwriteOptions: {
+      defaultOptions: {
         fetchOptions: {
           method: "POST"
         },
@@ -390,7 +390,7 @@ describe("processOptions", () => {
     });
   });
 
-  test("should build mergeable request options from overwriteOptions when original mergeable keys are missing", () => {
+  test("should build mergeable request options from defaultOptions when original mergeable keys are missing", () => {
     const result = processOptions(
       {
         authentication: "auth-from-options",
@@ -399,7 +399,7 @@ describe("processOptions", () => {
       {
         paramKeys: [],
         extractKeys: [],
-        overwriteOptions: {
+        defaultOptions: {
           fetchOptions: {
             method: "POST",
             credentials: "omit"

--- a/packages/arcgis-rest-request/test/utils/process-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-options.test.ts
@@ -15,7 +15,7 @@ describe("processOptions", () => {
       token: string;
       bogusOrMisspelledKey?: string;
       extra?: string;
-      // legacy request options still used in (someone's?) code that we should handle in some way.
+      // legacy request options still used in someone's? code that we should handle in some way.
       httpMethod?: HTTPMethods;
       credentials?: RequestCredentials;
       headers?: Record<string, any>;
@@ -31,8 +31,7 @@ describe("processOptions", () => {
       params: { a: 1 },
       // extra keys that should be ignored
       extra: "should be ignored",
-      // legacy request options keys that should be ignored altogether, as processOptions is not intended to support legacy request options at all
-      // (Typescript will complain if you try to use them), but if you force them as any, they will be moved to params instead
+      // legacy request options keys pass through so request() can warn and normalize them
       httpMethod: "POST",
       credentials: "include",
       headers: { "X-Custom-Header": "value" },
@@ -72,10 +71,16 @@ describe("processOptions", () => {
         a: expect.anything()
       })
     );
-    // requestOptions should be a pure IRequestOptions object with no extra keys or legacy keys
-    // requestOptions should prefer explicit options values over defaultOptions values
+    // requestOptions should preserve legacy options for request() to normalize.
+    // requestOptions should prefer explicit options values over defaultOptions values.
     expect(requestOptions).toEqual({
       authentication: "none",
+      httpMethod: "POST",
+      credentials: "include",
+      headers: {
+        "X-Custom-Header": "value"
+      },
+      hideToken: true,
       fetchOptions: {
         method: "POST",
         credentials: "omit",
@@ -92,7 +97,7 @@ describe("processOptions", () => {
     });
   });
 
-  test("should include abort controller signal in fetchOptions when provided", () => {
+  test("should preserve top-level signal and keep it out of params", () => {
     const abortController = new AbortController();
     const abortControllerTopLevel = new AbortController();
     const requestOptions: IRequestOptions = {
@@ -106,16 +111,16 @@ describe("processOptions", () => {
       y: 40,
       radius: 1600, // 5 miles in meters
       categoryIds: ["123456789987654321"],
-      // if signal is provided at top-level and included in paramKeys, it will be moved to params
+      // top-level signal is legacy and should pass through to requestOptions
+      // (not get moved into params)
       signal: abortControllerTopLevel.signal,
-      // structure abort controller in requestOptions.fetchOptions instead of at top-level
+      // fetchOptions.signal remains preferred and should be preserved as well
       ...requestOptions
     };
 
     const processed = processOptions(options, {
-      // typescript will complain about signal because it is a legacy top-level requestOption
-      // and is excluded from ExtractableKey<T> type and should be included in requestOptions.fetchOptions,
-      // but will be moved into params if you force it.
+      // Even if forced into paramKeys from JS usage, signal should be treated as a
+      // request option key and not moved into params.
       paramKeys: ["x", "y", "radius", "categoryIds", "signal" as any],
       extractKeys: []
     });
@@ -123,13 +128,14 @@ describe("processOptions", () => {
     expect(processed.requestOptions.fetchOptions?.signal).toBe(
       abortController.signal
     );
-    expect(processed.requestOptions).not.toHaveProperty("signal");
+    expect(processed.requestOptions.signal).toBe(
+      abortControllerTopLevel.signal
+    );
     expect(processed.requestOptions.params).toEqual({
       x: -73,
       y: 40,
       radius: 1600,
-      categoryIds: ["123456789987654321"],
-      signal: abortControllerTopLevel.signal
+      categoryIds: ["123456789987654321"]
     });
   });
 
@@ -160,7 +166,7 @@ describe("processOptions", () => {
     });
   });
 
-  test("should apply defaultOptions and prefer explicit option values for top-level and nested request options", () => {
+  test("should apply defaultOptions and prefer original option values for top-level and nested request options", () => {
     const options: IRequestOptions = {
       authentication: "from-options",
       portal: "https://from-options.example.com/sharing/rest",
@@ -237,9 +243,12 @@ describe("processOptions", () => {
     );
 
     expect(result.requestOptions.params).toEqual({
+      // from paramKeys
       token: "from-top-level",
+      // original options
       f: "json",
       culture: "fr-FR",
+      // from defaultOptions
       outSR: 3857
     });
   });
@@ -262,15 +271,14 @@ describe("processOptions", () => {
 
     expect(result.requestOptions.params).toEqual({
       // top level token was moved to params and overwrote the existing params.token value,
-      // to preserve 'params-token', use extractKeys to extract top level keys instead of moving them into params.
       token: "top-level-token",
       culture: "en-US",
       f: "json"
     });
   });
 
-  test("should return extracted keys and only keys included in toParams and toExtract", () => {
-    const result = processOptions(
+  test("should return extracted keys and pass through recognized request options", () => {
+    const processedOptions = processOptions(
       {
         id: "route-id",
         routeType: "fastest",
@@ -278,8 +286,9 @@ describe("processOptions", () => {
         params: {
           outSR: 4326
         },
-        // should ignore all keys below
+        // should ignore unknown keys below
         extra: "ignore-me",
+        // recognized legacy request options should pass through
         httpMethod: "POST",
         credentials: "include",
         headers: {
@@ -293,20 +302,26 @@ describe("processOptions", () => {
       }
     );
 
-    expect(result.id).toBe("route-id");
-    expect(result.routeType).toBe("fastest");
-    expect(result.requestOptions).toEqual({
+    expect(processedOptions.id).toBe("route-id");
+    expect(processedOptions.routeType).toBe("fastest");
+    expect(processedOptions.requestOptions).toEqual({
+      httpMethod: "POST",
+      credentials: "include",
+      headers: {
+        "X-Test": "value"
+      },
+      hideToken: true,
       params: {
         outSR: 4326,
         f: "json"
       }
     });
 
-    expect(result).not.toHaveProperty("extra");
-    expect(result).not.toHaveProperty("httpMethod");
-    expect(result).not.toHaveProperty("credentials");
-    expect(result).not.toHaveProperty("headers");
-    expect(result).not.toHaveProperty("hideToken");
+    expect(processedOptions).not.toHaveProperty("extra");
+    expect(processedOptions).not.toHaveProperty("httpMethod");
+    expect(processedOptions).not.toHaveProperty("credentials");
+    expect(processedOptions).not.toHaveProperty("headers");
+    expect(processedOptions).not.toHaveProperty("hideToken");
   });
 
   test("should build requestOptions correctly when defaultOptions is omitted", () => {
@@ -326,13 +341,13 @@ describe("processOptions", () => {
       }
     };
 
-    const result = processOptions(options, {
+    const processedOptions = processOptions(options, {
       paramKeys: ["f", "token"],
       extractKeys: ["id"]
     });
 
-    expect(result.id).toBe("abc123");
-    expect(result.requestOptions).toEqual({
+    expect(processedOptions.id).toBe("abc123");
+    expect(processedOptions.requestOptions).toEqual({
       portal: "https://example.com/sharing/rest",
       fetchOptions: {
         method: "POST"
@@ -394,7 +409,7 @@ describe("processOptions", () => {
     });
   });
 
-  test("should build mergeable request options from defaultOptions when original options are absent", () => {
+  test("should merge requestOptions with defaultOptions when original options dont overlap", () => {
     const options = {
       fetchOptions: {
         credentials: "include" as RequestCredentials
@@ -435,7 +450,7 @@ describe("processOptions", () => {
     });
   });
 
-  test("should build mergeable request options from defaultOptions when original mergeable keys are missing", () => {
+  test("should use defaultOptions when original options are missing", () => {
     const result = processOptions(
       {
         authentication: "auth-from-options",
@@ -493,7 +508,17 @@ describe("processOptions", () => {
   });
 
   test("should include explicitly undefined or null values in params", () => {
-    const options = {
+    type TestOptions = IRequestOptions & {
+      f: "json";
+      token: undefined;
+      extra: null;
+      params: {
+        a: number;
+        b: undefined;
+        c: null;
+      };
+    };
+    const options: TestOptions = {
       f: "json",
       token: undefined,
       extra: null,

--- a/packages/arcgis-rest-request/test/utils/process-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-options.test.ts
@@ -447,7 +447,7 @@ describe("processOptions", () => {
     });
   });
 
-  test("should not include undefined or null values in params", () => {
+  test("should include explicitly undefined or null values in params", () => {
     const options = {
       f: "json",
       token: undefined,
@@ -466,14 +466,20 @@ describe("processOptions", () => {
 
     expect(result.requestOptions.params).toEqual({
       f: "json",
-      a: 1
+      token: undefined,
+      extra: null,
+      a: 1,
+      b: undefined,
+      c: null
     });
   });
 
-  test("should handle empty paramKeys and extractKeys gracefully", () => {
+  test("should handle empty paramKeys and extractKeys", () => {
     const options = {
+      // these will be discarded because they are not included in paramKeys or extractKeys
       f: "json",
       token: "abc123",
+      // params will be includedi n output because it is a requestOptions key
       params: {
         a: 1
       }
@@ -484,10 +490,10 @@ describe("processOptions", () => {
       extractKeys: []
     });
 
-    expect(result.requestOptions.params).toEqual({
-      f: "json",
-      token: "abc123",
-      a: 1
+    expect(result.requestOptions).toEqual({
+      params: {
+        a: 1
+      }
     });
   });
 

--- a/packages/arcgis-rest-request/test/utils/process-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-options.test.ts
@@ -541,4 +541,22 @@ describe("processOptions", () => {
       }
     });
   });
+
+  test("should return empty requestOptions when options is an empty object", () => {
+    const result = processOptions({} as IRequestOptions, {
+      paramKeys: [],
+      extractKeys: []
+    });
+
+    expect(result.requestOptions).toEqual({});
+  });
+
+  test("should throw when options is undefined", () => {
+    expect(() =>
+      processOptions(undefined as any, {
+        paramKeys: [],
+        extractKeys: []
+      })
+    ).toThrow();
+  });
 });

--- a/packages/arcgis-rest-request/test/utils/process-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-options.test.ts
@@ -186,6 +186,9 @@ describe("processOptions", () => {
         },
         requestFlags: {
           suppressWarnings: false
+        },
+        params: {
+          f: "json"
         }
       }
     });
@@ -201,7 +204,43 @@ describe("processOptions", () => {
       requestFlags: {
         hideToken: true,
         suppressWarnings: true
+      },
+      params: {
+        f: "json"
       }
+    });
+  });
+
+  test("should merge params with precedence moved paramKeys > options.params > defaultOptions.params", () => {
+    const result = processOptions(
+      {
+        token: "from-top-level",
+        f: "pjson",
+        params: {
+          token: "from-options-params",
+          f: "json",
+          culture: "fr-FR"
+        }
+      },
+      {
+        paramKeys: ["token"],
+        extractKeys: [],
+        defaultOptions: {
+          params: {
+            token: "from-default",
+            f: "html",
+            culture: "en-US",
+            outSR: 3857
+          }
+        }
+      }
+    );
+
+    expect(result.requestOptions.params).toEqual({
+      token: "from-top-level",
+      f: "json",
+      culture: "fr-FR",
+      outSR: 3857
     });
   });
 
@@ -374,6 +413,9 @@ describe("processOptions", () => {
         },
         requestFlags: {
           suppressWarnings: true
+        },
+        params: {
+          f: "json"
         }
       }
     });
@@ -386,6 +428,9 @@ describe("processOptions", () => {
       requestFlags: {
         hideToken: true,
         suppressWarnings: true
+      },
+      params: {
+        f: "json"
       }
     });
   });
@@ -479,7 +524,7 @@ describe("processOptions", () => {
       // these will be discarded because they are not included in paramKeys or extractKeys
       f: "json",
       token: "abc123",
-      // params will be includedi n output because it is a requestOptions key
+      // params will be included in output because it is a requestOptions key
       params: {
         a: 1
       }
@@ -494,23 +539,6 @@ describe("processOptions", () => {
       params: {
         a: 1
       }
-    });
-  });
-
-  test("should handle missing params object gracefully", () => {
-    const options = {
-      f: "json",
-      token: "abc123"
-    };
-
-    const result = processOptions(options as any, {
-      paramKeys: ["f", "token"],
-      extractKeys: []
-    });
-
-    expect(result.requestOptions.params).toEqual({
-      f: "json",
-      token: "abc123"
     });
   });
 });

--- a/packages/arcgis-rest-request/test/utils/process-options.test.ts
+++ b/packages/arcgis-rest-request/test/utils/process-options.test.ts
@@ -1,0 +1,271 @@
+/* Copyright (c) 2026 Environmental Systems Research Institute, Inc. */
+
+import { describe, test, expect } from "vitest";
+import { processOptions } from "../../src/utils/process-options.js";
+import { IRequestOptions } from "../../src/utils/IRequestOptions.js";
+import { HTTPMethods } from "../../src/utils/HTTPMethods.js";
+
+describe("processOptions", () => {
+  test("should extract specified keys and merge request options", () => {
+    // this interface should match the options object below
+    interface TestOptions extends IRequestOptions {
+      // user's custom-defined options object
+      id: number;
+      f: string;
+      token: string;
+      bogusOrMisspelledKey?: string;
+      extra?: string;
+      // legacy request options still used in (someone's?) code that we should handle in some way.
+      httpMethod?: HTTPMethods;
+      credentials?: RequestCredentials;
+      headers?: Record<string, any>;
+      hideToken?: boolean;
+    }
+    const options: TestOptions = {
+      // extract key
+      id: 123,
+      // param keys
+      f: "json",
+      token: "abc123",
+      params: { a: 1 },
+      // extra keys that should be ignored
+      extra: "should be ignored",
+      // legacy request options keys that should be ignored altogether, as processOptions is not intended to support legacy request options at all
+      httpMethod: "POST",
+      credentials: "include",
+      headers: { "X-Custom-Header": "value" },
+      hideToken: true,
+      // requestOptions that should be in the final requestOptions object, but overridden by options if present
+      fetchOptions: {
+        method: "POST",
+        credentials: "omit",
+        signal: new AbortController().signal
+      },
+      requestFlags: {
+        suppressWarnings: true
+      }
+    };
+
+    const { id, requestOptions } = processOptions(options, {
+      paramKeys: ["f", "token", "bogus-or-misspelled-key" as any],
+      extractKeys: ["id"],
+      overwriteOptions: {
+        authentication: "none",
+        fetchOptions: {
+          method: "GET"
+        },
+        requestFlags: {
+          suppressWarnings: false
+        }
+      }
+    });
+
+    // id should be extracted from options and returned
+    expect(id).toBeDefined();
+    // f, token, and params in requestOptions.params
+    expect(requestOptions.params).toEqual(
+      expect.objectContaining({
+        f: expect.anything(),
+        token: expect.anything(),
+        a: expect.anything()
+      })
+    );
+    // requestOptions should be a pure IRequestOptions object with no extra keys or legacy keys
+    // requestOptions should reflect overriden values from options, if any
+    expect(requestOptions).toEqual({
+      authentication: "none",
+      fetchOptions: {
+        method: "GET",
+        credentials: "omit",
+        signal: expect.anything()
+      },
+      requestFlags: {
+        suppressWarnings: false
+      },
+      params: {
+        a: 1,
+        f: "json",
+        token: "abc123"
+      }
+    });
+  });
+
+  test("should apply overwriteOptions precedence for top-level and nested request options", () => {
+    const options: IRequestOptions = {
+      authentication: "from-options",
+      portal: "https://from-options.example.com/sharing/rest",
+      fetchOptions: {
+        method: "POST",
+        credentials: "include",
+        signal: new AbortController().signal
+      },
+      requestFlags: {
+        hideToken: true,
+        suppressWarnings: true
+      }
+    };
+
+    const result = processOptions(options, {
+      paramKeys: [],
+      extractKeys: [],
+      overwriteOptions: {
+        authentication: "from-overwrite",
+        portal: "https://from-overwrite.example.com/sharing/rest",
+        fetchOptions: {
+          method: "GET"
+        },
+        requestFlags: {
+          suppressWarnings: false
+        }
+      }
+    });
+
+    expect(result.requestOptions).toEqual({
+      authentication: "from-overwrite",
+      portal: "https://from-overwrite.example.com/sharing/rest",
+      fetchOptions: {
+        method: "GET",
+        credentials: "include",
+        signal: expect.anything()
+      },
+      requestFlags: {
+        hideToken: true,
+        suppressWarnings: false
+      }
+    });
+  });
+
+  test("should merge params and prefer moved paramKeys over existing params collisions", () => {
+    const result = processOptions(
+      {
+        token: "top-level-token",
+        f: "json",
+        params: {
+          token: "params-token",
+          culture: "en-US"
+        }
+      },
+      {
+        paramKeys: ["token", "f"],
+        extractKeys: []
+      }
+    );
+
+    expect(result.requestOptions.params).toEqual({
+      token: "top-level-token",
+      culture: "en-US",
+      f: "json"
+    });
+  });
+
+  test("should return extracted keys and exclude extracted and unsupported keys from requestOptions", () => {
+    const result = processOptions(
+      {
+        id: "route-id",
+        routeType: "fastest",
+        f: "json",
+        params: {
+          outSR: 4326
+        },
+        extra: "ignore-me",
+        httpMethod: "POST",
+        credentials: "include",
+        headers: {
+          "X-Test": "value"
+        },
+        hideToken: true
+      },
+      {
+        paramKeys: ["f"],
+        extractKeys: ["id", "routeType"]
+      }
+    );
+
+    expect(result.id).toBe("route-id");
+    expect(result.routeType).toBe("fastest");
+
+    expect(result.requestOptions).toEqual({
+      params: {
+        outSR: 4326,
+        f: "json"
+      }
+    });
+
+    expect(result.requestOptions).not.toHaveProperty("id");
+    expect(result.requestOptions).not.toHaveProperty("routeType");
+    expect(result.requestOptions).not.toHaveProperty("extra");
+    expect(result.requestOptions).not.toHaveProperty("httpMethod");
+    expect(result.requestOptions).not.toHaveProperty("credentials");
+    expect(result.requestOptions).not.toHaveProperty("headers");
+    expect(result.requestOptions).not.toHaveProperty("hideToken");
+  });
+
+  test("should build requestOptions correctly when overwriteOptions is omitted", () => {
+    const result = processOptions(
+      {
+        id: "abc123",
+        portal: "https://example.com/sharing/rest",
+        f: "json",
+        token: "token-from-options",
+        params: {
+          outSR: 3857
+        },
+        fetchOptions: {
+          method: "POST",
+          credentials: "include"
+        },
+        requestFlags: {
+          hideToken: true
+        }
+      },
+      {
+        paramKeys: ["f", "token"],
+        extractKeys: ["id"]
+      }
+    );
+
+    expect(result.id).toBe("abc123");
+
+    expect(result.requestOptions).toEqual({
+      portal: "https://example.com/sharing/rest",
+      fetchOptions: {
+        method: "POST",
+        credentials: "include"
+      },
+      requestFlags: {
+        hideToken: true
+      },
+      params: {
+        outSR: 3857,
+        f: "json",
+        token: "token-from-options"
+      }
+    });
+
+    expect(result.requestOptions).not.toHaveProperty("id");
+  });
+
+  test("should ignore reserved IRequestOptions keys forced into paramKeys", () => {
+    const result = processOptions(
+      {
+        authentication: "auth-from-options",
+        f: "json",
+        params: {
+          outSR: 102100
+        }
+      },
+      {
+        // Simulate a JS caller bypassing TypeScript constraints.
+        paramKeys: ["f", "authentication"] as any,
+        extractKeys: []
+      }
+    );
+
+    expect(result.requestOptions.authentication).toBe("auth-from-options");
+    expect(result.requestOptions.params).toEqual({
+      outSR: 102100,
+      f: "json"
+    });
+    expect(result.requestOptions.params).not.toHaveProperty("authentication");
+  });
+});

--- a/packages/arcgis-rest-routing/src/closestFacility.ts
+++ b/packages/arcgis-rest-routing/src/closestFacility.ts
@@ -4,7 +4,7 @@
 import {
   request,
   cleanUrl,
-  appendCustomParams,
+  processOptions,
   ILocation,
   IPoint,
   IFeature,
@@ -146,23 +146,26 @@ export function closestFacility(
     ...requestOptions.params
   };
 
-  const options = appendCustomParams<IClosestFacilityOptions>(requestOptions, [
-    "returnCFRoutes",
-    // "travelDirection",
-    "barriers",
-    "polylineBarriers",
-    "polygonBarriers",
-    "returnDirections",
-    "directionsOutputType",
-    "directionsLengthUnits",
-    "outputLines",
-    "returnFacilities",
-    "returnIncidents",
-    "returnBarriers",
-    "returnPolylineBarriers",
-    "returnPolygonBarriers",
-    "preserveObjectID"
-  ]);
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
+      "returnCFRoutes",
+      // "travelDirection",
+      "barriers",
+      "polylineBarriers",
+      "polygonBarriers",
+      "returnDirections",
+      "directionsOutputType",
+      "directionsLengthUnits",
+      "outputLines",
+      "returnFacilities",
+      "returnIncidents",
+      "returnBarriers",
+      "returnPolylineBarriers",
+      "returnPolygonBarriers",
+      "preserveObjectID"
+    ],
+    extractKeys: []
+  });
 
   // Set travelDirection
   if (requestOptions.travelDirection) {

--- a/packages/arcgis-rest-routing/src/originDestinationMatrix.ts
+++ b/packages/arcgis-rest-routing/src/originDestinationMatrix.ts
@@ -4,7 +4,7 @@
 import {
   request,
   cleanUrl,
-  appendCustomParams,
+  processOptions,
   IRequestOptions,
   ILocation,
   IPoint,
@@ -106,9 +106,8 @@ export function originDestinationMatrix(
     ...requestOptions.params
   };
 
-  const options = appendCustomParams<IOriginDestinationMatrixOptions>(
-    requestOptions,
-    [
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
       "outputType",
       "barriers",
       "polylineBarriers",
@@ -118,8 +117,9 @@ export function originDestinationMatrix(
       "returnBarriers",
       "returnPolylineBarriers",
       "returnPolygonBarriers"
-    ]
-  );
+    ],
+    extractKeys: []
+  });
 
   // the SAAS service does not support anonymous requests
   if (

--- a/packages/arcgis-rest-routing/src/serviceArea.ts
+++ b/packages/arcgis-rest-routing/src/serviceArea.ts
@@ -4,7 +4,7 @@
 import {
   request,
   cleanUrl,
-  appendCustomParams,
+  processOptions,
   ILocation,
   IPoint,
   IFeatureSet
@@ -96,17 +96,20 @@ export function serviceArea(
     ...requestOptions.params
   };
 
-  const options = appendCustomParams<IServiceAreaOptions>(requestOptions, [
-    "barriers",
-    "polylineBarriers",
-    "polygonBarriers",
-    "outputLines",
-    "returnFacilities",
-    "returnBarriers",
-    "returnPolylineBarriers",
-    "returnPolygonBarriers",
-    "preserveObjectID"
-  ]);
+  const { requestOptions: options } = processOptions(requestOptions, {
+    paramKeys: [
+      "barriers",
+      "polylineBarriers",
+      "polygonBarriers",
+      "outputLines",
+      "returnFacilities",
+      "returnBarriers",
+      "returnPolylineBarriers",
+      "returnPolygonBarriers",
+      "preserveObjectID"
+    ],
+    extractKeys: []
+  });
 
   // Set travelDirection
   if (requestOptions.travelDirection) {


### PR DESCRIPTION
This pull request adds `processOptions()` to replace the `appendCustomParams()` method, utilizing only v5 `IRequestOptions` and deprecates `appendCustomParams()`.

- adds `processOptions(requestOptions, { paramKeys[], extractKeys[], defaultOptions }): IRequestOptions`;
- implements `processOptions()` across packages
- deprecates `appendCustomParams()` with console warnings for users.
- adds tests to assert top level request options pass through `processOptions` to request (should allow us to close #657 and #1199)