### PR TITLE
v4.x Maintenance Release

### DIFF
--- a/.changeset/public-ends-hide.md
+++ b/.changeset/public-ends-hide.md
@@ -14,4 +14,4 @@
 "@esri/arcgis-rest-routing": patch
 ---
 
-publish v4 lts maintenance branch
+publish lts-v4.x maintenance branch

--- a/.changeset/public-ends-hide.md
+++ b/.changeset/public-ends-hide.md
@@ -1,0 +1,17 @@
+---
+"@esri/arcgis-rest-auth": patch
+"@esri/arcgis-rest-basemap-sessions": patch
+"@esri/arcgis-rest-demographics": patch
+"@esri/arcgis-rest-developer-credentials": patch
+"@esri/arcgis-rest-elevation": patch
+"@esri/arcgis-rest-feature-service": patch
+"@esri/arcgis-rest-fetch": patch
+"@esri/arcgis-rest-form-data": patch
+"@esri/arcgis-rest-geocoding": patch
+"@esri/arcgis-rest-places": patch
+"@esri/arcgis-rest-portal": patch
+"@esri/arcgis-rest-request": patch
+"@esri/arcgis-rest-routing": patch
+---
+
+publish v4 lts maintenance branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,11 @@ jobs:
       - name: Check & Log npm dist-tags and versions
         run: npm dist-tag ls @esri/arcgis-rest-request
 
-      - name: Create Release Pull Request or Publish to NPM (v4)
+      - name: Create Release Pull Request or Publish to NPM (lts-v4.x)
         id: changesets
         uses: changesets/action@v1.5.1 # workaround until fix for https://github.com/changesets/action/issues/501
         with:
-          # build all packages and publish to the v4 maintenance dist-tag
+          # build all packages and publish to the maintenance dist-tag lts-v4.x
           # do not change this tag to latest or anything else
           publish: npx changeset publish --tag lts-v4.x
           # call changeset version and then update the lock file via yarn install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
   # If the build and test works, run a release
   release:
-    name: Release v4 (dist-tag v4)
+    name: Release v4 (dist-tag lts-v4.x)
     needs: [build_and_test]
     runs-on: ubuntu-latest
     permissions:
@@ -83,7 +83,7 @@ jobs:
         with:
           # build all packages and publish to the v4 maintenance dist-tag
           # do not change this tag to latest or anything else
-          publish: npx changeset publish --tag v4
+          publish: npx changeset publish --tag lts-v4.x
           # call changeset version and then update the lock file via yarn install
           version: npx changeset version
           cwd: "${{ github.workspace }}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## v4.x.x Maintenance Release
 
-On this `4.x.x` maintenance branch, ArcGIS REST JS packages are released automatically using the default [changeset action](https://github.com/changesets/action) in the [release workflow](./.github/workflows/release.yml) and published with npm dist-tag `v4`. When changes are merged to `4.x`, changesets will automatically create a release PR on `4.x` that, when merged, will trigger a new release of all packages, published with dist-tag `v4`.
+On this `4.x.x` maintenance branch, ArcGIS REST JS packages are released automatically using the default [changeset action](https://github.com/changesets/action) in the [release workflow](./.github/workflows/release.yml) and published with npm dist-tag `lts-v4.x`. When changes are merged to `4.x`, changesets will automatically create a release PR on `4.x` that, when merged, will trigger a new release of all packages, published with dist-tag `lts-v4.x`.
 
 ## December 2025/January 2026 Updates
 


### PR DESCRIPTION
when this merges it should bump the version to 4.11.1 and release to dist-tag lts-v4.x