### PR TITLE
Typedoc Fix: addItemData options comment updated

### DIFF
--- a/.changeset/ready-trains-chew.md
+++ b/.changeset/ready-trains-chew.md
@@ -2,4 +2,4 @@
 "@esri/arcgis-rest-portal": patch
 ---
 
-Updates typedoc to reflect correct addItemData params
+Updates documentation to reflect correct addItemData parameters.

--- a/.changeset/ready-trains-chew.md
+++ b/.changeset/ready-trains-chew.md
@@ -1,0 +1,5 @@
+---
+"@esri/arcgis-rest-portal": patch
+---
+
+Updates typedoc to reflect correct addItemData params

--- a/packages/arcgis-rest-portal/src/items/add.ts
+++ b/packages/arcgis-rest-portal/src/items/add.ts
@@ -22,7 +22,7 @@ export interface IAddItemDataOptions extends IUserItemOptions {
    */
   file?: Blob | File;
   /**
-   * Text content to store/
+   * Text content to store.
    */
   text?: string;
 }
@@ -35,7 +35,7 @@ export interface IAddItemDataOptions extends IUserItemOptions {
  *
  * addItemData({
  *   id: '3ef',
- *   data: file,
+ *   file,
  *   authentication
  * })
  *   .then(response)


### PR DESCRIPTION
Resolves issue where Typedoc reflect incorrect param in `addItemData` options.